### PR TITLE
Add UI validation to API properties with spaces and upper case keywords

### DIFF
--- a/portals/publisher/site/public/locales/en.json
+++ b/portals/publisher/site/public/locales/en.json
@@ -5057,6 +5057,12 @@
       "value": "Property name/value can not be empty"
     }
   ],
+  "Apis.Details.Properties.Properties.\n                    property.name.has.whitespaces": [
+    {
+      "type": 0,
+      "value": "Property name can not have any whitespaces in it"
+    }
+  ],
   "Apis.Details.Properties.Properties.\n                    property.name.keyword.error": [
     {
       "type": 0,

--- a/portals/publisher/site/public/locales/raw.en.json
+++ b/portals/publisher/site/public/locales/raw.en.json
@@ -2397,6 +2397,9 @@
   "Apis.Details.Properties.Properties.\n                    property.name.empty.error": {
     "defaultMessage": "Property name/value can not be empty"
   },
+  "Apis.Details.Properties.Properties.\n                    property.name.has.whitespaces": {
+    "defaultMessage": "Property name can not have any whitespaces in it"
+  },
   "Apis.Details.Properties.Properties.\n                    property.name.keyword.error": {
     "defaultMessage": "Property name can not be a system reserved keyword"
   },

--- a/portals/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
@@ -205,7 +205,17 @@ function Properties(props) {
     };
 
     const isKeyword = (itemValue) => {
-        return keywords.includes(itemValue);
+        if (itemValue === null) {
+            return false;
+        }
+        return keywords.includes(itemValue.toLowerCase());
+    };
+    const hasWhiteSpace = (itemValue) => {
+        if (itemValue === null) {
+            return false;
+        }
+        const whitespaceChars = [' ', '\t', '\n'];
+        return Array.from(itemValue).some((char) => whitespaceChars.includes(char));
     };
     /**
      *
@@ -323,6 +333,15 @@ function Properties(props) {
                     property.name.keyword.error`,
                 defaultMessage:
                 'Property name can not be a system reserved keyword',
+            }));
+            return false;
+        } else if (hasWhiteSpace(fieldKey)) {
+            Alert.warning(intl.formatMessage({
+                id:
+                    `Apis.Details.Properties.Properties.
+                    property.name.has.whitespaces`,
+                defaultMessage:
+                    'Property name can not have any whitespaces in it',
             }));
             return false;
         } else {
@@ -607,12 +626,14 @@ function Properties(props) {
                                                         onChange={handleChange('propertyKey')}
                                                         onKeyDown={handleKeyDown('propertyKey')}
                                                         helperText={validateEmpty(propertyKey) ? ''
-                                                            : iff(isKeyword(propertyKey), intl.formatMessage({
+                                                            : iff((isKeyword(propertyKey)
+                                                                || hasWhiteSpace(propertyKey)), intl.formatMessage({
                                                                 id: `Apis.Details.Properties.Properties.
                                                                     show.add.property.invalid.error`,
                                                                 defaultMessage: 'Invalid property name',
                                                             }), '')}
-                                                        error={validateEmpty(propertyKey) || isKeyword(propertyKey)}
+                                                        error={validateEmpty(propertyKey) || isKeyword(propertyKey)
+                                                        || hasWhiteSpace(propertyKey)}
                                                         disabled={isRestricted(
                                                             ['apim:api_create', 'apim:api_publish'],
                                                             api,


### PR DESCRIPTION
### Purpose 
Adding UI validation for API properties Key value.
1. Property name should not contain spaces or any white space characters.
2. Property name cannot be any of the following reserved keywords: _**provider, version, context, status, description, subcontext, doc, lcstate, name, tags.**_ (In both lower and upper case keywords should be restricted)

This PR will add the above validations in the publisher portal UI.

### Goals
Fixes: https://github.com/wso2/product-apim/issues/11219 

### Approach
**1. Uppercase validation for Keywords**

![ScreenShot Tool -20210520155958](https://user-images.githubusercontent.com/42435576/118963861-88fc7480-b984-11eb-82ba-7e504d86c9b6.png)



**2. Whitespace validation**
![ScreenShot Tool -20210520155941](https://user-images.githubusercontent.com/42435576/118963848-8437c080-b984-11eb-819a-404137be80d5.png)

