### PR TITLE
Add fix to base64 encode username before passing to back-end

### DIFF
--- a/portals/admin/source/src/app/ProtectedApp.jsx
+++ b/portals/admin/source/src/app/ProtectedApp.jsx
@@ -99,7 +99,7 @@ class Protected extends Component {
         if (user) {
             this.setState({ user });
             settingPromise.then((settingsNew) => this.setState({ settings: settingsNew }));
-            api.getTenantInformation(user.name)
+            api.getTenantInformation(btoa(user.name))
                 .then((result) => {
                     const { tenantDomain } = result.body;
                     if (tenantDomain === 'carbon.super') {


### PR DESCRIPTION
### Purpose
To fix showing the error message: Admin Portal UnAuthenticated Request error.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/11394

### Approach
Pass the base64 encoded username to the back-end when calling to get tenant-info.
