### PR TITLE
Changing the frontend regular expression for throttling policy name

### DIFF
--- a/portals/admin/source/src/app/components/Throttling/Advanced/AddEdit.jsx
+++ b/portals/admin/source/src/app/components/Throttling/Advanced/AddEdit.jsx
@@ -165,7 +165,7 @@ function AddEdit(props) {
                         id: 'Throttling.Advanced.AddEdit.empty.error',
                         defaultMessage: ' contains white spaces.',
                     })}`;
-                } else if (/[^A-Za-z0-9]/.test(fieldValue)) {
+                } else if (/[^A-Za-z0-9_]/.test(fieldValue)) {
                     error = `Policy name ${intl.formatMessage({
                         id: 'Throttling.Advanced.AddEdit.special.characters.error',
                         defaultMessage: ' contains invalid characters.',


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11410

## Goals
Underscores should be allowed in throttling policy names since they are quite common in naming conventions.

## Approach
Changed the frontend regular expression for throttling policy name.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/10667