### PR TITLE
Change keywords to lowercase

### DIFF
--- a/portals/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Properties/Properties.jsx
@@ -173,7 +173,7 @@ function Properties(props) {
     const iff = (condition, then, otherwise) => (condition ? then : otherwise);
 
     const keywords = ['provider', 'version', 'context', 'status', 'description',
-        'subcontext', 'doc', 'lcState', 'name', 'tags'];
+        'subcontext', 'doc', 'lcstate', 'name', 'tags'];
 
     const toggleAddProperty = () => {
         setShowAddProperty(!showAddProperty);


### PR DESCRIPTION
### Goal
Fixes Issue of not recognizing "lcState" as Keyword