### PR TITLE
Fix UI issues when having huge resource path

### DIFF
--- a/portals/publisher/source/src/app/components/Apis/Details/Resources/components/GroupOfOperations.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Resources/components/GroupOfOperations.jsx
@@ -17,12 +17,27 @@
  */
 
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import PropTypes from 'prop-types';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+
+const useStyles = makeStyles((theme) => ({
+    tagClass: {
+        maxWidth: 1000,
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        [theme.breakpoints.down('md')]: {
+            maxWidth: 800,
+        },
+    },
+}
+));
+
 /**
  *
  * Return a group container , User should provide the operations list as the child component
@@ -31,19 +46,24 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
  * @returns {React.Component} @inheritdoc
  */
 export default function GroupOfOperations(props) {
+    const classes = useStyles();
     const { openAPI, children, tag } = props;
     const currentTagInfo = openAPI.tags && openAPI.tags.find((tagInfo) => tagInfo.name === tag);
     return (
         <ExpansionPanel defaultExpanded>
             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} aria-controls='panel1a-content' id='panel1a-header'>
-                <Typography variant='h4'>
+                <Typography
+                    variant='h4'
+                    className={classes.tagClass}
+                    title={tag}
+                >
                     {tag}
-                    {currentTagInfo && (
-                        <Typography style={{ margin: '0px 30px' }} variant='caption'>
-                            {currentTagInfo.description}
-                        </Typography>
-                    )}
                 </Typography>
+                {currentTagInfo && (
+                    <Typography style={{ margin: '0px 30px' }} variant='caption'>
+                        {currentTagInfo.description}
+                    </Typography>
+                )}
             </ExpansionPanelSummary>
             <ExpansionPanelDetails>{children}</ExpansionPanelDetails>
         </ExpansionPanel>

--- a/portals/publisher/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
@@ -103,6 +103,14 @@ function Operation(props) {
                 zIndex: theme.zIndex.operationDeleteUndo,
                 right: '10%',
             },
+            targetText: {
+                maxWidth: 180,
+                margin: '0px 20px',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                display: 'inline-block',
+            },
         };
     });
     const apiOperation = api.operations[target] && api.operations[target][verb.toUpperCase()];
@@ -162,8 +170,13 @@ function Operation(props) {
                     classes={{ content: classes.contentNoMargin }}
                 >
                     <Grid container direction='row' justify='space-between' alignItems='center' spacing={0}>
-                        <Grid item md={4}>
-                            <Badge invisible={!operation['x-wso2-new']} color='error' variant='dot'>
+                        <Grid item md={4} style={{ display: 'flex', alignItems: 'center' }}>
+                            <Badge
+                                invisible={!operation['x-wso2-new']}
+                                color='error'
+                                variant='dot'
+                                style={{ display: 'inline-block' }}
+                            >
                                 <Button
                                     disableFocusRipple
                                     variant='contained'
@@ -173,16 +186,24 @@ function Operation(props) {
                                     {verb}
                                 </Button>
                             </Badge>
-                            <Typography display='inline' style={{ margin: '0px 30px' }} variant='h6' gutterBottom>
+                            <Typography
+                                display='inline-block'
+                                variant='h6'
+                                gutterBottom
+                                className={classes.targetText}
+                                title={target}
+                            >
                                 {target}
-                                <Typography
-                                    display='inline'
-                                    style={{ margin: '0px 30px' }}
-                                    variant='caption'
-                                    gutterBottom
-                                >
-                                    {operation.summary}
-                                </Typography>
+                                {(operation.summary && operation.summary !== '') && (
+                                    <Typography
+                                        display='inline-block'
+                                        style={{ margin: '0px 30px' }}
+                                        variant='caption'
+                                        gutterBottom
+                                    >
+                                        {operation.summary}
+                                    </Typography>
+                                )}
                             </Typography>
                         </Grid>
                         {(isUsedInAPIProduct) ? (

--- a/portals/publisher/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/index.jsx
@@ -95,8 +95,10 @@ const styles = (theme) => ({
         flexGrow: 1,
         flexDirection: 'column',
         paddingBottom: theme.spacing(3),
+        overflow: 'auto',
     },
     contentInside: {
+        width: 'calc(100% - 56px)',
         paddingLeft: theme.spacing(3),
         paddingRight: theme.spacing(3),
         paddingTop: theme.spacing(2),


### PR DESCRIPTION
### Purpose
To fix the UI issues when having a huge resource pathname in the API definition. (i.e. text overlapping, zoom in the Resources tab, Runtime configuration page issues)

### Goal
Fixes: https://github.com/wso2/product-apim/issues/11442

### Approach
- Added text-overflow ellipsis to ellipsis the long resource paths
- Change width parameters to fit the UI of Runtime Configs without horizontal scroll bar