### PR TITLE
Fix Unauthenticated Request error when loading the Runtime Configurations

### DIFF
--- a/portals/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -305,20 +305,22 @@ export default function RuntimeConfiguration() {
     const [faultPolicy, setFaultPolicy] = useState(mediationPolicies.filter((seq) => seq.type === 'FAULT')[0]);
     const intl = useIntl();
     useEffect(() => {
-        Api.keyManagers().then((response) => {
-            const kmNameList = [];
-            if (response.body.list) {
-                response.body.list.forEach((km) => kmNameList.push(km.name));
-            }
-            setKeyManagersConfigured(kmNameList);
-        })
-            .catch((error) => {
-                const { response } = error;
-                if (response.body) {
-                    const { description } = response.body;
-                    Alert.error(description);
+        if (!isRestricted(['apim:api_create'], api)) {
+            Api.keyManagers().then((response) => {
+                const kmNameList = [];
+                if (response.body.list) {
+                    response.body.list.forEach((km) => kmNameList.push(km.name));
                 }
-            });
+                setKeyManagersConfigured(kmNameList);
+            })
+                .catch((error) => {
+                    const { response } = error;
+                    if (response.body) {
+                        const { description } = response.body;
+                        Alert.error(description);
+                    }
+                });
+        }
     }, []);
 
     const getMediationPoliciesToSave = () => {

--- a/portals/publisher/source/src/app/components/Apis/Details/Configuration/components/KeyManager.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Configuration/components/KeyManager.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -31,6 +31,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import API from 'AppData/api';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
+import { isRestricted } from 'AppData/AuthManager';
+import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 
 const useStyles = makeStyles((theme) => ({
     expansionPanel: {
@@ -83,8 +85,11 @@ export default function KeyManager(props) {
             value: newKeyManagers,
         });
     };
+    const { api } = useContext(APIContext);
     useEffect(() => {
-        API.keyManagers().then((response) => setKeyManagersConfigured(response.body.list));
+        if (!isRestricted(['apim:api_create'], api)) {
+            API.keyManagers().then((response) => setKeyManagersConfigured(response.body.list));
+        }
     }, []);
     if (!securityScheme.includes('oauth2')) {
         return (
@@ -125,7 +130,7 @@ export default function KeyManager(props) {
                 >
                     <FormControlLabel
                         value='all'
-                        control={<Radio />}
+                        control={<Radio disabled={isRestricted(['apim:api_create'], api)} />}
                         label={(
                             <FormattedMessage
                                 id='Apis.Details.Configuration.components.KeyManager.allow.all'
@@ -135,7 +140,7 @@ export default function KeyManager(props) {
                     />
                     <FormControlLabel
                         value='selected'
-                        control={<Radio />}
+                        control={<Radio disabled={isRestricted(['apim:api_create'], api)} />}
                         label={(
                             <FormattedMessage
                                 id='Apis.Details.Configuration.components.KeyManager.allow.selected'


### PR DESCRIPTION
### Purpose
To fix the Unauthenticated Request error UI issue when loading the Runtime Configurations in Publisher portal

### Goal
Fixes: 
https://github.com/wso2/product-apim/issues/11458
https://github.com/wso2/product-apim/issues/9177

### Approach

Check whether the user is having apim:api_create scope, if it does not have such scope then prevent making the rest call and disable radio buttons as well

![image](https://user-images.githubusercontent.com/28702407/127164431-f67fde22-18eb-4289-a913-591fa68c2968.png)
