### PR TITLE
Update duplicate context validation to handle dynamic contexts

### DIFF
--- a/portals/publisher/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -96,7 +96,7 @@ function actualContext({ context, version }) {
  * @returns {Boolean} true or false
  */
 function checkContext(value, result) {
-    const contextVal = value.includes('/') ? value.toLowerCase() : '/' + value.toLowerCase();
+    const contextVal = value.startsWith('/') ? value.toLowerCase() : '/' + value.toLowerCase();
     if (contextVal === '/' + result.toLowerCase().slice(result.toLowerCase().lastIndexOf('/') + 1)
      || contextVal === result.toLowerCase()) {
         return true;
@@ -175,13 +175,19 @@ export default function DefaultAPIForm(props) {
             case 'context': {
                 const contextValidity = APIValidation.apiContext.required().validate(value, { abortEarly: false })
                     .error;
-                const apiContext = value.includes('/') ? value : '/' + value;
+                const apiContext = value.startsWith('/') ? value : '/' + value;
                 if (contextValidity === null) {
                     APIValidation.apiParameter.validate(field + ':' + apiContext).then((result) => {
-                        if (result.body.list.length > 0 && checkContext(value, result.body.list[0].context)) {
+                        const count = result.body.list.length;
+                        if (count > 0 && checkContext(value, result.body.list[0].context)) {
                             updateValidity({
                                 ...validity,
                                 context: { details: [{ message: apiContext + ' context already exists' }] },
+                            });
+                        } else if (count > 0 && checkContext(value, result.body.list[0].contextTemplate)) {
+                            updateValidity({
+                                ...validity,
+                                context: { details: [{ message: apiContext + ' dynamic context already exists' }] },
                             });
                         } else {
                             updateValidity({ ...validity, context: contextValidity, version: null });


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/11841

As of now, when the context consists of a template (i.e. a dynamic context) the validation on whether or not the provided context is unique, fails. This PR fixes this duplicate templated context being allowed issue. This is done by taking into consideration the template of the context, rather than the plain context. Please refer to the below screenshot to see the modified error message shown in the Publisher when this validation happens.

<img width="805" alt="Screenshot 2021-10-20 at 20 58 50" src="https://user-images.githubusercontent.com/30475839/138470488-84d2a68a-969c-4d7b-b198-446386426a8d.png">

## Related PRs

- https://github.com/wso2/carbon-apimgt/pull/10863 (backend fix PR)
- https://github.com/wso2/product-apim/pull/11899 (test PR)
