### PR TITLE
Add support to add json yaml and md type documents

### DIFF
--- a/portals/publisher/site/public/conf/settings.js
+++ b/portals/publisher/site/public/conf/settings.js
@@ -32,6 +32,10 @@ const AppConfig = {
         propertyDisplaySuffix: '__display',
         loadDefaultLocales: true, // If false, Default en.json file will not be used/loaded in app.
         // loadDefaultLocales = false is good for performance but text overrides using the locale file will not work
+        supportedDocTypes: 'application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document,'
+                    + ' application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,'
+                    + ' application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet,'
+                    + ' application/json, application/x-yaml, .md',
     },
     serviceCatalogDefinitionTypes: {
         OAS2: 'Swagger',

--- a/portals/publisher/site/public/conf/settings.js
+++ b/portals/publisher/site/public/conf/settings.js
@@ -33,7 +33,8 @@ const AppConfig = {
         loadDefaultLocales: true, // If false, Default en.json file will not be used/loaded in app.
         // loadDefaultLocales = false is good for performance but text overrides using the locale file will not work
         supportedDocTypes: 'application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document,'
-                    + ' application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,'
+                    + ' application/pdf, text/plain, application/vnd.ms-excel,'
+                    + ' application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,'
                     + ' application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet,'
                     + ' application/json, application/x-yaml, .md',
     },

--- a/portals/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -37,6 +37,7 @@ import APIProduct from 'AppData/APIProduct';
 import APIValidation from 'AppData/APIValidation';
 import AppContext from 'AppComponents/Shared/AppContext';
 import Alert from 'AppComponents/Shared/Alert';
+import Configurations from 'Config';
 
 const styles = theme => ({
     button: {
@@ -768,7 +769,7 @@ class CreateEditForm extends React.Component {
                 {sourceType === 'FILE' && (
                     <Dropzone
                         multiple={false}
-                        accept='application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/pdf, text/plain'
+                        accept={Configurations.app.supportedDocTypes}
                         className={classes.dropzone}
                         activeClassName={classes.acceptDrop}
                         rejectClassName={classes.rejectDrop}


### PR DESCRIPTION
This PR fixes part of https://github.com/wso2/product-apim/issues/11500 with default support for json, yaml and md files through UI.