### PR TITLE
Fix app owner mismatch occurring due to case sensitivity

### DIFF
--- a/portals/devportal/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/portals/devportal/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -489,7 +489,10 @@ class ApplicationFormHandler extends React.Component {
                                             variant='contained'
                                             color='primary'
                                             onClick={isEdit ? this.saveEdit : this.saveApplication}
-                                            disabled={isEdit && AuthManager.getUser().name !== applicationOwner}
+                                            disabled={
+                                                isEdit
+                                                && AuthManager.getUser().name.toLowerCase() !== applicationOwner.toLowerCase()
+                                            }
                                             className={classes.button}
                                         >
                                             <FormattedMessage

--- a/portals/devportal/source/src/app/components/Applications/Listing/AppsTableContent.jsx
+++ b/portals/devportal/source/src/app/components/Applications/Listing/AppsTableContent.jsx
@@ -123,7 +123,7 @@ class AppsTableContent extends Component {
             <TableBody className={classes.fullHeight}>
                 {appsTableData
                     .map((app) => {
-                        const isAppOwner = app.owner === AuthManager.getUser().name;
+                        const isAppOwner = app.owner.toLowerCase() === AuthManager.getUser().name.toLowerCase();
                         return (
                             <StyledTableRow className={classes.tableRow} key={app.applicationId}>
                                 <StyledTableCell align='left' className={classes.appName}>
@@ -133,7 +133,7 @@ class AppsTableContent extends Component {
                                         app.name
                                     )}
                                 </StyledTableCell>
-                                <StyledTableCell align='left'>{app.owner}</StyledTableCell>
+                                <StyledTableCell align='left'>{app.owner.toLowerCase()}</StyledTableCell>
                                 <StyledTableCell align='left'>{app.throttlingPolicy}</StyledTableCell>
                                 <StyledTableCell align='left'>
                                     {app.status === this.APPLICATION_STATES.APPROVED && (


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/12152

When the application owner is switched through the admin portal, but with no consideration on the case sensitivity, the devportal behaves as though this username is case sensitive. Hence, the actual app owner is unable to edit/delete this app. This PR fixes this application owner mismatch occurring due to case sensitivity. All owner usernames are hereby considered to be case insensitive.

With this fix, when the owner is switched while disregarding the case sensitivity, that owner is able to edit and delete that said application.