### PR TITLE
Add document sort function to the dev portal

### DIFF
--- a/portals/devportal/source/src/app/components/Apis/Details/Documents/Documents.jsx
+++ b/portals/devportal/source/src/app/components/Apis/Details/Documents/Documents.jsx
@@ -177,6 +177,9 @@ function Documents(props) {
                         }
                     }
                 }
+                // Sort the documents by name
+                types.forEach((a) => a.docs.sort((b, c) => ((b.name.toUpperCase()
+                    > c.name.toUpperCase()) ? 1 : -1)));
                 changeDocumentList(types);
                 if (!documentId && types.length > 0) {
                     setSelectedDoc(types[0].docs[0]);


### PR DESCRIPTION
## Purpose
As $subject, this fix will sort the document list before showing it in the dev portal.

### Fixes
- https://github.com/wso2/product-apim/issues/12192