### PR TITLE
Add UI components for updating solace definition

### DIFF
--- a/portals/publisher/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -734,20 +734,18 @@ class APIDefinition extends React.Component {
                             )}
                         </Typography>
                         {asyncAPI ? (
-                            (api.gatewayVendor === 'wso2') && (
-                                <Button
-                                    size='small'
-                                    className={classes.button}
-                                    onClick={this.openEditor}
-                                    disabled={isRestricted(['apim:api_create'], api)}
-                                >
-                                    <EditRounded className={classes.buttonIcon} />
-                                    <FormattedMessage
-                                        id='Apis.Details.APIDefinition.APIDefinition.edit'
-                                        defaultMessage='Edit'
-                                    />
-                                </Button>
-                            )
+                            <Button
+                                size='small'
+                                className={classes.button}
+                                onClick={this.openEditor}
+                                disabled={isRestricted(['apim:api_create'], api)}
+                            >
+                                <EditRounded className={classes.buttonIcon} />
+                                <FormattedMessage
+                                    id='Apis.Details.APIDefinition.APIDefinition.edit'
+                                    defaultMessage='Edit'
+                                />
+                            </Button>
                         ) : (
                             !(graphQL || api.type === API.CONSTS.APIProduct) && (
                                 <Button

--- a/portals/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -1419,7 +1419,7 @@ export default function Environments() {
                     </Typography>
                 </Grid>
             )}
-            {!api.isRevision && allRevisions && allRevisions.length !== 0 && api.gatewayVendor === 'wso2'
+            {!api.isRevision && allRevisions && allRevisions.length !== 0
             && (
                 <Grid container>
                     <Button

--- a/portals/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -1814,7 +1814,7 @@ export default function Environments() {
                     </DialogActions>
                 </Dialog>
             </Grid>
-            {allRevisions && allRevisions.length !== 0 && api.gatewayVendor === 'wso2' && (
+            {allRevisions && allRevisions.length !== 0 && (
                 <>
                     <Grid
                         container

--- a/portals/publisher/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
@@ -220,7 +220,6 @@ function AsyncOperation(props) {
                             disableUpdate={disableUpdate}
                             target={target}
                             verb={verb}
-                            disableForSolace={api.gatewayVendor === 'solace'}
                         />
                         {operation.parameters && (
                             <Parameters
@@ -231,7 +230,6 @@ function AsyncOperation(props) {
                                 spec={spec}
                                 target={target}
                                 verb={verb}
-                                disableForSolace={api.gatewayVendor === 'solace'}
                             />
                         )}
                         <PayloadProperties
@@ -240,7 +238,6 @@ function AsyncOperation(props) {
                             disableUpdate={disableUpdate}
                             target={target}
                             verb={verb}
-                            disableForSolace={api.gatewayVendor === 'solace'}
                         />
                         {(api.gatewayVendor === 'wso2') && (
                             <>


### PR DESCRIPTION
### Purpose

- Fixes https://github.com/wso2/product-apim/issues/12210

### User Stories

- When updating an Async API definition the corresponding API and API product in Solace is updated. This update can be performed through **Topics** and **AsyncAPIDefintion** panel

![Screenshot from 2022-02-03 12-43-54](https://user-images.githubusercontent.com/60866295/152297743-3ff0257e-ef23-4a6a-8fd2-9491c176629e.png)

- Even after just saving the API definition, a use can navigate to deployment panel and deploy the current snapshot to the Solace using **Deploy New Revision** method. 

![Screenshot from 2022-02-07 12-49-49](https://user-images.githubusercontent.com/60866295/153135448-a3369376-9eb5-4b6b-863d-603950d15ce3.png)


### Related PRs

- https://github.com/wso2/carbon-apimgt/pull/11012
