### PR TITLE
Hide generate CURL section in TryOut for unsupported types

### DIFF
--- a/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiConsole.jsx
+++ b/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiConsole.jsx
@@ -205,9 +205,7 @@ export default function AsyncApiConsole() {
             wss: null,
         };
         const [protocol] = url.split('://');
-        if (protocol === 'http' || protocol === 'https' || protocol === 'ws' || protocol === 'wss') {
-            urlJson[protocol] = url;
-        }
+        urlJson[protocol] = url;
         return urlJson;
     };
 

--- a/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
+++ b/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
@@ -63,9 +63,14 @@ export default function AsyncApiUI(props) {
     const isAdvertised = api.advertiseInfo && api.advertiseInfo.advertised;
 
     let initialEndpoint;
-    initialEndpoint = URLs && URLs.http;
+    initialEndpoint = URLs && (URLs.http || URLs.https);
     if (api.type === CONSTANTS.API_TYPES.WS) {
-        initialEndpoint = URLs && URLs.ws;
+        initialEndpoint = URLs && (URLs.ws || URLs.wss);
+    }
+
+    let expandable = true;
+    if (!URLs || (!URLs.http && !URLs.https)) {
+        expandable = false;
     }
 
     const [allTopics, setAllTopics] = useState('');
@@ -218,22 +223,29 @@ export default function AsyncApiUI(props) {
                     <WebhookSubscriptionUI
                         topic={topic}
                         generateGenericWHSubscriptionCurl={generateGenericWHSubscriptionCurl}
+                        expandable
                     />
                 ))}
                 {api.type === CONSTANTS.API_TYPES.SSE && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateSSESubscriptionCommand}
-                        topic={topic}/>
+                        topic={topic}
+                        expandable
+                    />
                 ))}
                 {api.type === CONSTANTS.API_TYPES.WS && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateWSSubscriptionCommand}
-                        topic={topic}/>
+                        topic={topic}
+                        expandable
+                    />
                 ))}
                 {api.type === CONSTANTS.API_TYPES.ASYNC && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateASYNCSubscriptionCommand}
-                        topic={topic}/>
+                        topic={topic}
+                        expandable={expandable}
+                    />
                 ))}
             </>
         );

--- a/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
+++ b/portals/devportal/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
@@ -82,7 +82,7 @@ export default function GenericSubscriptionUI(props) {
             },
         };
     });
-    const { generateGenericSubscriptionCommand, topic } = props;
+    const { generateGenericSubscriptionCommand, topic, expandable } = props;
     const [command, setCommand] = useState(generateGenericSubscriptionCommand(topic));
 
     const handleClick = () => {
@@ -92,9 +92,9 @@ export default function GenericSubscriptionUI(props) {
     const classes = useStyles();
 
     return (
-        <Accordion className={classes.subscription}>
+        <Accordion className={classes.subscription} style={{ pointerEvents: expandable ? 'auto' : 'none' }}>
             <AccordionSummary
-                expandIcon={<ExpandMoreIcon />}
+                expandIcon={expandable && (<ExpandMoreIcon />)}
                 aria-controls='generic-subscription-content'
                 id='generic-subscription-header'
                 className={classes.subscriptionSummary}


### PR DESCRIPTION
This PR hides 'Generate CURL' section in tryout page for unsupported API types.

![image](https://user-images.githubusercontent.com/25485783/153857042-b52078a9-c667-4ec9-b653-cac8c9b9b642.png)
