### PR TITLE
Change Toast message theme in publisher

### DIFF
--- a/portals/publisher/source/src/app/components/Base/index.jsx
+++ b/portals/publisher/source/src/app/components/Base/index.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Footer from 'AppComponents/Base/Footer/Footer';
 import Header from 'AppComponents/Base/Header';
 import { Toaster } from 'react-hot-toast';
@@ -59,6 +59,7 @@ const useStyles = makeStyles((theme) => ({
  */
 const Base = ({ children, user }) => {
     const classes = useStyles();
+    const theme = useTheme();
     return (
         <>
             {/* <CssBaseline /> */}
@@ -67,13 +68,34 @@ const Base = ({ children, user }) => {
                 gutter={8}
                 toastOptions={{
                     style: {
-                        background: '#DDEFFF',
+                        background: '#008fcc',
+                        color: '#ffffff',
+                        fontFamily: theme.typography.fontFamily,
+                        fontSize: "13px",
                     },
                     success: {
-                        style: { backgroundColor: '#C7FFBE' },
+                        style: {
+                            backgroundColor: '#4caf50',
+                            color: '#ffffff',
+                            fontFamily: theme.typography.fontFamily,
+                            fontSize: "13px"
+                        },
+                        iconTheme: {
+                            primary: '#ffffff',
+                            secondary: '#4caf50',
+                        },
                     },
                     error: {
-                        style: { backgroundColor: '#FFC7BE' },
+                        style: {
+                            backgroundColor: '#BD0808',
+                            color: '#ffffff',
+                            fontFamily: theme.typography.fontFamily,
+                            fontSize: "13px"
+                        },
+                        iconTheme: {
+                            primary: '#ffffff',
+                            secondary: '#BD0808',
+                        },
                     },
                     custom: {
                         style: { backgroundColor: '#DDEFFF' },

--- a/portals/publisher/source/src/app/components/Base/index.jsx
+++ b/portals/publisher/source/src/app/components/Base/index.jsx
@@ -68,37 +68,37 @@ const Base = ({ children, user }) => {
                 gutter={8}
                 toastOptions={{
                     style: {
-                        background: '#008fcc',
+                        background: '#008fccC8',
                         color: '#ffffff',
                         fontFamily: theme.typography.fontFamily,
                         fontSize: "13px",
                     },
                     success: {
                         style: {
-                            backgroundColor: '#4caf50',
+                            backgroundColor: '#4caf50C8',
                             color: '#ffffff',
                             fontFamily: theme.typography.fontFamily,
-                            fontSize: "13px"
+                            fontSize: "13px",
                         },
                         iconTheme: {
-                            primary: '#ffffff',
-                            secondary: '#4caf50',
+                            primary: '#ffffffC8',
+                            secondary: '#4caf50C8',
                         },
                     },
                     error: {
                         style: {
-                            backgroundColor: '#BD0808',
+                            backgroundColor: '#BD0808BE',
                             color: '#ffffff',
                             fontFamily: theme.typography.fontFamily,
                             fontSize: "13px"
                         },
                         iconTheme: {
-                            primary: '#ffffff',
-                            secondary: '#BD0808',
+                            primary: '#ffffffBE',
+                            secondary: '#BD0808BE',
                         },
                     },
                     custom: {
-                        style: { backgroundColor: '#DDEFFF' },
+                        style: { backgroundColor: '#DDEFFFC8' },
                     },
                 }}
             />

--- a/portals/publisher/source/src/app/components/Shared/Alert.jsx
+++ b/portals/publisher/source/src/app/components/Shared/Alert.jsx
@@ -19,7 +19,7 @@ import toast from 'react-hot-toast';
 import React from 'react';
 
 export default {
-    info: toast,
+    info: toast.success,
     success: toast.success,
     error: toast.error,
     warning: (message, options) => toast(message, {


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim/issues/12452

### Description:
Color theme and font of the message boxes that appear when an API state was changed, API was updated, etc. is not compatible with the existing portal theme.

### Existing view:
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/2484781/155283273-f542312b-bc95-4de1-a45a-8a8ff6f1de33.png">

<img width="318" alt="image" src="https://user-images.githubusercontent.com/2484781/155283304-5c0c2c43-0ae0-443f-8117-54ccab5c3ba6.png">

### Solution provided via PR:

#### What is changed: 
Font, Font size and the color of the Toasts

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/2484781/156733443-9c7f488f-fc69-494f-903f-6e9509611b73.png">

<img width="1639" alt="image" src="https://user-images.githubusercontent.com/2484781/156734408-81855694-41fa-4aba-9516-d32ed9bacf3a.png">

Loading Toast is in blue and Success Toast is in Green:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/2484781/156733977-d3ea808e-86bc-4abf-b877-cc74e17109f0.png">

### Error Toast:
![image](https://user-images.githubusercontent.com/2484781/156735657-38b3415e-4fa5-480e-b536-a4d679dc8d2d.png)