### PR TITLE
[Operation Level Policy Support] Extend policy create and view capabilities for CC

### DIFF
--- a/portals/publisher/package-lock.json
+++ b/portals/publisher/package-lock.json
@@ -29,7 +29,6 @@
                 "babel-plugin-formatjs": "^10.3.18",
                 "base64url": "3.0.1",
                 "caniuse-api": "^3.0.0",
-                "classnames": "^2.3.1",
                 "clean-webpack-plugin": "^4.0.0",
                 "dayjs": "^1.10.7",
                 "downshift": "^6.1.7",

--- a/portals/publisher/package.json
+++ b/portals/publisher/package.json
@@ -48,7 +48,6 @@
         "babel-plugin-formatjs": "^10.3.18",
         "base64url": "3.0.1",
         "caniuse-api": "^3.0.0",
-        "classnames": "^2.3.1",
         "clean-webpack-plugin": "^4.0.0",
         "dayjs": "^1.10.7",
         "downshift": "^6.1.7",

--- a/portals/publisher/site/public/conf/settings.js
+++ b/portals/publisher/site/public/conf/settings.js
@@ -6,8 +6,8 @@ const AppConfig = {
     app: {
         context: '/publisher', // Note the leading `/` and no trailing `/`
         /*
-        If the proxy context path is configured, it's required to provide it here as well.
-        for example, to serve https://company.com/apim/publisher/ URL the context and proxy_context_path will be as follows.
+        If the proxy context path is configured, it's required to provide it here as well. For example,
+        to serve https://company.com/apim/publisher/ URL the context and proxy_context_path will be as follows.
         context: '/apim/publisher',
         proxy_context_path: '/apim',
         */
@@ -16,25 +16,27 @@ const AppConfig = {
             forwardedHeader: 'X-Forwarded-For',
         },
         origin: {
-            host: 'localhost', // Used to construct the loopback origin, It's very unlike you need to change this hostname,
+            // Used to construct the loopback origin, It's very unlike you need to change this hostname,
             // It is `localhost` in 99.99% case, If you want to change server host name change it in deployment.toml
+            host: 'localhost',
         },
         feedback: { // If enabled, Feedback form option(an icon) will be available in the footer LHS bottom
             enable: false,
             serviceURL: '', // Check `/source/src/app/components/Base/Footer/FeedbackForm.jsx` for details
         },
         singleLogout: {
-            enabled: true, // If enabled, user will be logged out from the App when logged out from the IDP (eg: SSO logout from a different App).
+            // If enabled, user will be logged out from the App when logged out from the IDP
+            // (eg: SSO logout from a different App).
+            enabled: true,
             timeout: 4000, // Defines the timeout for the above periodical session status check
         },
         throttlingPolicyLimit: 80,
-        mediationPolicyCount: 50,
         operationPolicyCount: 50,
         propertyDisplaySuffix: '__display',
         loadDefaultLocales: true, // If false, Default en.json file will not be used/loaded in app.
         // loadDefaultLocales = false is good for performance but text overrides using the locale file will not work
-        supportedDocTypes: 'application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document,'
-                    + ' application/pdf, text/plain, application/vnd.ms-excel,'
+        supportedDocTypes: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document,'
+                    + ' application/msword, application/pdf, text/plain, application/vnd.ms-excel,'
                     + ' application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,'
                     + ' application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet,'
                     + ' application/json, application/x-yaml, .md',

--- a/portals/publisher/site/public/conf/settings.js
+++ b/portals/publisher/site/public/conf/settings.js
@@ -29,7 +29,7 @@ const AppConfig = {
         },
         throttlingPolicyLimit: 80,
         mediationPolicyCount: 50,
-        operationPolicyCount: 25,
+        operationPolicyCount: 50,
         propertyDisplaySuffix: '__display',
         loadDefaultLocales: true, // If false, Default en.json file will not be used/loaded in app.
         // loadDefaultLocales = false is good for performance but text overrides using the locale file will not work

--- a/portals/publisher/site/public/conf/settings.js
+++ b/portals/publisher/site/public/conf/settings.js
@@ -31,7 +31,7 @@ const AppConfig = {
             timeout: 4000, // Defines the timeout for the above periodical session status check
         },
         throttlingPolicyLimit: 80,
-        operationPolicyCount: 50,
+        operationPolicyCount: 500,
         propertyDisplaySuffix: '__display',
         loadDefaultLocales: true, // If false, Default en.json file will not be used/loaded in app.
         // loadDefaultLocales = false is good for performance but text overrides using the locale file will not work

--- a/portals/publisher/site/public/locales/en.json
+++ b/portals/publisher/site/public/locales/en.json
@@ -5392,7 +5392,7 @@
   "Apis.Details.Policies.GatewaySelector.change.gateway.confirm.content": [
     {
       "type": 0,
-      "value": "Changing the gateway type will remove all existing policies added to the API."
+      "value": "Changing the gateway type will remove all existing policies added to the API"
     }
   ],
   "Apis.Details.Policies.GatewaySelector.change.gateway.confirm.proceed": [

--- a/portals/publisher/site/public/locales/en.json
+++ b/portals/publisher/site/public/locales/en.json
@@ -5722,7 +5722,7 @@
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.title": [
     {
       "type": 0,
-      "value": "Policy File"
+      "value": "Policy File(s)"
     }
   ],
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.supported.gateways.label": [
@@ -5752,7 +5752,11 @@
   "Apis.Details.Policies.PolicyForm.UploadPolicyDropzone.title": [
     {
       "type": 0,
-      "value": "Upload Policy File"
+      "value": "Upload Policy File for "
+    },
+    {
+      "type": 1,
+      "value": "gateway"
     }
   ],
   "Apis.Details.Policies.PolicyList.add.new.policy": [

--- a/portals/publisher/site/public/locales/raw.en.json
+++ b/portals/publisher/site/public/locales/raw.en.json
@@ -2560,7 +2560,7 @@
     "defaultMessage": "Cancel"
   },
   "Apis.Details.Policies.GatewaySelector.change.gateway.confirm.content": {
-    "defaultMessage": "Changing the gateway type will remove all existing policies added to the API."
+    "defaultMessage": "Changing the gateway type will remove all existing policies added to the API"
   },
   "Apis.Details.Policies.GatewaySelector.change.gateway.confirm.proceed": {
     "defaultMessage": "Proceed"

--- a/portals/publisher/site/public/locales/raw.en.json
+++ b/portals/publisher/site/public/locales/raw.en.json
@@ -2713,7 +2713,7 @@
     "defaultMessage": "Download Policy"
   },
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.title": {
-    "defaultMessage": "Policy File"
+    "defaultMessage": "Policy File(s)"
   },
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.supported.gateways.label": {
     "defaultMessage": "Supported Gateways"
@@ -2728,7 +2728,7 @@
     "defaultMessage": "Click or drag the policy file to upload"
   },
   "Apis.Details.Policies.PolicyForm.UploadPolicyDropzone.title": {
-    "defaultMessage": "Upload Policy File"
+    "defaultMessage": "Upload Policy File for {gateway}"
   },
   "Apis.Details.Policies.PolicyList.add.new.policy": {
     "defaultMessage": "Add New Policy"

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
@@ -61,22 +61,26 @@ const CreatePolicy: React.FC<CreatePolicyProps> = ({
     const classes = useStyles();
     const { api } = useContext<any>(ApiContext);
     const [saving, setSaving] = useState(false);
-    const [policyDefinitionFile, setPolicyDefinitionFile] = useState<any[]>([]);
+    const [synapsePolicyDefinitionFile, setSynapsePolicyDefinitionFile] = useState<any[]>([]);
+    const [ccPolicyDefinitionFile, setCcPolicyDefinitionFile] = useState<any[]>([]);
 
     const savePolicy = (
         policySpecContent: CreatePolicySpec,
-        policyDefinition: any,
+        synapsePolicyDefinition: any,
+        ccPolicyDefinition: any,
     ) => {
         setSaving(true);
         const promisedCommonPolicyAdd = API.addOperationPolicy(
             policySpecContent,
-            policyDefinition,
+            synapsePolicyDefinition,
+            ccPolicyDefinition,
             api.id,
         );
         promisedCommonPolicyAdd
             .then(() => {
                 Alert.info('Policy created successfully!');
-                setPolicyDefinitionFile([]);
+                setSynapsePolicyDefinitionFile([]);
+                setCcPolicyDefinitionFile([]);
                 handleDialogClose();
                 fetchPolicies();
             })
@@ -90,14 +94,21 @@ const CreatePolicy: React.FC<CreatePolicyProps> = ({
             });
     };
 
+    const onSave = (policySpecification: CreatePolicySpec) => {
+        const synapseFile = synapsePolicyDefinitionFile.length !== 0 ? synapsePolicyDefinitionFile : null;
+        const ccFile = ccPolicyDefinitionFile.length !== 0 ? ccPolicyDefinitionFile : null;
+        savePolicy(
+            policySpecification,
+            synapseFile,
+            ccFile,
+        );
+        handleDialogClose();
+    };
+
     const stopPropagation = (
         e: React.MouseEvent<HTMLDivElement, MouseEvent>,
     ) => {
         e.stopPropagation();
-    };
-    const onSave = (policySpecification: CreatePolicySpec) => {
-        savePolicy(policySpecification, policyDefinitionFile);
-        handleDialogClose();
     };
 
     return (
@@ -141,10 +152,10 @@ const CreatePolicy: React.FC<CreatePolicyProps> = ({
                         <DialogContentText>
                             <PolicyCreateForm
                                 onSave={onSave}
-                                policyDefinitionFile={policyDefinitionFile}
-                                setPolicyDefinitionFile={
-                                    setPolicyDefinitionFile
-                                }
+                                synapsePolicyDefinitionFile={synapsePolicyDefinitionFile}
+                                setSynapsePolicyDefinitionFile={setSynapsePolicyDefinitionFile}
+                                ccPolicyDefinitionFile={ccPolicyDefinitionFile}
+                                setCcPolicyDefinitionFile={setCcPolicyDefinitionFile}
                                 onCancel={handleDialogClose}
                                 saving={saving}
                             />

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
@@ -72,9 +72,9 @@ const CreatePolicy: React.FC<CreatePolicyProps> = ({
         setSaving(true);
         const promisedCommonPolicyAdd = API.addOperationPolicy(
             policySpecContent,
+            api.id,
             synapsePolicyDefinition,
             ccPolicyDefinition,
-            api.id,
         );
         promisedCommonPolicyAdd
             .then(() => {

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/CreatePolicy.tsx
@@ -30,7 +30,7 @@ import { FormattedMessage } from 'react-intl';
 import API from 'AppData/api.js';
 import Alert from 'AppComponents/Shared/Alert';
 import ApiContext from 'AppComponents/Apis/Details/components/ApiContext';
-import CONST from 'AppData/Constants';
+import CONSTS from 'AppData/Constants';
 import type { CreatePolicySpec } from './Types';
 import PolicyCreateForm from './PolicyForm/PolicyCreateForm';
 
@@ -158,7 +158,7 @@ const CreatePolicy: React.FC<CreatePolicyProps> = ({
                     px={3}
                     pb={3}
                 >
-                    <Link to={CONST.PATH_TEMPLATES.COMMON_POLICIES}>
+                    <Link to={CONSTS.PATH_TEMPLATES.COMMON_POLICIES}>
                         <Typography className={classes.link} variant='caption'>
                             Want to create a common policy that will be visible to all APIs instead?
                             <LaunchIcon

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -61,16 +61,11 @@ const useStyles = makeStyles(() => ({
     }
 }));
 
-interface PoliciesProps {
-    disableUpdate: any;
-}
-
 /**
  * Renders the policy management page.
- * @param {JSON} props Input props from parent components.
  * @returns {TSX} Policy management page to render.
  */
-const Policies: React.FC<PoliciesProps> = ({ disableUpdate }) => {
+const Policies: React.FC = () => {
     const classes = useStyles();
     const [api, updateAPI] = useAPI();
     const [updating, setUpdating] = useState(false);
@@ -483,10 +478,7 @@ const Policies: React.FC<PoliciesProps> = ({ disableUpdate }) => {
                                                                 highlight
                                                                 operation={operation}
                                                                 api={localAPI}
-                                                                disableUpdate={
-                                                                    disableUpdate ||
-                                                                    isRestricted(['apim:api_create'], api)
-                                                                }
+                                                                disableUpdate={isRestricted(['apim:api_create'], api)}
                                                                 expandedResource={expandedResource}
                                                                 setExpandedResource={setExpandedResource}
                                                                 policyList={policies}

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -361,20 +361,23 @@ const Policies: React.FC = () => {
             });
     }
 
+    /**
+     * To memoize the value passed into ApiOperationContextProvider
+     */
+    const providerValue = useMemo(() => ({
+        apiOperations,
+        updateApiOperations,
+        updateAllApiOperations,
+        deleteApiOperation,
+        rearrangeApiOperations,
+    }), [apiOperations, updateApiOperations, updateAllApiOperations, deleteApiOperation, rearrangeApiOperations])
+
     if (!policies || !openAPISpec || updating) {
         return <Progress per={90} message='Loading Policies ...' />
     }
 
     return (
-        <ApiOperationContextProvider
-            value={{
-                apiOperations,
-                updateApiOperations,
-                updateAllApiOperations,
-                deleteApiOperation,
-                rearrangeApiOperations,
-            }}
-        >
+        <ApiOperationContextProvider value={providerValue}>
             <DndProvider backend={HTML5Backend}>
                 <Box mb={4}>
                     <Typography id='itest-api-details-resources-head' variant='h4' component='h2' gutterBottom>

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyDropzone.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyDropzone.tsx
@@ -91,16 +91,13 @@ const PolicyDropzone: FC<PolicyDropzoneProps> = ({
     const classes = useStyles();
     const [droppedPolicy, setDroppedPolicy] = useState<Policy | null>(null);
 
-    const [{ canDrop, isOver }, drop] = useDrop({
+    const [{ canDrop }, drop] = useDrop({
         accept: droppablePolicyList,
         drop: (item: any) => setDroppedPolicy(item.droppedPolicy),
         collect: (monitor) => ({
-            isOver: monitor.isOver(),
             canDrop: monitor.canDrop(),
         }),
     });
-
-    const isActive = canDrop && isOver;
 
     return (
         <>
@@ -109,7 +106,7 @@ const PolicyDropzone: FC<PolicyDropzoneProps> = ({
                     ref={drop}
                     className={clsx({
                         [classes.dropzoneDiv]: true,
-                        [classes.acceptDrop]: isActive,
+                        [classes.acceptDrop]: canDrop,
                         [classes.alignCenter]: currentPolicyList.length === 0,
                         [classes.alignLeft]:
                             currentPolicyList.length !== 0 &&

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyDropzone.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyDropzone.tsx
@@ -21,7 +21,7 @@ import { Grid, makeStyles, Theme, Typography } from '@material-ui/core';
 import { useDrop } from 'react-dnd';
 import green from '@material-ui/core/colors/green';
 import red from '@material-ui/core/colors/red';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { AttachedPolicy, Policy, PolicySpec } from './Types';
 import AttachedPolicyList from './AttachedPolicyList';
 import PolicyConfiguringDrawer from './PolicyConfiguringDrawer';
@@ -107,7 +107,7 @@ const PolicyDropzone: FC<PolicyDropzoneProps> = ({
             <Grid container>
                 <div
                     ref={drop}
-                    className={classNames({
+                    className={clsx({
                         [classes.dropzoneDiv]: true,
                         [classes.acceptDrop]: isActive,
                         [classes.alignCenter]: currentPolicyList.length === 0,

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
@@ -182,14 +182,14 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
         // Supported gateways current state validation
         if (state.supportedGateways.length === 0) hasError = true;
 
-        // Synapse policy file upload current state validation
+        // Policy file upload current state validation for Synapse
         if (
             state.supportedGateways.includes(CONSTS.GATEWAY_TYPE.synapse) &&
             synapsePolicyDefinitionFile.length === 0
         )
             hasError = true;
 
-        // CC policy file upload current state validation
+        // Policy file upload current state validation for Choreo Connect
         if (
             state.supportedGateways.includes(CONSTS.GATEWAY_TYPE.choreoConnect) &&
             ccPolicyDefinitionFile.length === 0

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
@@ -24,6 +24,7 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import { FormattedMessage } from 'react-intl';
 import { isRestricted } from 'AppData/AuthManager';
+import CONSTS from 'AppData/Constants';
 import type { CreatePolicySpec } from '../Types';
 import type { NewPolicyState, PolicyAttribute } from './Types';
 import PolicyAttributes from './PolicyAttributes';
@@ -136,8 +137,10 @@ function policyReducer(state: NewPolicyState, action: any) {
 
 interface PolicyCreateFormProps {
     onSave: (policySpecification: CreatePolicySpec) => void;
-    policyDefinitionFile: any[];
-    setPolicyDefinitionFile: React.Dispatch<React.SetStateAction<any[]>>;
+    synapsePolicyDefinitionFile: any[];
+    setSynapsePolicyDefinitionFile: React.Dispatch<React.SetStateAction<any[]>>;
+    ccPolicyDefinitionFile: any[];
+    setCcPolicyDefinitionFile: React.Dispatch<React.SetStateAction<any[]>>;
     onCancel: () => void;
     saving: boolean;
 }
@@ -149,8 +152,10 @@ interface PolicyCreateFormProps {
  */
 const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
     onSave,
-    policyDefinitionFile,
-    setPolicyDefinitionFile,
+    synapsePolicyDefinitionFile,
+    setSynapsePolicyDefinitionFile,
+    ccPolicyDefinitionFile,
+    setCcPolicyDefinitionFile,
     onCancel,
     saving,
 }) => {
@@ -177,9 +182,20 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
         // Supported gateways current state validation
         if (state.supportedGateways.length === 0) hasError = true;
 
-        // Policy file upload current state validation
-        if (policyDefinitionFile.length === 0) hasError = true;
+        // Synapse policy file upload current state validation
+        if (
+            state.supportedGateways.includes(CONSTS.GATEWAY_TYPE.synapse) &&
+            synapsePolicyDefinitionFile.length === 0
+        )
+            hasError = true;
 
+        // CC policy file upload current state validation
+        if (
+            state.supportedGateways.includes(CONSTS.GATEWAY_TYPE.choreoConnect) &&
+            ccPolicyDefinitionFile.length === 0
+        )
+            hasError = true;        
+        
         // Policy attributes current state validation
         state.policyAttributes.forEach((attribute: PolicyAttribute) => {
             if (
@@ -197,7 +213,8 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
         state.applicableFlows,
         state.supportedGateways,
         state.policyAttributes,
-        policyDefinitionFile,
+        synapsePolicyDefinitionFile,
+        ccPolicyDefinitionFile
     ]);
 
     /**
@@ -250,8 +267,10 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
             {/* Gateway specific details of policy */}
             <SourceDetails
                 supportedGateways={state.supportedGateways}
-                policyDefinitionFile={policyDefinitionFile}
-                setPolicyDefinitionFile={setPolicyDefinitionFile}
+                synapsePolicyDefinitionFile={synapsePolicyDefinitionFile}
+                setSynapsePolicyDefinitionFile={setSynapsePolicyDefinitionFile}
+                ccPolicyDefinitionFile={ccPolicyDefinitionFile}
+                setCcPolicyDefinitionFile={setCcPolicyDefinitionFile}
                 dispatch={dispatch}
             />
             <Divider light />

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
@@ -47,10 +47,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 }));
 
+export const GATEWAY_TYPE_LABELS = {
+    SYNAPSE: 'Regular Gateway',
+    CC: 'Choreo Connect'
+}
+
 interface SourceDetailsProps {
     supportedGateways: string[];
-    policyDefinitionFile?: any[];
-    setPolicyDefinitionFile?: React.Dispatch<React.SetStateAction<any[]>>;
+    synapsePolicyDefinitionFile?: any[];
+    setSynapsePolicyDefinitionFile?: React.Dispatch<React.SetStateAction<any[]>>;
+    ccPolicyDefinitionFile?: any[];
+    setCcPolicyDefinitionFile?: React.Dispatch<React.SetStateAction<any[]>>;
     dispatch?: React.Dispatch<any>;
     isViewMode?: boolean;
     policyId?: string;
@@ -64,8 +71,10 @@ interface SourceDetailsProps {
  */
 const SourceDetails: FC<SourceDetailsProps> = ({
     supportedGateways,
-    policyDefinitionFile,
-    setPolicyDefinitionFile,
+    synapsePolicyDefinitionFile,
+    setSynapsePolicyDefinitionFile,
+    ccPolicyDefinitionFile,
+    setCcPolicyDefinitionFile,
     dispatch,
     isViewMode,
     policyId,
@@ -138,62 +147,78 @@ const SourceDetails: FC<SourceDetailsProps> = ({
         }
     };
 
-    const renderPolicyFileDetails = () => {
-        if (!isViewMode && policyDefinitionFile && setPolicyDefinitionFile) {
-            return (
-                <UploadPolicyDropzone
-                    policyDefinitionFile={policyDefinitionFile}
-                    setPolicyDefinitionFile={setPolicyDefinitionFile}
-                />
-            );
-        } else {
-            return (
-                <>
-                    <Box display='flex' flexDirection='row' alignItems='center'>
-                        <Typography
-                            color='inherit'
-                            variant='subtitle2'
-                            component='div'
-                        >
-                            <FormattedMessage
-                                id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.title'
-                                defaultMessage='Policy File'
-                            />
-                            <sup className={classes.mandatoryStar}>*</sup>
-                        </Typography>
-                    </Box>
-                    <Typography color='inherit' variant='caption' component='p'>
-                        <FormattedMessage
-                            id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.description'
-                            defaultMessage='Policy file contains the business logic of the policy'
-                        />
-                    </Typography>
-                    <Box
-                        flex='1'
-                        display='flex'
-                        flexDirection='row'
-                        justifyContent='left'
-                        mt={3}
-                        mb={3}
-                    >
-                        <Button
-                            aria-label='download-policy'
-                            variant='contained'
-                            size='large'
-                            color='primary'
-                            onClick={handlePolicyDownload}
-                            endIcon={<CloudDownloadIcon />}
-                        >
-                            <FormattedMessage
-                                id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.download'
-                                defaultMessage='Download Policy'
-                            />
-                        </Button>
-                    </Box>
-                </>
-            );
-        }
+    /**
+     * Renders the policy file upload related section
+     * @param {any[]} policyFile Policy file
+     * @param {React.Dispatch<React.SetStateAction<any[]>>} setPolicyFile Policy file setter
+     * @param {string} gateway Gateway type
+     * @returns {TSX} Policy upload section
+     */
+    const renderPolicyFileUpload = (
+        policyFile: any[],
+        setPolicyFile: React.Dispatch<React.SetStateAction<any[]>>,
+        gateway: string,
+    ) => {
+        return (
+            <UploadPolicyDropzone
+                policyDefinitionFile={policyFile}
+                setPolicyDefinitionFile={setPolicyFile}
+                gateway={gateway}
+            />
+        );
     };
+
+    /**
+     *
+     * @returns {TSX} Policy download section
+     */
+    const renderPolicyDownload = () => {
+        return (
+            <>
+                <Box display='flex' flexDirection='row' alignItems='center'>
+                    <Typography
+                        color='inherit'
+                        variant='subtitle2'
+                        component='div'
+                    >
+                        <FormattedMessage
+                            id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.title'
+                            defaultMessage='Policy File(s)'
+                        />
+                        <sup className={classes.mandatoryStar}>*</sup>
+                    </Typography>
+                </Box>
+                <Typography color='inherit' variant='caption' component='p'>
+                    <FormattedMessage
+                        id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.description'
+                        defaultMessage='Policy file contains the business logic of the policy'
+                    />
+                </Typography>
+                <Box
+                    flex='1'
+                    display='flex'
+                    flexDirection='row'
+                    justifyContent='left'
+                    mt={3}
+                    mb={3}
+                >
+                    <Button
+                        aria-label='download-policy'
+                        variant='contained'
+                        size='large'
+                        color='primary'
+                        onClick={handlePolicyDownload}
+                        endIcon={<CloudDownloadIcon />}
+                    >
+                        <FormattedMessage
+                            id='Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.download'
+                            defaultMessage='Download Policy'
+                        />
+                    </Button>
+                </Box>
+            </>
+        );
+    }
 
     return (
         <Box display='flex' flexDirection='row' mt={1}>
@@ -255,7 +280,7 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                                             onChange={handleChange}
                                         />
                                     }
-                                    label='Regular Gateway'
+                                    label={GATEWAY_TYPE_LABELS.SYNAPSE}
                                 />
                                 <FormControlLabel
                                     control={
@@ -266,10 +291,9 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                                                 CONSTS.GATEWAY_TYPE.choreoConnect,
                                             )}
                                             onChange={handleChange}
-                                            disabled
                                         />
                                     }
-                                    label='Choreo Connect'
+                                    label={GATEWAY_TYPE_LABELS.CC}
                                 />
                             </FormGroup>
                             <FormHelperText>
@@ -280,8 +304,30 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                         </FormControl>
                     </Box>
                 </Box>
+
+                {/* Render dropzones for policy file uploads */}
                 {supportedGateways.includes(CONSTS.GATEWAY_TYPE.synapse) &&
-                    renderPolicyFileDetails()}
+                    !isViewMode &&
+                    synapsePolicyDefinitionFile &&
+                    setSynapsePolicyDefinitionFile &&
+                    renderPolicyFileUpload(
+                        synapsePolicyDefinitionFile,
+                        setSynapsePolicyDefinitionFile,
+                        GATEWAY_TYPE_LABELS.SYNAPSE,
+                        
+                    )}
+                {supportedGateways.includes(CONSTS.GATEWAY_TYPE.choreoConnect) &&
+                    !isViewMode &&
+                    ccPolicyDefinitionFile &&
+                    setCcPolicyDefinitionFile &&
+                    renderPolicyFileUpload(
+                        ccPolicyDefinitionFile,
+                        setCcPolicyDefinitionFile,
+                        GATEWAY_TYPE_LABELS.CC,
+                    )}
+
+                {/* Render policy file download option in view mode */}
+                {isViewMode && renderPolicyDownload()}
             </Box>
         </Box>
     );

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
@@ -31,6 +31,7 @@ import Button from '@material-ui/core/Button';
 import Utils from 'AppData/Utils';
 import API from 'AppData/api.js';
 import { Alert } from 'AppComponents/Shared';
+import CONSTS from 'AppData/Constants';
 import { ACTIONS } from './PolicyCreateForm';
 import UploadPolicyDropzone from './UploadPolicyDropzone';
 import ApiContext from '../../components/ApiContext';
@@ -45,11 +46,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         flexDirection: 'row',
     },
 }));
-
-const SUPPORTED_GATEWAYS = {
-    SYNAPSE: 'Synapse',
-    CC: 'ChoreoConnect',
-};
 
 interface SourceDetailsProps {
     supportedGateways: string[];
@@ -92,8 +88,8 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                 type: ACTIONS.UPDATE_SUPPORTED_GATEWAYS,
                 name:
                     event.target.name === 'regularGateway'
-                        ? SUPPORTED_GATEWAYS.SYNAPSE
-                        : SUPPORTED_GATEWAYS.CC,
+                        ? CONSTS.GATEWAY_TYPE.synapse
+                        : CONSTS.GATEWAY_TYPE.choreoConnect,
                 checked: event.target.checked,
             });
         }
@@ -254,7 +250,7 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                                             name='regularGateway'
                                             color='primary'
                                             checked={supportedGateways.includes(
-                                                SUPPORTED_GATEWAYS.SYNAPSE,
+                                                CONSTS.GATEWAY_TYPE.synapse,
                                             )}
                                             onChange={handleChange}
                                         />
@@ -267,7 +263,7 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                                             name='choreoConnect'
                                             color='primary'
                                             checked={supportedGateways.includes(
-                                                SUPPORTED_GATEWAYS.CC,
+                                                CONSTS.GATEWAY_TYPE.choreoConnect,
                                             )}
                                             onChange={handleChange}
                                             disabled
@@ -284,7 +280,7 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                         </FormControl>
                     </Box>
                 </Box>
-                {supportedGateways.includes(SUPPORTED_GATEWAYS.SYNAPSE) &&
+                {supportedGateways.includes(CONSTS.GATEWAY_TYPE.synapse) &&
                     renderPolicyFileDetails()}
             </Box>
         </Box>

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
@@ -35,6 +35,7 @@ import green from '@material-ui/core/colors/green';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 import { HelpOutline } from '@material-ui/icons';
+import { GATEWAY_TYPE_LABELS } from './SourceDetails';
 
 const useStyles = makeStyles((theme: Theme) => ({
     dropZoneWrapper: {
@@ -75,6 +76,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface UploadPolicyDropzoneProps {
     policyDefinitionFile: any[];
     setPolicyDefinitionFile: React.Dispatch<React.SetStateAction<any[]>>;
+    gateway: string;
 }
 
 /**
@@ -85,6 +87,7 @@ interface UploadPolicyDropzoneProps {
 const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
     policyDefinitionFile,
     setPolicyDefinitionFile,
+    gateway,
 }) => {
     const classes = useStyles();
 
@@ -143,11 +146,16 @@ const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
                     >
                         <FormattedMessage
                             id='Apis.Details.Policies.PolicyForm.UploadPolicyDropzone.title'
-                            defaultMessage='Upload Policy File'
+                            defaultMessage='Upload Policy File for {gateway}'
+                            values={{ gateway }}
                         />
                         <sup className={classes.mandatoryStar}>*</sup>
                         <Tooltip
-                            title='Regular gateway supports only .j2 and .xml file uploads'
+                            title={
+                                gateway === GATEWAY_TYPE_LABELS.SYNAPSE
+                                    ? 'Regular gateway only supports .j2 and .xml file uploads'
+                                    : 'Choreo Connect only supports .gotmpl file uploads'
+                            }
                             placement='right'
                             interactive
                         >

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
@@ -30,7 +30,7 @@ import Avatar from '@material-ui/core/Avatar';
 import InsertDriveFile from '@material-ui/icons/InsertDriveFile';
 import DeleteIcon from '@material-ui/icons/Delete';
 import Dropzone from 'react-dropzone';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import green from '@material-ui/core/colors/green';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
@@ -112,7 +112,7 @@ const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         <div {...getRootProps({})}>
                             <div
-                                className={classNames(
+                                className={clsx(
                                     classes.dropZoneWrapper,
                                     isDragAccept ? classes.acceptDrop : null,
                                     isDragReject ? classes.rejectDrop : null,

--- a/portals/publisher/source/src/app/components/CommonPolicies/CommonPolicies.tsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/CommonPolicies.tsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
-import CONST from 'AppData/Constants';
+import CONSTS from 'AppData/Constants';
 import Listing from './Listing';
 import CreatePolicy from './CreatePolicy';
 import ViewPolicy from './ViewPolicy';
@@ -33,12 +33,12 @@ const CommonPolicies = () => {
         <Switch>
             <Route
                 exact
-                path={CONST.PATH_TEMPLATES.COMMON_POLICIES}
+                path={CONSTS.PATH_TEMPLATES.COMMON_POLICIES}
                 component={Listing}
             />
             <Route
                 exact
-                path={CONST.PATH_TEMPLATES.COMMON_POLICY_CREATE}
+                path={CONSTS.PATH_TEMPLATES.COMMON_POLICY_CREATE}
                 component={CreatePolicy}
             />
             <Route

--- a/portals/publisher/source/src/app/components/CommonPolicies/CreatePolicy.tsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/CreatePolicy.tsx
@@ -28,7 +28,7 @@ import API from 'AppData/api.js';
 import type { CreatePolicySpec } from 'AppComponents/Apis/Details/Policies/Types';
 import PolicyCreateForm from 'AppComponents/Apis/Details/Policies/PolicyForm/PolicyCreateForm';
 import { Box } from '@material-ui/core';
-import CONST from 'AppData/Constants';
+import CONSTS from 'AppData/Constants';
 
 const useStyles = makeStyles((theme: any) => ({
     titleWrapper: {
@@ -57,27 +57,31 @@ const CreatePolicy: React.FC = () => {
     const classes = useStyles();
     const history = useHistory();
     const api = new API();
-    const [policyDefinitionFile, setPolicyDefinitionFile] = useState<any[]>([]);
+    const [synapsePolicyDefinitionFile, setSynapsePolicyDefinitionFile] = useState<any[]>([]);
+    const [ccPolicyDefinitionFile, setCcPolicyDefinitionFile] = useState<any[]>([]);
     const [saving, setSaving] = useState(false);
 
     const addCommonPolicy = (
         policySpecContent: CreatePolicySpec,
-        policyDefinition: any,
+        synapsePolicyDefinition: any,
+        ccPolicyDefinition: any,
     ) => {
         setSaving(true);
         const promisedCommonPolicyAdd = api.addCommonOperationPolicy(
             policySpecContent,
-            policyDefinition,
+            synapsePolicyDefinition,
+            ccPolicyDefinition
         );
         promisedCommonPolicyAdd
             .then(() => {
                 Alert.info('Policy created successfully!');
-                setPolicyDefinitionFile([]);
-                history.push(CONST.PATH_TEMPLATES.COMMON_POLICIES);
+                setSynapsePolicyDefinitionFile([]);
+                setCcPolicyDefinitionFile([]);
+                history.push(CONSTS.PATH_TEMPLATES.COMMON_POLICIES);
             })
             .catch((error) => {
                 console.error(error);
-                history.push(CONST.PATH_TEMPLATES.COMMON_POLICIES);
+                history.push(CONSTS.PATH_TEMPLATES.COMMON_POLICIES);
                 Alert.error('Something went wrong while creating policy');
             })
             .finally(() => {
@@ -86,11 +90,17 @@ const CreatePolicy: React.FC = () => {
     };
 
     const onSave = (policySpecification: CreatePolicySpec) => {
-        addCommonPolicy(policySpecification, policyDefinitionFile);
+        const synapseFile = synapsePolicyDefinitionFile.length !== 0 ? synapsePolicyDefinitionFile : null;
+        const ccFile = ccPolicyDefinitionFile.length !== 0 ? ccPolicyDefinitionFile : null;
+        addCommonPolicy(
+            policySpecification,
+            synapseFile,
+            ccFile
+        );
     };
 
     const onCancel = () => {
-        history.push(CONST.PATH_TEMPLATES.COMMON_POLICIES);
+        history.push(CONSTS.PATH_TEMPLATES.COMMON_POLICIES);
     };
 
     return (
@@ -102,7 +112,7 @@ const CreatePolicy: React.FC = () => {
                     <Grid item md={12}>
                         <div className={classes.titleWrapper}>
                             <Link
-                                to={CONST.PATH_TEMPLATES.COMMON_POLICIES}
+                                to={CONSTS.PATH_TEMPLATES.COMMON_POLICIES}
                                 className={classes.titleLink}
                             >
                                 <Typography variant='h4' component='h2'>
@@ -124,8 +134,10 @@ const CreatePolicy: React.FC = () => {
                     <Grid item md={12}>
                         <PolicyCreateForm
                             onSave={onSave}
-                            policyDefinitionFile={policyDefinitionFile}
-                            setPolicyDefinitionFile={setPolicyDefinitionFile}
+                            synapsePolicyDefinitionFile={synapsePolicyDefinitionFile}
+                            setSynapsePolicyDefinitionFile={setSynapsePolicyDefinitionFile}
+                            ccPolicyDefinitionFile={ccPolicyDefinitionFile}
+                            setCcPolicyDefinitionFile={setCcPolicyDefinitionFile}
                             onCancel={onCancel}
                             saving={saving}
                         />

--- a/portals/publisher/source/src/app/components/CommonPolicies/CreatePolicy.tsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/CreatePolicy.tsx
@@ -95,7 +95,7 @@ const CreatePolicy: React.FC = () => {
         addCommonPolicy(
             policySpecification,
             synapseFile,
-            ccFile
+            ccFile,
         );
     };
 

--- a/portals/publisher/source/src/app/components/CommonPolicies/Listing.jsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/Listing.jsx
@@ -127,9 +127,9 @@ const Listing = () => {
 
     // Provides the gateway specific policies list.
     const getPoliciesList = () => {
-        let gatewayType = CONST.GATEWAY_TYPE.synapse;
+        let gatewayType = CONSTS.GATEWAY_TYPE.synapse;
         if (isAllowedToFilterCCPolicies) {
-            gatewayType = CONST.GATEWAY_TYPE.choreoConnect;
+            gatewayType = CONSTS.GATEWAY_TYPE.choreoConnect;
         }
         // removes irrelevant policies for the selected gateway type
         return policies?.filter((policy) => {

--- a/portals/publisher/source/src/app/components/CommonPolicies/Listing.jsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/Listing.jsx
@@ -43,7 +43,7 @@ import ArrowForward from '@material-ui/icons/ArrowForward';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import TrendingDown from '@material-ui/icons/TrendingDown';
 import ResourceNotFoundError from 'AppComponents/Base/Errors/ResourceNotFoundError';
-import CONST from 'AppData/Constants';
+import CONSTS from 'AppData/Constants';
 import Delete from './DeletePolicy';
 import CommonPolicyGatewaySelector from './CommonPolicyGatewaySelector';
 
@@ -332,7 +332,7 @@ const Listing = () => {
                 }
             >
                 <OnboardingMenuCard
-                    to={CONST.PATH_TEMPLATES.COMMON_POLICY_CREATE}
+                    to={CONSTS.PATH_TEMPLATES.COMMON_POLICY_CREATE}
                     name='Policies'
                     iconName={commonPolicyAddIcon}
                     disabled={isRestricted([
@@ -412,7 +412,7 @@ const Listing = () => {
                                 'apim:mediation_policy_create',
                                 'apim:mediation_policy_manage',
                                 'apim:api_mediation_policy_manage',
-                            ]) && CONST.PATH_TEMPLATES.COMMON_POLICY_CREATE
+                            ]) && CONSTS.PATH_TEMPLATES.COMMON_POLICY_CREATE
                         }
                     >
                         <AddCircle className={classes.buttonIcon} />

--- a/portals/publisher/source/src/app/components/CommonPolicies/ViewPolicy.tsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/ViewPolicy.tsx
@@ -24,7 +24,7 @@ import Icon from '@material-ui/core/Icon';
 import Typography from '@material-ui/core/Typography';
 import { FormattedMessage } from 'react-intl';
 import { Link, useHistory, useParams } from 'react-router-dom';
-import CONST from 'AppData/Constants';
+import CONSTS from 'AppData/Constants';
 import API from 'AppData/api';
 import { PolicySpec } from 'AppComponents/Apis/Details/Policies/Types';
 import { Progress } from 'AppComponents/Shared';
@@ -85,7 +85,7 @@ const ViewPolicy: React.FC = () => {
     }, [policyId]);
 
     const redirectToPolicies = () => {
-        history.push(CONST.PATH_TEMPLATES.COMMON_POLICIES);
+        history.push(CONSTS.PATH_TEMPLATES.COMMON_POLICIES);
     };
 
     const resourceNotFoundMessage = {
@@ -110,7 +110,7 @@ const ViewPolicy: React.FC = () => {
                     <Grid item md={12}>
                         <div className={classes.titleWrapper}>
                             <Link
-                                to={CONST.PATH_TEMPLATES.COMMON_POLICIES}
+                                to={CONSTS.PATH_TEMPLATES.COMMON_POLICIES}
                                 className={classes.titleLink}
                             >
                                 <Typography variant='h4' component='h2'>

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -19,7 +19,7 @@ import APIClientFactory from './APIClientFactory';
 import Utils from './Utils';
 import Resource from './Resource';
 import cloneDeep from 'lodash.clonedeep';
-import Configurations from '/site/public/conf/settings';
+import Configurations from '../../../../site/public/conf/settings';
 
 /**
  * An abstract representation of an API
@@ -2751,7 +2751,6 @@ class API extends Resource {
      * @returns {boolean|*}
      */
     updateAsyncAPIDefinitionByFile(apiId, AsyncAPIFile) {
-        console.log('hello');
         console.log(apiId);
         console.log(AsyncAPIFile);
         let payload, promise_updated;

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -19,7 +19,7 @@ import APIClientFactory from './APIClientFactory';
 import Utils from './Utils';
 import Resource from './Resource';
 import cloneDeep from 'lodash.clonedeep';
-import Configurations from 'Config';
+import Configurations from '/site/public/conf/settings';
 
 /**
  * An abstract representation of an API
@@ -2470,38 +2470,6 @@ class API extends Resource {
     }
 
     /**
-     * Get global mediation policies.
-     * @returns {Promise}
-     *
-     */
-    static getGlobalMediationPolicies() {
-        const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const limit = Configurations.app.mediationPolicyCount;
-        return restApiClient.then(client => {
-            return client.apis['Global Mediation Policies'].getAllGlobalMediationPolicies({limit}, this._requestMetaData());
-        });
-    }
-
-    /**
-     * Get the content of a mediation policy.
-     * @param {String} mediationPolicyId mediation policy uuid
-     * @param {String} apiId uuid of the api
-     * @returns {Promise}
-     *
-     */
-    static getGlobalMediationPolicyContent(mediationPolicyId) {
-        const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        return restApiClient.then(client => {
-            return client.apis['Global Mediation Policy'].getGlobalMediationPolicyContent(
-                {
-                    mediationPolicyId: mediationPolicyId,
-                },
-                this._requestMetaData(),
-            );
-        });
-    }
-
-    /**
      * @static
      * Get all the external stores configured for the current environment
      * @returns {Promise}
@@ -2820,11 +2788,10 @@ class API extends Resource {
      */
     static getCommonOperationPolicies() {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+        const limit = Configurations.app.operationPolicyCount;
         return restApiClient.then(client => {
             return client.apis['Operation Policies'].getAllCommonOperationPolicies(
-                {
-                    limit: 50,
-                },
+                {limit},
                 this._requestMetaData(),
             );
         });
@@ -2837,7 +2804,6 @@ class API extends Resource {
      */
     static getCommonOperationPolicy(policyId) {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const limit = Configurations.app.operationPolicyCount;
         return restApiClient.then(client => {
             return client.apis['Operation Policies'].getCommonOperationPolicyByPolicyId(
                 {
@@ -2972,12 +2938,12 @@ class API extends Resource {
     /**
      * Add an API specific operation policy
      * @param {Object} policySpec policy specification of the operation policy
+     * @param {String} apiId UUID of the API
      * @param {any} synapsePolicyDefinition policy definition of the operation policy for Synapse
      * @param {any} ccPolicyDefinition policy definition of the operation policy for Choreo Connect
-     * @param {String} apiId UUID of the API
      * @returns {Promise} Promise containing added operation policy specification
      */
-    static addOperationPolicy(policySpec, synapsePolicyDefinition = null, ccPolicyDefinition = null, apiId) {
+    static addOperationPolicy(policySpec, apiId, synapsePolicyDefinition = null, ccPolicyDefinition = null) {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         return restApiClient.then(client => {
             return client.apis['API Operation Policies'].addAPISpecificOperationPolicy(

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -2820,10 +2820,11 @@ class API extends Resource {
      */
     static getCommonOperationPolicies() {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const limit = Configurations.app.operationPolicyCount;
         return restApiClient.then(client => {
             return client.apis['Operation Policies'].getAllCommonOperationPolicies(
-                {limit},
+                {
+                    limit: 50,
+                },
                 this._requestMetaData(),
             );
         });

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -2850,10 +2850,11 @@ class API extends Resource {
     /**
      * Add a common operation policy
      * @param {Object} policySpec policy specification of the common operation policy to upload
-     * @param {any} policyDefinition policy definition of the common operation policy to upload
+     * @param {any} synapsePolicyDefinition policy definition of the common operation policy for Synapse
+     * @param {any} ccPolicyDefinition policy definition of the common operation policy for Choreo Connect
      * @returns {Promise} Promise containing uploaded operation policy specification
      */
-    addCommonOperationPolicy(policySpec, policyDefinition) {
+    addCommonOperationPolicy(policySpec, synapsePolicyDefinition = null, ccPolicyDefinition = null) {
         const promised_addCommonOperationPolicy = this.client.then(client => {
             const payload = {
                 'Content-Type': 'multipart/form-data',
@@ -2861,8 +2862,9 @@ class API extends Resource {
             const requestBody = {
                 requestBody: {
                     policySpecFile: JSON.stringify(policySpec),
-                    synapsePolicyDefinitionFile: policyDefinition,
-                }
+                    ...(synapsePolicyDefinition !== null ? {synapsePolicyDefinitionFile: synapsePolicyDefinition} : {}),
+                    ...(ccPolicyDefinition !== null ? {ccPolicyDefinitionFile: ccPolicyDefinition} : {}),
+                },
             }
             return client.apis['Operation Policies'].addCommonOperationPolicy(
                 payload,
@@ -2969,11 +2971,12 @@ class API extends Resource {
     /**
      * Add an API specific operation policy
      * @param {Object} policySpec policy specification of the operation policy
-     * @param {any} policyDefinition policy definition of the operation policy
+     * @param {any} synapsePolicyDefinition policy definition of the operation policy for Synapse
+     * @param {any} ccPolicyDefinition policy definition of the operation policy for Choreo Connect
      * @param {String} apiId UUID of the API
      * @returns {Promise} Promise containing added operation policy specification
      */
-    static addOperationPolicy(policySpec, policyDefinition, apiId) {
+    static addOperationPolicy(policySpec, synapsePolicyDefinition = null, ccPolicyDefinition = null, apiId) {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         return restApiClient.then(client => {
             return client.apis['API Operation Policies'].addAPISpecificOperationPolicy(
@@ -2983,7 +2986,8 @@ class API extends Resource {
                 {
                     requestBody: {
                         policySpecFile: JSON.stringify(policySpec),
-                        synapsePolicyDefinitionFile: policyDefinition,
+                        ...(synapsePolicyDefinition !== null ? {synapsePolicyDefinitionFile: synapsePolicyDefinition} : {}),
+                        ...(ccPolicyDefinition !== null ? {ccPolicyDefinitionFile: ccPolicyDefinition} : {}),
                     },
                 },
                 this._requestMetaData({

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -2782,15 +2782,20 @@ class API extends Resource {
     }
 
     /**
-     * Get all common operation policies to all the APIs
-     * @returns {Promise} Promise containing a list of all common operation policies that can be used by any API
+     * Get all common operation policies
+     * @param {String} limit limit of the common operation policy list which needs to be retrieved
+     * @param {String} offset offset of the common operation policy list which needs to be retrieved
+     * @returns {Promise} Promise containing common operation policies that can be used by any API
      */
-    static getCommonOperationPolicies() {
+    static getCommonOperationPolicies(limit = null, offset = null) {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const limit = Configurations.app.operationPolicyCount;
+        const policyLimit = limit ? limit : Configurations.app.operationPolicyCount;
         return restApiClient.then(client => {
             return client.apis['Operation Policies'].getAllCommonOperationPolicies(
-                {limit},
+                {
+                    limit: policyLimit,
+                    offset
+                },
                 this._requestMetaData(),
             );
         });

--- a/portals/publisher/source/src/app/data/api.js
+++ b/portals/publisher/source/src/app/data/api.js
@@ -3017,17 +3017,6 @@ class API extends Resource {
         });
     }
 
-    /**
-     * Retrieve the operation policy specification related JSON schema
-     * @returns {Promise}
-     */
-    static getOperationPolicySpecSchema() {
-        const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        return restApiClient.then(client => {
-            return client.apis['Operation Policies'].exportOperationPolicySpecificationSchema();
-        });
-    }
-
 }
 
 API.CONSTS = {


### PR DESCRIPTION
## Purpose

With this PR, the policy create and view capabilities have been extended to support Choreo Connect gateway. Major changes include:
- When creating a new policy (common policy / API specific policy), now you can also upload the CC related policy definition file. With this change you can either upload policy files for both gateways or just a single gateway.
- Also, when viewing a policy, you can see CC related details in the same form which previously existed.