### PR TITLE
[Operation Level Policy Support] Improvements and bug fixes - 04

### DIFF
--- a/portals/publisher/site/public/locales/en.json
+++ b/portals/publisher/site/public/locales/en.json
@@ -5261,7 +5261,13 @@
       "value": "Resources"
     }
   ],
-  "Apis.Details.Policies.AttachedPolicyCard.download.error": [
+  "Apis.Details.Policies.AttachedPolicyCard.apiSpecificPolicy.download.error": [
+    {
+      "type": 0,
+      "value": "Something went wrong while downloading the policy"
+    }
+  ],
+  "Apis.Details.Policies.AttachedPolicyCard.commonPolicy.download.error": [
     {
       "type": 0,
       "value": "Something went wrong while downloading the policy"
@@ -5342,7 +5348,7 @@
   "Apis.Details.Policies.DeletePolicy.confirm": [
     {
       "type": 0,
-      "value": "Yes"
+      "value": "Delete"
     }
   ],
   "Apis.Details.Policies.DeletePolicy.delete.confirm": [
@@ -5683,16 +5689,22 @@
       "value": "Done"
     }
   ],
+  "Apis.Details.Policies.PolicyForm.SourceDetails.apiSpecificPolicy.download.error": [
+    {
+      "type": 0,
+      "value": "Something went wrong while downloading the policy"
+    }
+  ],
+  "Apis.Details.Policies.PolicyForm.SourceDetails.commonPolicy.download.error": [
+    {
+      "type": 0,
+      "value": "Something went wrong while downloading the policy"
+    }
+  ],
   "Apis.Details.Policies.PolicyForm.SourceDetails.description": [
     {
       "type": 0,
       "value": "Define the Gateway (s) that will be supporting this policy. Based off of this selection, you can upload the relevant business logic inclusive policy file."
-    }
-  ],
-  "Apis.Details.Policies.PolicyForm.SourceDetails.download.error": [
-    {
-      "type": 0,
-      "value": "Something went wrong while downloading the policy"
     }
   ],
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.description": [

--- a/portals/publisher/site/public/locales/raw.en.json
+++ b/portals/publisher/site/public/locales/raw.en.json
@@ -2499,7 +2499,10 @@
   "Apis.Details.Overview.ProductResources.resources": {
     "defaultMessage": "Resources"
   },
-  "Apis.Details.Policies.AttachedPolicyCard.download.error": {
+  "Apis.Details.Policies.AttachedPolicyCard.apiSpecificPolicy.download.error": {
+    "defaultMessage": "Something went wrong while downloading the policy"
+  },
+  "Apis.Details.Policies.AttachedPolicyCard.commonPolicy.download.error": {
     "defaultMessage": "Something went wrong while downloading the policy"
   },
   "Apis.Details.Policies.AttachedPolicyForm.General.apply.to.all.resources": {
@@ -2539,7 +2542,7 @@
     "defaultMessage": "Cancel"
   },
   "Apis.Details.Policies.DeletePolicy.confirm": {
-    "defaultMessage": "Yes"
+    "defaultMessage": "Delete"
   },
   "Apis.Details.Policies.DeletePolicy.delete.confirm": {
     "defaultMessage": "Confirm Delete"
@@ -2694,11 +2697,14 @@
   "Apis.Details.Policies.PolicyForm.PolicyViewForm.done": {
     "defaultMessage": "Done"
   },
+  "Apis.Details.Policies.PolicyForm.SourceDetails.apiSpecificPolicy.download.error": {
+    "defaultMessage": "Something went wrong while downloading the policy"
+  },
+  "Apis.Details.Policies.PolicyForm.SourceDetails.commonPolicy.download.error": {
+    "defaultMessage": "Something went wrong while downloading the policy"
+  },
   "Apis.Details.Policies.PolicyForm.SourceDetails.description": {
     "defaultMessage": "Define the Gateway (s) that will be supporting this policy. Based off of this selection, you can upload the relevant business logic inclusive policy file."
-  },
-  "Apis.Details.Policies.PolicyForm.SourceDetails.download.error": {
-    "defaultMessage": "Something went wrong while downloading the policy"
   },
   "Apis.Details.Policies.PolicyForm.SourceDetails.form.policy.file.description": {
     "defaultMessage": "Policy file contains the business logic of the policy"

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
@@ -170,7 +170,11 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
     };
 
     const handleDrawerOpen = () => {
-        setDrawerOpen(true);
+        if (policyObj.id !== '') {
+            // Drawer will only appear for policies that have an ID
+            // Note that a migrated policy will have an empty string as the ID at the initial stage
+            setDrawerOpen(true);
+        }
     };
 
     return (
@@ -207,6 +211,7 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
                         onClick={handlePolicyDownload}
                         disableFocusRipple
                         disableRipple
+                        disabled={policyObj.id === ''} // Disabling policy download for migrated policy
                     >
                         <CloudDownloadIcon />
                     </IconButton>

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
@@ -137,15 +137,13 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
                     Utils.forceDownload(apiPolicyResponse);
                 })
                 .catch((error) => {
-                    if (process.env.NODE_ENV !== 'production') {
-                        console.error(error);
-                        Alert.error(
-                            <FormattedMessage
-                                id='Apis.Details.Policies.AttachedPolicyCard.apiSpecificPolicy.download.error'
-                                defaultMessage='Something went wrong while downloading the policy'
-                            />,
-                        );
-                    }
+                    console.error(error);
+                    Alert.error(
+                        <FormattedMessage
+                            id='Apis.Details.Policies.AttachedPolicyCard.apiSpecificPolicy.download.error'
+                            defaultMessage='Something went wrong while downloading the policy'
+                        />,
+                    );
                 });
         } else {
             const commonPolicyContentPromise = API.getCommonOperationPolicyContent(
@@ -156,15 +154,13 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
                     Utils.forceDownload(commonPolicyResponse);
                 })
                 .catch((error) => {
-                    if (process.env.NODE_ENV !== 'production') {
-                        console.error(error);
-                        Alert.error(
-                            <FormattedMessage
-                                id='Apis.Details.Policies.AttachedPolicyCard.commonPolicy.download.error'
-                                defaultMessage='Something went wrong while downloading the policy'
-                            />,
-                        );
-                    }
+                    console.error(error);
+                    Alert.error(
+                        <FormattedMessage
+                            id='Apis.Details.Policies.AttachedPolicyCard.commonPolicy.download.error'
+                            defaultMessage='Something went wrong while downloading the policy'
+                        />,
+                    );
                 });
         }
     };

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/AttachedPolicyCard.tsx
@@ -98,7 +98,11 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
         opacity: isDragging ? 0.5 : 1,
     };
 
-    const handleDelete = (event: any) => {
+    /**
+     * Handle policy delete
+     * @param {React.MouseEvent<HTMLButtonElement, MouseEvent>} event event
+     */
+    const handleDelete = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         const filteredList = currentPolicyList.filter(
             (policy) => policy.uniqueKey !== policyObj.uniqueKey,
         );
@@ -116,37 +120,53 @@ const AttachedPolicyCard: FC<AttachedPolicyCardProps> = ({
         event.preventDefault();
     };
 
-    const handlePolicyDownload = (event: any) => {
+    /**
+     * Handle policy download
+     * @param {React.MouseEvent<HTMLButtonElement, MouseEvent>} event event
+     */
+    const handlePolicyDownload = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         event.stopPropagation();
         event.preventDefault();
-        const commonPolicyContentPromise = API.getCommonOperationPolicyContent(
-            policyObj.id,
-        );
-        commonPolicyContentPromise
-            .then((commonPolicyResponse) => {
-                Utils.forceDownload(commonPolicyResponse);
-            })
-            .catch(() => {
-                const apiPolicyContentPromise = API.getOperationPolicyContent(
-                    policyObj.id,
-                    api.id,
-                );
-                apiPolicyContentPromise
-                    .then((apiPolicyResponse) => {
-                        Utils.forceDownload(apiPolicyResponse);
-                    })
-                    .catch((error) => {
-                        if (process.env.NODE_ENV !== 'production') {
-                            console.error(error);
-                            Alert.error(
-                                <FormattedMessage
-                                    id='Apis.Details.Policies.AttachedPolicyCard.download.error'
-                                    defaultMessage='Something went wrong while downloading the policy'
-                                />,
-                            );
-                        }
-                    });
-            });
+        if (policyObj.isAPISpecific) {
+            const apiPolicyContentPromise = API.getOperationPolicyContent(
+                policyObj.id,
+                api.id,
+            );
+            apiPolicyContentPromise
+                .then((apiPolicyResponse) => {
+                    Utils.forceDownload(apiPolicyResponse);
+                })
+                .catch((error) => {
+                    if (process.env.NODE_ENV !== 'production') {
+                        console.error(error);
+                        Alert.error(
+                            <FormattedMessage
+                                id='Apis.Details.Policies.AttachedPolicyCard.apiSpecificPolicy.download.error'
+                                defaultMessage='Something went wrong while downloading the policy'
+                            />,
+                        );
+                    }
+                });
+        } else {
+            const commonPolicyContentPromise = API.getCommonOperationPolicyContent(
+                policyObj.id,
+            );
+            commonPolicyContentPromise
+                .then((commonPolicyResponse) => {
+                    Utils.forceDownload(commonPolicyResponse);
+                })
+                .catch((error) => {
+                    if (process.env.NODE_ENV !== 'production') {
+                        console.error(error);
+                        Alert.error(
+                            <FormattedMessage
+                                id='Apis.Details.Policies.AttachedPolicyCard.commonPolicy.download.error'
+                                defaultMessage='Something went wrong while downloading the policy'
+                            />,
+                        );
+                    }
+                });
+        }
     };
 
     const handleDrawerOpen = () => {

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/DeletePolicy.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/DeletePolicy.tsx
@@ -132,10 +132,11 @@ const DeletePolicy: FC<DeletePolicyProps> = ({
                         id={'delete-' + policyId}
                         onClick={handleDelete}
                         color='primary'
+                        variant='outlined'
                     >
                         <FormattedMessage
                             id='Apis.Details.Policies.DeletePolicy.confirm'
-                            defaultMessage='Yes'
+                            defaultMessage='Delete'
                         />
                     </Button>
                 </DialogActions>

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/DraggablePolicyCard.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/DraggablePolicyCard.tsx
@@ -28,7 +28,6 @@ import Utils from 'AppData/Utils';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import IconButton from '@material-ui/core/IconButton';
 import { FormattedMessage } from 'react-intl';
-import classNames from 'classnames';
 import { useDrag } from 'react-dnd';
 import type { Policy } from './Types';
 import ViewPolicy from './ViewPolicy';
@@ -146,10 +145,7 @@ const DraggablePolicyCard: React.FC<DraggablePolicyCardProps> = ({
                         <Box
                             display='flex'
                             justifyContent='flex-end'
-                            height='35px'
-                            className={classNames({
-                                [classes.policyActions]: !hovered,
-                            })}
+                            className={!hovered ? classes.policyActions : ''}
                         >
                             <Tooltip
                                 placement='top'

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PoliciesExpansion.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PoliciesExpansion.tsx
@@ -37,6 +37,19 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 }));
 
+const defaultPolicyForMigration = {
+    id: '',
+    category: 'Mediation',
+    name: '',
+    displayName: '',
+    description: '',
+    applicableFlows: [],
+    supportedGateways: ['Synapse'],
+    supportedApiTypes: ['HTTP'],
+    policyAttributes: [],
+    isAPISpecific: true,
+};
+
 interface PoliciesExpansionProps {
     target: any;
     verb: string;
@@ -44,7 +57,6 @@ interface PoliciesExpansionProps {
     isChoreoConnectEnabled: boolean;
     policyList: Policy[];
 }
-
 
 const PoliciesExpansion: FC<PoliciesExpansionProps> = ({
     target,
@@ -108,25 +120,36 @@ const PoliciesExpansion: FC<PoliciesExpansionProps> = ({
             for (const requestFlowAttachedPolicy of requestFlow) {
                 const { policyId, policyName, uuid } =
                     requestFlowAttachedPolicy;
-                const policyObj = allPolicies?.find(
-                    (policy: PolicySpec) => policy.name === policyName,
-                );
-                if (policyObj) {
-                    requestFlowList.push({ ...policyObj, uniqueKey: uuid });
+                if (policyId === null) {
+                    // Handling migration flow
+                    requestFlowList.push({
+                        ...defaultPolicyForMigration,
+                        name: policyName,
+                        displayName: policyName,
+                        applicableFlows: ['request'],
+                        uniqueKey: uuid,
+                    });
                 } else {
-                    try {
-                        // eslint-disable-next-line no-await-in-loop
-                        const policyResponse = await API.getOperationPolicy(
-                            policyId,
-                            api.id,
-                        );
-                        if (policyResponse)
-                            requestFlowList.push({
-                                ...policyResponse.body,
-                                uniqueKey: uuid,
-                            });
-                    } catch (error) {
-                        console.error(error);
+                    const policyObj = allPolicies?.find(
+                        (policy: PolicySpec) => policy.name === policyName,
+                    );
+                    if (policyObj) {
+                        requestFlowList.push({ ...policyObj, uniqueKey: uuid });
+                    } else {
+                        try {
+                            // eslint-disable-next-line no-await-in-loop
+                            const policyResponse = await API.getOperationPolicy(
+                                policyId,
+                                api.id,
+                            );
+                            if (policyResponse)
+                                requestFlowList.push({
+                                    ...policyResponse.body,
+                                    uniqueKey: uuid,
+                                });
+                        } catch (error) {
+                            console.error(error);
+                        }
                     }
                 }
             }
@@ -138,26 +161,37 @@ const PoliciesExpansion: FC<PoliciesExpansionProps> = ({
             for (const responseFlowAttachedPolicy of responseFlow) {
                 const { policyId, policyName, uuid } =
                     responseFlowAttachedPolicy;
-                const policyObj = allPolicies?.find(
-                    (policy: PolicySpec) => policy.name === policyName,
-                );
-                if (policyObj) {
-                    responseFlowList.push({ ...policyObj, uniqueKey: uuid });
+                if (policyId === null) {
+                    // Handling migration flow
+                    responseFlowList.push({
+                        ...defaultPolicyForMigration,
+                        name: policyName,
+                        displayName: policyName,
+                        applicableFlows: ['response'],
+                        uniqueKey: uuid,
+                    });
                 } else {
-                    try {
-                        // eslint-disable-next-line no-await-in-loop
-                        const policyResponse = await API.getOperationPolicy(
-                            policyId,
-                            api.id,
-                        );
-                        if (policyResponse)
-                            responseFlowList.push({
-                                ...policyResponse.body,
-                                uniqueKey: uuid,
-                            });
-                    } catch (error) {
-                        console.error(error);
-                    }
+                    const policyObj = allPolicies?.find(
+                        (policy: PolicySpec) => policy.name === policyName,
+                    );
+                    if (policyObj) {
+                        responseFlowList.push({ ...policyObj, uniqueKey: uuid });
+                    } else {
+                        try {
+                            // eslint-disable-next-line no-await-in-loop
+                            const policyResponse = await API.getOperationPolicy(
+                                policyId,
+                                api.id,
+                            );
+                            if (policyResponse)
+                                responseFlowList.push({
+                                    ...policyResponse.body,
+                                    uniqueKey: uuid,
+                                });
+                        } catch (error) {
+                            console.error(error);
+                        }
+                    }   
                 }
             }
             setResponseFlowPolicyList(responseFlowList);
@@ -169,25 +203,36 @@ const PoliciesExpansion: FC<PoliciesExpansionProps> = ({
                 for (const faultFlowAttachedPolicy of faultFlow) {
                     const { policyId, policyName, uuid } =
                         faultFlowAttachedPolicy;
-                    const policyObj = allPolicies?.find(
-                        (policy: PolicySpec) => policy.name === policyName,
-                    );
-                    if (policyObj) {
-                        faultFlowList.push({ ...policyObj, uniqueKey: uuid });
+                    if (policyId === null) {
+                        // Handling migration flow
+                        faultFlowList.push({
+                            ...defaultPolicyForMigration,
+                            name: policyName,
+                            displayName: policyName,
+                            applicableFlows: ['fault'],
+                            uniqueKey: uuid,
+                        });
                     } else {
-                        try {
-                            // eslint-disable-next-line no-await-in-loop
-                            const policyResponse = await API.getOperationPolicy(
-                                policyId,
-                                api.id,
-                            );
-                            if (policyResponse)
-                                faultFlowList.push({
-                                    ...policyResponse.body,
-                                    uniqueKey: uuid,
-                                });
-                        } catch (error) {
-                            console.error(error);
+                        const policyObj = allPolicies?.find(
+                            (policy: PolicySpec) => policy.name === policyName,
+                        );
+                        if (policyObj) {
+                            faultFlowList.push({ ...policyObj, uniqueKey: uuid });
+                        } else {
+                            try {
+                                // eslint-disable-next-line no-await-in-loop
+                                const policyResponse = await API.getOperationPolicy(
+                                    policyId,
+                                    api.id,
+                                );
+                                if (policyResponse)
+                                    faultFlowList.push({
+                                        ...policyResponse.body,
+                                        uniqueKey: uuid,
+                                    });
+                            } catch (error) {
+                                console.error(error);
+                            }
                         }
                     }
                 }

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyViewForm.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyViewForm.tsx
@@ -76,6 +76,7 @@ const PolicyViewForm: FC<PolicyViewFormProps> = ({ policySpec, onDone }) => {
                 supportedGateways={policySpec.supportedGateways}
                 isViewMode
                 policyId={policySpec.id}
+                isAPISpecific={policySpec.isAPISpecific}
             />
             <Divider light />
             {/* Attributes of policy */}

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
@@ -114,15 +114,13 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                         Utils.forceDownload(apiPolicyResponse);
                     })
                     .catch((error) => {
-                        if (process.env.NODE_ENV !== 'production') {
-                            console.error(error);
-                            Alert.error(
-                                <FormattedMessage
-                                    id='Apis.Details.Policies.PolicyForm.SourceDetails.apiSpecificPolicy.download.error'
-                                    defaultMessage='Something went wrong while downloading the policy'
-                                />,
-                            );
-                        }
+                        console.error(error);
+                        Alert.error(
+                            <FormattedMessage
+                                id='Apis.Details.Policies.PolicyForm.SourceDetails.apiSpecificPolicy.download.error'
+                                defaultMessage='Something went wrong while downloading the policy'
+                            />,
+                        );
                     });
             } else {
                 const commonPolicyContentPromise =
@@ -132,15 +130,13 @@ const SourceDetails: FC<SourceDetailsProps> = ({
                         Utils.forceDownload(commonPolicyResponse);
                     })
                     .catch((error) => {
-                        if (process.env.NODE_ENV !== 'production') {
-                            console.error(error);
-                            Alert.error(
-                                <FormattedMessage
-                                    id='Apis.Details.Policies.PolicyForm.SourceDetails.commonPolicy.download.error'
-                                    defaultMessage='Something went wrong while downloading the policy'
-                                />,
-                            );
-                        }
+                        console.error(error);
+                        Alert.error(
+                            <FormattedMessage
+                                id='Apis.Details.Policies.PolicyForm.SourceDetails.commonPolicy.download.error'
+                                defaultMessage='Something went wrong while downloading the policy'
+                            />,
+                        );
                     });
             }
         }

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/PolicyForm/SourceDetails.tsx
@@ -58,6 +58,7 @@ interface SourceDetailsProps {
     dispatch?: React.Dispatch<any>;
     isViewMode?: boolean;
     policyId?: string;
+    isAPISpecific?: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ const SourceDetails: FC<SourceDetailsProps> = ({
     dispatch,
     isViewMode,
     policyId,
+    isAPISpecific,
 }) => {
     const classes = useStyles();
     const { api } = useContext<any>(ApiContext);
@@ -102,31 +104,45 @@ const SourceDetails: FC<SourceDetailsProps> = ({
      */
     const handlePolicyDownload = () => {
         if (policyId) {
-            const commonPolicyContentPromise =
-                API.getCommonOperationPolicyContent(policyId);
-            commonPolicyContentPromise
-                .then((commonPolicyResponse) => {
-                    Utils.forceDownload(commonPolicyResponse);
-                })
-                .catch(() => {
-                    const apiPolicyContentPromise =
-                        API.getOperationPolicyContent(policyId, api.id);
-                    apiPolicyContentPromise
-                        .then((apiPolicyResponse) => {
-                            Utils.forceDownload(apiPolicyResponse);
-                        })
-                        .catch((error) => {
-                            if (process.env.NODE_ENV !== 'production') {
-                                console.error(error);
-                                Alert.error(
-                                    <FormattedMessage
-                                        id='Apis.Details.Policies.PolicyForm.SourceDetails.download.error'
-                                        defaultMessage='Something went wrong while downloading the policy'
-                                    />,
-                                );
-                            }
-                        });
-                });
+            if (isAPISpecific) {
+                const apiPolicyContentPromise = API.getOperationPolicyContent(
+                    policyId,
+                    api.id,
+                );
+                apiPolicyContentPromise
+                    .then((apiPolicyResponse) => {
+                        Utils.forceDownload(apiPolicyResponse);
+                    })
+                    .catch((error) => {
+                        if (process.env.NODE_ENV !== 'production') {
+                            console.error(error);
+                            Alert.error(
+                                <FormattedMessage
+                                    id='Apis.Details.Policies.PolicyForm.SourceDetails.apiSpecificPolicy.download.error'
+                                    defaultMessage='Something went wrong while downloading the policy'
+                                />,
+                            );
+                        }
+                    });
+            } else {
+                const commonPolicyContentPromise =
+                    API.getCommonOperationPolicyContent(policyId);
+                commonPolicyContentPromise
+                    .then((commonPolicyResponse) => {
+                        Utils.forceDownload(commonPolicyResponse);
+                    })
+                    .catch((error) => {
+                        if (process.env.NODE_ENV !== 'production') {
+                            console.error(error);
+                            Alert.error(
+                                <FormattedMessage
+                                    id='Apis.Details.Policies.PolicyForm.SourceDetails.commonPolicy.download.error'
+                                    defaultMessage='Something went wrong while downloading the policy'
+                                />,
+                            );
+                        }
+                    });
+            }
         }
     };
 

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/SaveOperationPolicies.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/SaveOperationPolicies.tsx
@@ -63,33 +63,31 @@ const SaveOperationPolicies: React.FC<SaveOperationPoliciesProps> = ({
     }
 
     return (
-        <>
-            <Grid container direction='row' spacing={1}>
-                <Grid item>
-                    <Box p={1} mt={3}>
-                        {api.isRevision || isRestricted(['apim:api_create'], api) ? (
-                            <Button
-                                disabled
-                                type='submit'
-                                variant='contained'
-                                color='primary'
-                            >
-                                <FormattedMessage
-                                    id='Apis.Details.Policies.SaveOperationPolicies.save'
-                                    defaultMessage='Save'
-                                />
-                            </Button>
-                        ) : (
-                            <CustomSplitButton
-                                handleSave={handleSave}
-                                handleSaveAndDeploy={handleSaveAndDeploy}
-                                isUpdating={updating}
+        <Grid container direction='row' spacing={1}>
+            <Grid item>
+                <Box p={1} mt={3}>
+                    {api.isRevision || isRestricted(['apim:api_create'], api) ? (
+                        <Button
+                            disabled
+                            type='submit'
+                            variant='contained'
+                            color='primary'
+                        >
+                            <FormattedMessage
+                                id='Apis.Details.Policies.SaveOperationPolicies.save'
+                                defaultMessage='Save'
                             />
-                        )}
-                    </Box>
-                </Grid>
+                        </Button>
+                    ) : (
+                        <CustomSplitButton
+                            handleSave={handleSave}
+                            handleSaveAndDeploy={handleSaveAndDeploy}
+                            isUpdating={updating}
+                        />
+                    )}
+                </Box>
             </Grid>
-        </>
+        </Grid>
     );
 };
 

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/SaveOperationPolicies.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/SaveOperationPolicies.tsx
@@ -18,6 +18,7 @@
 
 import React, { useContext } from 'react';
 import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import { useHistory } from 'react-router-dom';
 import { isRestricted } from 'AppData/AuthManager';
@@ -63,27 +64,29 @@ const SaveOperationPolicies: React.FC<SaveOperationPoliciesProps> = ({
 
     return (
         <>
-            <Grid container direction='row' spacing={1} style={{ marginTop: 20 }}>
+            <Grid container direction='row' spacing={1}>
                 <Grid item>
-                    {api.isRevision || isRestricted(['apim:api_create'], api) ? (
-                        <Button
-                            disabled
-                            type='submit'
-                            variant='contained'
-                            color='primary'
-                        >
-                            <FormattedMessage
-                                id='Apis.Details.Policies.SaveOperationPolicies.save'
-                                defaultMessage='Save'
+                    <Box p={1} mt={3}>
+                        {api.isRevision || isRestricted(['apim:api_create'], api) ? (
+                            <Button
+                                disabled
+                                type='submit'
+                                variant='contained'
+                                color='primary'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.Policies.SaveOperationPolicies.save'
+                                    defaultMessage='Save'
+                                />
+                            </Button>
+                        ) : (
+                            <CustomSplitButton
+                                handleSave={handleSave}
+                                handleSaveAndDeploy={handleSaveAndDeploy}
+                                isUpdating={updating}
                             />
-                        </Button>
-                    ) : (
-                        <CustomSplitButton
-                            handleSave={handleSave}
-                            handleSaveAndDeploy={handleSaveAndDeploy}
-                            isUpdating={updating}
-                        />
-                    )}
+                        )}
+                    </Box>
                 </Grid>
             </Grid>
         </>

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/Types.d.ts
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/Types.d.ts
@@ -33,6 +33,7 @@ export type AttachedPolicy = {
     applicableFlows: string[];
     uniqueKey: string;
     attributes?: any;
+    isAPISpecific?: boolean;
 };
 
 export type PolicySpecAttribute = {

--- a/portals/publisher/source/src/app/components/Apis/Details/Policies/ViewPolicy.tsx
+++ b/portals/publisher/source/src/app/components/Apis/Details/Policies/ViewPolicy.tsx
@@ -135,7 +135,7 @@ const ViewPolicy: React.FC<ViewPolicyProps> = ({
                 >
                     <Box display='flex'>
                         <Typography variant='h4' component='h2'>
-                            {policyObj.displayName} Policy
+                            {policyObj.displayName}
                         </Typography>
                     </Box>
                     <Box display='flex'>

--- a/portals/publisher/source/src/app/components/CommonPolicies/ViewPolicy.tsx
+++ b/portals/publisher/source/src/app/components/CommonPolicies/ViewPolicy.tsx
@@ -72,9 +72,7 @@ const ViewPolicy: React.FC = () => {
                     setPolicySpec(response.body);
                 })
                 .catch((error) => {
-                    if (process.env.NODE_ENV !== 'production') {
-                        console.error(error);
-                    }
+                    console.error(error);
                     const { status } = error;
                     if (status === 404) {
                         setNotFound(true);


### PR DESCRIPTION
## Purpose

UI changes needed for [1].

This PR adds the capability to handle the migration from `Mediation Policy` to `Operation Level Policy`.
- When a migrated API has an already attached mediation policy, it is shown in the policies UI.
- Attached policy is not configurable, but is free to delete if see fit.
- Upon the first `Save`, they fall back to the normal behavior (i.e. can download and configure policy)

Also, fixes the following bug:
- Removes redundant API calls being made for policy download. With the fix added by this PR, just the single API call is made for policy download.

## Related Issues
1. https://github.com/wso2/product-apim/issues/12566