### PR TITLE
Add the support to configure min scopes to login to admin portal via configs

### DIFF
--- a/portals/admin/site/public/conf/settings.js
+++ b/portals/admin/site/public/conf/settings.js
@@ -30,6 +30,7 @@ const AppConfig = {
             timeout: 2000, // Defines the timeout for the above periodical session status check
         },
         docUrl: 'https://apim.docs.wso2.com/en/4.1.0/',
+        minScopesToLogin: ['apim:api_workflow_view','apim:api_workflow_approve','apim:tenantInfo','apim:admin_settings'],
     },
 };
 

--- a/portals/admin/source/src/app/components/AdminPages/Dashboard/Dashboard.jsx
+++ b/portals/admin/source/src/app/components/AdminPages/Dashboard/Dashboard.jsx
@@ -28,6 +28,8 @@ import TasksWorkflowCard from 'AppComponents/AdminPages/Dashboard/TasksWorkflowC
  * @returns {JSX} Loading animation.
  */
 export default function Dashboard() {
+    const { user: { _scopes } } = useAppContext();
+    const hasWorkflowViewPermission = _scopes.includes('apim:api_workflow_view');
     return (
         <ContentBase width='full' title='Dashboard' pageStyle='paperLess'>
             <Grid container spacing={3} justify='center'>
@@ -37,9 +39,11 @@ export default function Dashboard() {
                 <Grid item xs={11} md={6}>
                     <APICategoriesCard />
                 </Grid>
-                <Grid item xs={11} md={6}>
-                    <TasksWorkflowCard />
-                </Grid>
+                {hasWorkflowViewPermission && (
+                    <Grid item xs={11} md={6}>
+                        <TasksWorkflowCard />
+                    </Grid>
+                )}
             </Grid>
         </ContentBase>
     );

--- a/portals/admin/source/src/app/components/AdminPages/Dashboard/Dashboard.jsx
+++ b/portals/admin/source/src/app/components/AdminPages/Dashboard/Dashboard.jsx
@@ -22,6 +22,7 @@ import ContentBase from 'AppComponents/AdminPages/Addons/ContentBase';
 import APICategoriesCard from 'AppComponents/AdminPages/Dashboard/APICategoriesCard';
 import RateLimitingCard from 'AppComponents/AdminPages/Dashboard/RateLimitingCard';
 import TasksWorkflowCard from 'AppComponents/AdminPages/Dashboard/TasksWorkflowCard';
+import { useAppContext } from 'AppComponents/Shared/AppContext';
 
 /**
  * Render progress inside a container centering in the container.

--- a/portals/admin/source/src/app/components/Base/Navigator.jsx
+++ b/portals/admin/source/src/app/components/Base/Navigator.jsx
@@ -79,6 +79,11 @@ function Navigator(props) {
         routeMenuMapping = RouteMenuMapping(intl).filter((menu) => menu.id !== 'Manage Alerts');
     }
 
+    const hasWorkflowViewPermission = _scopes.includes('apim:api_workflow_view');
+    if (!hasWorkflowViewPermission) {
+        routeMenuMapping = RouteMenuMapping(intl).filter((menu) => menu.id !== 'Tasks');
+    }
+
     const isWorkflowManager = _scopes.includes('apim:api_workflow_view')
     && _scopes.includes('apim:api_workflow_approve')
     && _scopes.includes('apim:tenantInfo')

--- a/portals/admin/source/src/app/data/AuthManager.js
+++ b/portals/admin/source/src/app/data/AuthManager.js
@@ -142,11 +142,20 @@ class AuthManager {
     }
 
     static hasBasicLoginPermission(scopes) {
-        return (scopes.includes('apim:admin')
-        || (scopes.includes('apim:api_workflow_view')
-        && scopes.includes('apim:api_workflow_approve')
-        && scopes.includes('apim:tenantInfo')
-        && scopes.includes('apim:admin_settings')));
+        if (scopes.includes('apim:admin')) {
+            return true;
+        } else {
+            let { minScopesToLogin } = Configurations.app;
+            if (!minScopesToLogin) {
+                minScopesToLogin = CONSTS.DEFAULT_MIN_SCOPES_TO_LOGIN;
+            }
+            for (let i = 0; i < minScopesToLogin.length; i++) {
+                if (!scopes.includes(minScopesToLogin[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     /**

--- a/portals/admin/source/src/app/data/Constants.js
+++ b/portals/admin/source/src/app/data/Constants.js
@@ -25,6 +25,8 @@ const CONSTS = {
         NO_TOKEN_FOUND: '901401: No partial token found!',
     },
     TENANT_STATE_ACTIVE: 'ACTIVE',
+    DEFAULT_MIN_SCOPES_TO_LOGIN: ['apim:api_workflow_view', 'apim:api_workflow_approve', 'apim:tenantInfo',
+        'apim:admin_settings'],
 };
 
 export default CONSTS;


### PR DESCRIPTION
Previously, scopes of `apim:api_workflow_view`, `apim:api_workflow_approve`, `apim:admin_settings`, `apim:tenantInfo` or `apim:admin` were mandatory for any user to login to admin portal. With this strict scope requirement, it was hard to maintain access control among admin users. 

With these changes, we have made it configurable. `minScopesToLogin` config in setting.js will be used to evaluate the existing scopes of the admin users at the login. 

With this improvement, we have currently fixed the `Workflow Task` section and configured it with visibility to show only for users with workflow configurations.

Fixes: https://github.com/wso2/product-apim/issues/12618