### PR TITLE
Fix intl not defined issue when loading keys

### DIFF
--- a/portals/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -340,7 +340,7 @@ class TokenManager extends React.Component {
      * load application key generation ui
      */
     loadApplication = () => {
-        const { keyType } = this.props;
+        const { keyType, intl } = this.props;
         if (this.appId) {
             const api = new API();
             const promisedKeyManagers = api.getKeyManagers();


### PR DESCRIPTION
This PR fixes intl not defined issue when loading keys.

Fixes https://github.com/wso2/api-manager/issues/351