### PR TITLE
Fix Key Generation Pages Not Loading Issue

### DIFF
--- a/portals/devportal/source/src/app/data/api.jsx
+++ b/portals/devportal/source/src/app/data/api.jsx
@@ -728,7 +728,7 @@ export default class API extends Resource {
      * */
     getKeyManagers() {
         return this.client.then((client) => {
-            return client.apis['Key Managers (Collection)'].get_key_managers(this._requestMetaData());
+            return client.apis['Key Managers'].get_key_managers(this._requestMetaData());
         });
     }
 
@@ -739,7 +739,7 @@ export default class API extends Resource {
      * */
     apiCategories(params) {
         return this.client.then((client) => {
-            return client.apis['API Category (Collection)'].get_api_categories(
+            return client.apis['API Categories'].get_api_categories(
                 params, this._requestMetaData());
         });
     }


### PR DESCRIPTION
## Purpose
- Fix key generation pages not loading issue
- Related Github Issue: https://github.com/wso2/api-manager/issues/473

## Approach
- REST API definitions were updated recently with [1]. With this modifications, the tag of `/key-managers` resource has been modified. The UI uses these tags to invoke the REST APIs. The key generation pages were not loading since it was invoking the `/key-managers` resource and the change made to the tag field of the resource was not incorporated to the UI.
- This PR incorporates these REST API definition changes to use the correct tags when invoking the REST APIs from the UI. 

[1] https://github.com/wso2/carbon-apimgt/pull/11282