### PR TITLE
Make API name more prominent in developer portal tabs

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Breadcrumb.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Breadcrumb.jsx
@@ -125,7 +125,7 @@ export default function Breadcrumb() {
                 <Typography color='textPrimary' component='h1' variant='h6'>{selected.text}</Typography>
                 <VerticalDivider height={15} />
                 <Breadcrumbs separator={<NavigateNextIcon fontSize='small' />} aria-label='breadcrumb'>
-                    <MUILink color='inherit' to={'/apis/' + api.id + '/overview'} component={Link}>
+                    <MUILink color='textPrimary' to={'/apis/' + api.id + '/overview'} component={Link}>
                         {api.name}
                     </MUILink>
                     <Typography color='textPrimary'>{selected.text}</Typography>


### PR DESCRIPTION
Related to : https://github.com/wso2/product-apim/issues/12489

<img width="1355" alt="Screenshot 2022-08-15 at 14 00 27" src="https://user-images.githubusercontent.com/47107946/184602671-019aa7d6-caf6-4565-aafc-d1c22e9faf05.png">
