### PR TITLE
Fixed java doc issue "error: bad use of '>' "

### DIFF
--- a/portals/admin/src/main/java/org/wso2/carbon/apimgt/ui/admin/Util.java
+++ b/portals/admin/src/main/java/org/wso2/carbon/apimgt/ui/admin/Util.java
@@ -39,7 +39,7 @@ public class Util {
      *
      * @param path    required parameter
      * @param context required parameter
-     * @return Map<String, Object>
+     * @return Map of read json file
      * @throws FileNotFoundException
      */
     public static Map<String, Object> readJsonFile(String path, ServletContext context) throws FileNotFoundException {
@@ -54,7 +54,7 @@ public class Util {
      *
      * @param json required parameter
      * @param path required parameter
-     * @return Map<String, Object>
+     * @return value in the given path of the nested tree map
      */
     public static Object readJsonObj(Map json, String path) {
         String[] pathStrings = path.split("\\.");

--- a/portals/devportal/src/main/java/org/wso2/carbon/apimgt/ui/devportal/Util.java
+++ b/portals/devportal/src/main/java/org/wso2/carbon/apimgt/ui/devportal/Util.java
@@ -47,7 +47,7 @@ public class Util {
      *
      * @param path    required parameter
      * @param context required parameter
-     * @return Map<String, Object>
+     * @return Map of read json file
      * @throws FileNotFoundException
      */
     public static Map<String, Object> readJsonFile(String path, ServletContext context) throws FileNotFoundException {
@@ -62,7 +62,7 @@ public class Util {
      *
      * @param json required parameter
      * @param path required parameter
-     * @return Map<String, Object>
+     * @return value in the given path of the nested tree map
      */
     public static Object readJsonObj(Map json, String path) {
         String[] pathStrings = path.split("\\.");

--- a/portals/publisher/src/main/java/org/wso2/carbon/apimgt/ui/publisher/Util.java
+++ b/portals/publisher/src/main/java/org/wso2/carbon/apimgt/ui/publisher/Util.java
@@ -44,7 +44,7 @@ public class Util {
      *
      * @param path    required parameter
      * @param context required parameter
-     * @return Map<String, Object>
+     * @return Map of read json file
      * @throws FileNotFoundException
      */
     public static Map<String, Object> readJsonFile(String path, ServletContext context) throws FileNotFoundException {
@@ -59,7 +59,7 @@ public class Util {
      *
      * @param json required parameter
      * @param path required parameter
-     * @return Map<String, Object>
+     * @return value in the given path of the nested tree map
      */
     public static Object readJsonObj(Map json, String path) {
         String[] pathStrings = path.split("\\.");


### PR DESCRIPTION
## Purpose
When generating the javadoc in the JDK 8 and above environments this **error: bad use of '>'** arises due to the usage of **invalid HTML tags, such as List\<String\>** in the function definitions of Java class files. This PR gives a workaround for that.
## Fix
Use named tags such as one in the **return** tag in the below example,
```
    /**
     * Read a json file from the directory and output as a Map object.
     *
     * @param path    required parameter
     * @param context required parameter
     * @return Map of read json file
     * @throws FileNotFoundException
     */
```