### PR TITLE
Update GraphiQL UI to work with graphql-transport-ws protocol

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
@@ -25,7 +25,6 @@ import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import GraphiQLExplorer from 'graphiql-explorer';
 import Collapse from '@material-ui/core/Collapse';
-import { SubscriptionClient } from 'subscriptions-transport-ws';
 import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import { ApiContext } from '../ApiContext';
 import Api from '../../../../data/api';
@@ -105,7 +104,8 @@ export default function GraphQLUI(props) {
         return createGraphiQLFetcher({
             headers,
             url: URLs ? URLs.https : null,
-            legacyWsClient: new SubscriptionClient(wsUrl + '?access_token=' + accessTokenProvider(), { reconnect: false, lazy: true }),
+            subscriptionUrl: wsUrl === null || wsUrl === undefined ? null
+                : wsUrl + '?access_token=' + accessTokenProvider(),
         });
     }
 


### PR DESCRIPTION
> Fix https://github.com/wso2/api-manager/issues/208