### PR TITLE
Fix Appearing Extra Buttons when refreshing the API Definition page of an API Product

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -726,7 +726,7 @@ class APIDefinition extends React.Component {
                                 />
                             </Button>
                         ) : (
-                            !(graphQL || api.type === API.CONSTS.APIProduct) && (
+                            !(graphQL || api.apiType === API.CONSTS.APIProduct) && (
                                 <Button
                                     size='small'
                                     className={classes.button}
@@ -741,7 +741,7 @@ class APIDefinition extends React.Component {
                                 </Button>
                             )
                         )}
-                        {api.type !== API.CONSTS.APIProduct && (
+                        {api.apiType !== API.CONSTS.APIProduct && (
                             <ImportDefinition setSchemaDefinition={this.setSchemaDefinition} />
                         )}
                         {(api.serviceInfo && api.serviceInfo.outdated && api.type !== 'SOAP') && (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -654,8 +654,10 @@ class APIDefinition extends React.Component {
         } = this.state;
 
         const {
-            classes, resourceNotFountMessage, api,
+            classes, resourceNotFountMessage, api, match,
         } = this.props;
+
+        const isApiProduct = match.path.search('/api-products/') !== -1 ;
 
         let downloadLink;
         let fileName;
@@ -726,7 +728,7 @@ class APIDefinition extends React.Component {
                                 />
                             </Button>
                         ) : (
-                            !(graphQL || api.apiType === API.CONSTS.APIProduct) && (
+                            !(graphQL || isApiProduct) && (
                                 <Button
                                     size='small'
                                     className={classes.button}
@@ -741,7 +743,7 @@ class APIDefinition extends React.Component {
                                 </Button>
                             )
                         )}
-                        {api.apiType !== API.CONSTS.APIProduct && (
+                        {!isApiProduct && (
                             <ImportDefinition setSchemaDefinition={this.setSchemaDefinition} />
                         )}
                         {(api.serviceInfo && api.serviceInfo.outdated && api.type !== 'SOAP') && (


### PR DESCRIPTION
This update contains the fix for the issue https://github.com/wso2/product-apim/issues/12836.
The fix was made to stop appearing 'Edit' button and 'Import Definition' button with the refreshing of the API Definition page of an API Product.