### PR TITLE
Fixed wrong footer information of DevPortal in es,si,ar languages

### DIFF
--- a/portals/devportal/src/main/webapp/site/public/locales/ar.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/ar.json
@@ -259,7 +259,7 @@
  "Base.Header.headersearch.HeaderSearch.tooltip.option6": "حسب العلامات [التركيب - العلامات: xxxx]",
  "Base.index.logo.alt": "بوابة التطوير",
  "Base.index.banner.alt": "شعار Dev Portal",
- "Base.index.copyright.text": "WSO2 API-M v3.2.0 | © 2020 WSO2 Inc",
+ "Base.index.copyright.text": "WSO2 API-M v4.1.0 | © 2022 WSO2 LLC",
  "Base.Header.headersearch.SearchUtils.lcState.published": "إنتاج",
  "Base.Header.headersearch.HeaderSearch.tooltip.option9": "بواسطة Microgateway Label [البنية - التسمية: xxxx]",
  "Base.Header.headersearch.SearchUtils.lcState.prototyped": "النموذج",

--- a/portals/devportal/src/main/webapp/site/public/locales/es.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/es.json
@@ -327,7 +327,7 @@
  "Base.Header.headersearch.SearchUtils.lcState.prototyped": "Prototipo",
  "Base.index.settingsMenu.alertConfiguration": "Configurar alertas",
  "Base.Header.headersearch.HeaderSearch.tooltip.option4": "Por contexto [Sintaxis - contexto: xxxx]",
- "Base.index.copyright.text": "WSO2 API-M v3.2.0 | © 2020 WSO2 Inc",
+ "Base.index.copyright.text": "WSO2 API-M v4.1.0 | © 2022 WSO2 LLC",
  "Base.Header.headersearch.HeaderSearch.tooltip.option9": "Por etiqueta Microgateway [Sintaxis - etiqueta: xxxx]",
  "Base.Header.headersearch.HeaderSearch.tooltip.option7": "Por subcontexto [Sintaxis - subcontexto: xxxx]",
  "Change.Password.current.password.incorrect": "Contraseña actual incorrecta",

--- a/portals/devportal/src/main/webapp/site/public/locales/si.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/si.json
@@ -316,7 +316,7 @@
  "Base.Errors.ResourceNotFound.more.links": "ඔබට පහත සබැඳි පරීක්ෂා කළ හැකිය",
  "Base.Header.headersearch.SearchUtils.lcState.published": "නිෂ්පාදනය",
  "Base.Header.headersearch.SearchUtils.lcState.all": "සියලුම",
- "Base.index.copyright.text": "WSO2 API-M v3.2.0 | © 2020 WSO2 Inc.",
+ "Base.index.copyright.text": "WSO2 API-M v4.1.0 | © 2022 WSO2 LLC",
  "Base.Header.headersearch.SearchUtils.lcState.prototyped": "මූලාකෘති",
  "Base.Header.headersearch.HeaderSearch.tooltip.option2": "API සපයන්නා විසින් [සින්ටැක්ස් - සැපයුම්කරු: xxxx]",
  "Base.Header.headersearch.HeaderSearch.tooltip.option3": "API අනුවාදය අනුව [සින්ටැක්ස් - අනුවාදය: xxxx]",


### PR DESCRIPTION
## Purpose

- Wrong footer information is shown in the DevPortal for the languages other than English. The language codes include `es,ar,si`. 
- Master fix for public git issue https://github.com/wso2/api-manager/issues/770.

## Approach
- Changed respective entries in language files.
