### PR TITLE
Add enableSubscriberVerification property for WebSub APIs

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -2257,6 +2257,24 @@
       "value": "API will be exposed in selected transport(s) in the gateway(s) If Mutual SSL option is selected, a trusted client certificate should be presented to access the API"
     }
   ],
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration": [
+    {
+      "type": 0,
+      "value": "WebSub Configuration"
+    }
+  ],
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration.subVerification": [
+    {
+      "type": 0,
+      "value": "Enable subscriber verification"
+    }
+  ],
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration.subVerification.tooltip": [
+    {
+      "type": 0,
+      "value": "If enabled, APIM will perform verification of intent for the subscription API"
+    }
+  ],
   "Apis.Details.Configuration.components.oauth.disabled": [
     {
       "type": 0,

--- a/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
@@ -924,6 +924,15 @@
   "Apis.Details.Configuration.components.CORSConfigurations.origin.helper": {
     "defaultMessage": "Press `Enter` after typing the origin name,to add a new origin"
   },
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration": {
+    "defaultMessage": "WebSub Configuration"
+  },
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration.subVerification": {
+    "defaultMessage": "Enable subscriber verification"
+  },
+  "Apis.Details.Configuration.components.WebSubConfiguration.configuration.subVerification.tooltip": {
+    "defaultMessage": "If enabled, APIM will perform verification of intent for the subscription API"
+  },
   "Apis.Details.Configuration.components.DescriptionEditor.edit.content.button": {
     "defaultMessage": "Edit description"
   },

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -49,6 +49,7 @@ import {
     API_SECURITY_MUTUAL_SSL_MANDATORY,
     API_SECURITY_MUTUAL_SSL,
 } from './components/APISecurity/components/apiSecurityConstants';
+import WebSubConfiguration from './components/WebSubConfiguration';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -134,6 +135,7 @@ function copyAPIConfig(api) {
         visibility: api.visibility,
         isDefaultVersion: api.isDefaultVersion,
         enableSchemaValidation: api.enableSchemaValidation,
+        enableSubscriberVerification: api.enableSubscriberVerification,
         accessControlRoles: [...api.accessControlRoles],
         visibleRoles: [...api.visibleRoles],
         tags: [...api.tags],
@@ -194,6 +196,7 @@ export default function RuntimeConfiguration() {
             case 'accessControl':
             case 'visibility':
             case 'maxTps':
+            case 'enableSubscriberVerification':
             case 'tags':
                 nextState[action] = value;
                 return nextState;
@@ -504,20 +507,31 @@ export default function RuntimeConfiguration() {
                                             )}
 
                                         </Typography>
-                                        <Grid item xs={12} style={{ position: 'relative' }}>
-                                            <Box mb={3}>
-                                                <Paper className={classes.paper} elevation={0}>
-                                                    {!isAsyncAPI && (
-                                                        <ResponseCaching
-                                                            api={apiConfig}
-                                                            configDispatcher={configDispatcher}
-                                                        />
-                                                    )}
-                                                </Paper>
-                                                {!isWebSub && (
-                                                    <ArrowBackIcon className={classes.arrowBackIcon} />
+                                        <Grid item xs={12} style={{ marginBottom: 30, position: 'relative' }}>
+                                            <Paper className={classes.paper} elevation={0}>
+                                                {!isWebSub ? (
+                                                    <Grid item xs={12} style={{ position: 'relative' }}>
+                                                        <Box mb={3}>
+                                                            <Paper className={classes.paper} elevation={0}>
+                                                                {!isAsyncAPI && (
+                                                                    <ResponseCaching
+                                                                        api={apiConfig}
+                                                                        configDispatcher={configDispatcher}
+                                                                    />
+                                                                )}
+                                                            </Paper>
+                                                        </Box>
+                                                    </Grid>
+                                                ) : (
+                                                    <WebSubConfiguration 
+                                                        api={apiConfig} 
+                                                        configDispatcher={configDispatcher} 
+                                                    />
                                                 )}
-                                            </Box>
+                                            </Paper>
+                                            {!isWebSub && (
+                                                <ArrowBackIcon className={classes.arrowBackIcon} />
+                                            )}
                                         </Grid>
                                     </>
                                 )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/WebSubConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/WebSubConfiguration.jsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+import { FormattedMessage } from 'react-intl';
+import Typography from '@material-ui/core/Typography';
+import WrappedExpansionPanel from 'AppComponents/Shared/WrappedExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { makeStyles } from '@material-ui/core/styles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { isRestricted } from 'AppData/AuthManager';
+import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
+import Checkbox from '@material-ui/core/Checkbox';
+
+const useStyles = makeStyles((theme) => ({
+    expansionPanel: {
+        marginBottom: theme.spacing(3),
+    },
+    expansionPanelDetails: {
+        flexDirection: 'column',
+    },
+    iconSpace: {
+        marginLeft: theme.spacing(0.5),
+    },
+    actionSpace: {
+        marginLeft: '0px',
+        marginTop: '-7px',
+        marginBottom: '-7px',
+    },
+    subHeading: {
+        fontSize: '1rem',
+        fontWeight: 400,
+        margin: 0,
+        display: 'inline-flex',
+        lineHeight: 1.5,
+    },
+}));
+
+/**
+ *
+ * api.webSubConfiguration possible values true and false
+ * @export
+ * @param {*} props
+ * @returns
+ */
+export default function WebSubConfiguration(props) {
+    const { api, configDispatcher } = props;
+    const { api: apiFromContext } = useAPI();
+    const classes = useStyles();
+    return (
+        <WrappedExpansionPanel className={classes.expansionPanel} id='webSubConfiguration'>
+            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography className={classes.subHeading} variant='h6' component='h4'>
+                    <FormattedMessage
+                        id='Apis.Details.Configuration.components.WebSubConfiguration.configuration'
+                        defaultMessage='WebSub Configuration'
+                    />
+                </Typography>
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails className={classes.expansionPanelDetails}>
+                <Grid container>
+                    <Grid item>
+                        <FormControlLabel
+                            className={classes.actionSpace}
+                            label={(
+                                <Typography>
+                                    <FormattedMessage
+                                        id={
+                                            'Apis.Details.Configuration.components.WebSubConfiguration.configuration'
+                                            + '.subVerification'
+                                        }
+                                        defaultMessage='Enable subscriber verification'
+                                    />
+                                    <Tooltip
+                                        title={(
+                                            <FormattedMessage
+                                                id={
+                                                    'Apis.Details.Configuration.components.WebSubConfiguration'
+                                                    + '.configuration.subVerification.tooltip'
+                                                }
+                                                defaultMessage={
+                                                    'If enabled, APIM will perform verification of intent '
+                                                    + 'for the subscription API'
+                                                }
+                                            />
+                                        )}
+                                        aria-label='WebSub Configuration helper text'
+                                        placement='right-end'
+                                        interactive
+                                    >
+                                        <HelpOutline className={classes.iconSpace} />
+                                    </Tooltip>
+                                </Typography>
+                            )}
+                            control={(
+                                <Checkbox
+                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                    checked={
+                                        api.enableSubscriberVerification === undefined ? 
+                                            false : api.enableSubscriberVerification
+                                    }
+                                    onChange={({ target: { checked } }) => configDispatcher({
+                                        action: 'enableSubscriberVerification',
+                                        value: checked,
+                                    })}
+                                    color='primary'
+                                    inputProps={{
+                                        'aria-label': 'WebSub Configuration',
+                                    }}
+                                    id='websub-verification-checkbox'
+                                />
+                            )}
+                        />
+                    </Grid>
+                </Grid>
+            </ExpansionPanelDetails>
+        </WrappedExpansionPanel>
+    );
+}
+
+WebSubConfiguration.propTypes = {
+    api: PropTypes.shape({ enableSubscriberVerification: PropTypes.bool }).isRequired,
+    configDispatcher: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
- Add **enableSubscriberVerification** to enable/disable WebSub subcriber intent verification.

Fix https://github.com/wso2/api-manager/issues/775

> Related PRs: https://github.com/wso2/carbon-apimgt/pull/11572, https://github.com/wso2/product-apim/pull/12989