### PR TITLE
Fix pagination persistency of Publisher portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -84,13 +84,14 @@ class TableView extends React.Component {
         } else {
             defaultApiView = localStorage.getItem('publisher.listType') || defaultApiView;
         }
+        const prevRowsPerPage = parseInt(localStorage.getItem('publisher.rowsPerPage'), 10) || 10;
         this.state = {
             apisAndApiProducts: null,
             notFound: true,
             listType: defaultApiView,
             loading: true,
             totalCount: -1,
-            rowsPerPage: 10,
+            rowsPerPage: prevRowsPerPage,
             page: 0,
         };
         this.setListType = this.setListType.bind(this);


### PR DESCRIPTION
## Purpose

- The pagination choice (items per page) is not persisted in the Publisher portal API listing page. 
- Public Issue:  wso2/api-manager/issues/798