### PR TITLE
Use correct URL to Retrieve Service Catalog Scopes

### DIFF
--- a/portals/publisher/src/main/webapp/services/login/idp.jsp
+++ b/portals/publisher/src/main/webapp/services/login/idp.jsp
@@ -71,7 +71,7 @@
     HttpResponse<String> settingsResult = client.send(getSettingsReq, HttpResponse.BodyHandlers.ofString());
 
     HttpRequest getCatalogReq = HttpRequest.newBuilder()
-            .uri(URI.create(settingsAPIUrl))
+            .uri(URI.create(serviceCatalogSettingsAPIUrl))
             .build();
     HttpResponse<String> serviceCatalogResult = client.send(getCatalogReq, HttpResponse.BodyHandlers.ofString());
 


### PR DESCRIPTION
## Purpose
- Use correct URL to retrieve service catalog scopes
- Previously, the publisher settings URL was mistakenly used in-place of the service catalog settings URL. Hence, the scopes retrieved from the publisher settings REST API was appended twice.
- Fixes https://github.com/wso2/api-manager/issues/825

## Approach
- Used the correct service catalog settings REST API URL to fetch the service catalog scopes