### PR TITLE
Add the policies support for SOAP and SOAP to REST API types

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -148,18 +148,33 @@ const Policies: React.FC = () => {
             unionByPolicyDisplayName.sort(
                 (a: Policy, b: Policy) => a.name.localeCompare(b.name))
             
-            let filteredList = null;
+            let filteredByGatewayTypeList = null;
             if (!isChoreoConnectEnabled) {
                 // Get synpase gateway supported policies
-                filteredList = unionByPolicyDisplayName.filter(
+                filteredByGatewayTypeList = unionByPolicyDisplayName.filter(
                     (policy: Policy) => policy.supportedGateways.includes('Synapse'));
             } else {
                 // Get CC gateway supported policies
-                filteredList = unionByPolicyDisplayName.filter(
+                filteredByGatewayTypeList = unionByPolicyDisplayName.filter(
                     (policy: Policy) => policy.supportedGateways.includes('ChoreoConnect'));
             }
 
-            setPolicies(filteredList);
+            let filteredByAPITypeList = null;
+            if (api.type === "HTTP") {
+                // Get HTTP supported policies
+                filteredByAPITypeList = filteredByGatewayTypeList.filter(
+                    (policy: Policy) => policy.supportedApiTypes.includes('HTTP'));
+            } else if (api.type === "SOAP"){
+                // Get CC gateway supported policies
+                filteredByAPITypeList = filteredByGatewayTypeList.filter(
+                    (policy: Policy) => policy.supportedApiTypes.includes('SOAP'));
+            } else if (api.type === "SOAPTOREST"){
+                // Get CC gateway supported policies
+                filteredByAPITypeList = filteredByGatewayTypeList.filter(
+                    (policy: Policy) => policy.supportedApiTypes.includes('SOAPTOREST'));
+            }
+
+            setPolicies(filteredByAPITypeList);
 
         }).catch((error) => {
             console.error(error);
@@ -418,6 +433,7 @@ const Policies: React.FC = () => {
                         />
                     </Typography>
                 </Box>
+                {(api.type === 'HTTP') && (
                 <Box mb={4} px={1}>
                     <GatewaySelector
                         setIsChangedToCCGatewayType={setIsChangedToCCGatewayType}
@@ -425,6 +441,7 @@ const Policies: React.FC = () => {
                         removeAPIPoliciesForGatewayChange={removeAPIPoliciesForGatewayChange}
                     />
                 </Box>
+                )}
                 {isChoreoConnectEnabled ?
                     <Box display='flex' flexDirection='row'>
                         <Box width='65%' pr={1} height='85vh' className={classes.operationListingBox}>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -434,13 +434,13 @@ const Policies: React.FC = () => {
                     </Typography>
                 </Box>
                 {(api.type === 'HTTP') && (
-                <Box mb={4} px={1}>
-                    <GatewaySelector
-                        setIsChangedToCCGatewayType={setIsChangedToCCGatewayType}
-                        isChoreoConnectEnabled={isChoreoConnectEnabled}
-                        removeAPIPoliciesForGatewayChange={removeAPIPoliciesForGatewayChange}
-                    />
-                </Box>
+                    <Box mb={4} px={1}>
+                        <GatewaySelector
+                            setIsChangedToCCGatewayType={setIsChangedToCCGatewayType}
+                            isChoreoConnectEnabled={isChoreoConnectEnabled}
+                            removeAPIPoliciesForGatewayChange={removeAPIPoliciesForGatewayChange}
+                        />
+                    </Box>
                 )}
                 {isChoreoConnectEnabled ?
                     <Box display='flex' flexDirection='row'>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -165,11 +165,11 @@ const Policies: React.FC = () => {
                 filteredByAPITypeList = filteredByGatewayTypeList.filter(
                     (policy: Policy) => policy.supportedApiTypes.includes('HTTP'));
             } else if (api.type === "SOAP"){
-                // Get CC gateway supported policies
+                // Get SOAP supported policies
                 filteredByAPITypeList = filteredByGatewayTypeList.filter(
                     (policy: Policy) => policy.supportedApiTypes.includes('SOAP'));
             } else if (api.type === "SOAPTOREST"){
-                // Get CC gateway supported policies
+                // Get SOAP to REST supported policies
                 filteredByAPITypeList = filteredByGatewayTypeList.filter(
                     (policy: Policy) => policy.supportedApiTypes.includes('SOAPTOREST'));
             }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PoliciesExpansion.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PoliciesExpansion.tsx
@@ -46,7 +46,7 @@ const defaultPolicyForMigration = {
     description: '',
     applicableFlows: [],
     supportedGateways: ['Synapse'],
-    supportedApiTypes: ['HTTP'],
+    supportedApiTypes: [],
     policyAttributes: [],
     isAPISpecific: true,
 };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/GeneralDetails.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/GeneralDetails.tsx
@@ -46,6 +46,7 @@ interface GeneralDetailsProps {
     version: string | null;
     description: string;
     applicableFlows: string[];
+    supportedApiTypes: string[];
     dispatch?: React.Dispatch<any>;
     isViewMode: boolean;
 }
@@ -60,6 +61,7 @@ const GeneralDetails: FC<GeneralDetailsProps> = ({
     version,
     description,
     applicableFlows,
+    supportedApiTypes,
     dispatch,
     isViewMode,
 }) => {
@@ -68,6 +70,10 @@ const GeneralDetails: FC<GeneralDetailsProps> = ({
     // Validates whether atleast one flow (i.e. request, response or fault) is selected
     // True if none of the flows are selected.
     const applicableFlowsError = applicableFlows.length === 0;
+
+    // Validates whether atleast one Api Type (i.e. HTTP, SOAP or SOAPTOREST) is selected
+    // True if none of the API types are selected.
+    const supportedApiTypesError = supportedApiTypes.length === 0;
 
     // Name validation
     const nameError = displayName === '';
@@ -102,6 +108,20 @@ const GeneralDetails: FC<GeneralDetailsProps> = ({
             });
         }
     };
+
+        /**
+     * Function to handle supported Api Type related checkbox changes
+     * @param {React.ChangeEvent<HTMLInputElement>} event event
+     */
+         const handleApiTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+            if (dispatch) {
+                dispatch({
+                    type: ACTIONS.UPDATE_SUPPORTED_API_TYPES,
+                    name: event.target.name,
+                    checked: event.target.checked,
+                });
+            }
+        };
 
     return (
         <Box display='flex' flexDirection='row' mt={1}>
@@ -300,6 +320,86 @@ const GeneralDetails: FC<GeneralDetailsProps> = ({
                                 <FormHelperText>
                                     {applicableFlowsError
                                         ? 'Please select one or more flows'
+                                        : ''}
+                                </FormHelperText>
+                            </FormControl>
+                        </Box>
+                    </Box>
+                    <Box display='flex' flexDirection='row' alignItems='center'>
+                        <Typography
+                            color='inherit'
+                            variant='body1'
+                            component='div'
+                        >
+                            <FormattedMessage
+                                id='Apis.Details.Policies.PolicyForm.GeneralDetails.form.supported.api.label'
+                                defaultMessage='Supported API Types'
+                            />
+                            <sup className={classes.mandatoryStar}>*</sup>
+                        </Typography>
+                        <Box
+                            flex='1'
+                            display='flex'
+                            flexDirection='row-reverse'
+                            justifyContent='space-around'
+                        >
+                            <FormControl
+                                required
+                                component='fieldset'
+                                variant='standard'
+                                margin='normal'
+                                error={supportedApiTypesError}
+                            >
+                                <FormGroup className={classes.formGroup}>
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                name='HTTP'
+                                                color='primary'
+                                                checked={supportedApiTypes.includes(
+                                                    'HTTP',
+                                                )}
+                                                id='http-select-check-box'
+                                                onChange={handleApiTypeChange}
+                                            />
+                                        }
+                                        label='HTTP'
+                                        data-testid='http-type'
+                                    />
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                name='SOAP'
+                                                color='primary'
+                                                checked={supportedApiTypes.includes(
+                                                    'SOAP',
+                                                )}
+                                                id='soap-select-check-box'
+                                                onChange={handleApiTypeChange}
+                                            />
+                                        }
+                                        label='SOAP'
+                                        data-testid='soap-type'
+                                    />
+                                    <FormControlLabel
+                                        control={
+                                            <Checkbox
+                                                name='SOAPTOREST'
+                                                color='primary'
+                                                checked={supportedApiTypes.includes(
+                                                    'SOAPTOREST',
+                                                )}
+                                                id='soaptorest-select-check-box'
+                                                onChange={handleApiTypeChange}
+                                            />
+                                        }
+                                        label='SOAPTOREST'
+                                        data-testid='soaptorest-flow'
+                                    />
+                                </FormGroup>
+                                <FormHelperText>
+                                    {supportedApiTypesError
+                                        ? 'Please select one or more API Types'
                                         : ''}
                                 </FormHelperText>
                             </FormControl>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyCreateForm.tsx
@@ -48,6 +48,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const ACTIONS = {
     UPDATE_POLICY_METADATA: 'updatePolicyMetadata',
     UPDATE_APPLICALBLE_FLOWS: 'updateApplicableFlows',
+    UPDATE_SUPPORTED_API_TYPES: 'updateSupportedApiTypes',
     UPDATE_SUPPORTED_GATEWAYS: 'updateSupportedGateways',
     ADD_POLICY_ATTRIBUTE: 'addPolicyAttribute',
     UPDATE_POLICY_ATTRIBUTE: 'updatePolicyAttribute',
@@ -75,6 +76,16 @@ function policyReducer(state: NewPolicyState, action: any) {
                     ? [...state.applicableFlows, action.name]
                     : state.applicableFlows.filter(
                         (flow: string) => flow !== action.name,
+                    ),
+            };
+        }
+        case ACTIONS.UPDATE_SUPPORTED_API_TYPES: {
+            return {
+                ...state,
+                supportedApiTypes: action.checked
+                    ? [...state.supportedApiTypes, action.name]
+                    : state.supportedApiTypes.filter(
+                        (apiType: string) => apiType !== action.name,
                     ),
             };
         }
@@ -166,6 +177,7 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
         version: null,
         description: '',
         applicableFlows: ['request', 'response', 'fault'],
+        supportedApiTypes: ['HTTP'],
         supportedGateways: ['Synapse'],
         policyAttributes: [],
     };
@@ -183,6 +195,9 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
 
         // Applicable flows current state validation
         if (state.applicableFlows.length === 0) hasError = true;
+
+        // Applicable api types current state validation
+        if (state.supportedApiTypes.length === 0) hasError = true;
 
         // Supported gateways current state validation
         if (state.supportedGateways.length === 0) hasError = true;
@@ -217,6 +232,7 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
         state.displayName,
         state.version,
         state.applicableFlows,
+        state.supportedApiTypes,
         state.supportedGateways,
         state.policyAttributes,
         synapsePolicyDefinitionFile,
@@ -253,9 +269,9 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
                 version: 'v' + state.version,
                 description: state.description,
                 applicableFlows: state.applicableFlows,
+                supportedApiTypes: state.supportedApiTypes,
                 supportedGateways: state.supportedGateways,
                 policyAttributes: getPolicyAttributes(),
-                supportedApiTypes: ['HTTP'],
             };
             onSave(policySpec);
         }
@@ -269,6 +285,7 @@ const PolicyCreateForm: FC<PolicyCreateFormProps> = ({
                 version={state.version}
                 description={state.description}
                 applicableFlows={state.applicableFlows}
+                supportedApiTypes={state.supportedApiTypes}
                 dispatch={dispatch}
                 isViewMode={false}
             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyViewForm.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/PolicyViewForm.tsx
@@ -69,6 +69,7 @@ const PolicyViewForm: FC<PolicyViewFormProps> = ({ policySpec, onDone }) => {
                 version={policySpec.version}
                 description={policySpec.description}
                 applicableFlows={policySpec.applicableFlows}
+                supportedApiTypes={policySpec.supportedApiTypes}
                 isViewMode
             />
             <Divider light />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/Types.d.ts
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/Types.d.ts
@@ -35,5 +35,6 @@ export type NewPolicyState = {
     description: string;
     applicableFlows: string[];
     supportedGateways: string[];
+    supportedApiTypes: string[];
     policyAttributes: any;
 };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Types.d.ts
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Types.d.ts
@@ -23,6 +23,7 @@ export type Policy = {
     displayName: string;
     applicableFlows: string[];
     supportedGateways: string[];
+    supportedApiTypes: string[];
     isAPISpecific: boolean;
     supportedGateways: string[];
 };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
@@ -314,7 +314,7 @@ export default function DevelopSectionMenu(props) {
                             />
                         )}
                         {api.advertiseInfo && !api.advertiseInfo.advertised && !isAPIProduct
-                            && api.type === 'HTTP' && (
+                            && (api.type === 'HTTP' || api.type === 'SOAP' || api.type === 'SOAPTOREST') && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.policies',


### PR DESCRIPTION
This PR adds the UI support for policies feature to select and use different API types.

API Types are HTTP, SOAP and SOAPTOREST.

Fixes : https://github.com/wso2/product-apim/issues/12559

UI improvements.

1. Policy list at API level will be filtered based on the API type.
2. Gateway selection for policies tab will be enabled only for HTTP policies.
3. Policies create and view form will have a section to select/view supported API type.

![Screenshot 2022-10-26 at 11 06 56 AM](https://user-images.githubusercontent.com/47380453/198190200-b6bf2bf5-b957-47bd-835b-55e0ab326dfd.png)


