### PR TITLE
Add yaml file extension to supported doc types

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/conf/settings.json
+++ b/portals/publisher/src/main/webapp/site/public/conf/settings.json
@@ -27,7 +27,7 @@
             "syntaxHighlighterDarkTheme": false
         },
         "loadDefaultLocales": false,
-        "supportedDocTypes": "application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword, application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet, application/json, application/x-yaml, .md"
+        "supportedDocTypes": "application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword, application/pdf, text/plain, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.oasis.opendocument.text, application/vnd.oasis.opendocument.spreadsheet, application/json, application/x-yaml, .yaml, .md"
     },
     "serviceCatalogDefinitionTypes": {
       "OAS2": "Swagger",


### PR DESCRIPTION
## Purpose

- Add ".yaml" extension to the supported document types.
- Fixes https://github.com/wso2/api-manager/issues/895