### PR TITLE
Fix error adding WSO2-IS as Key Manager from Admin portal

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -1096,16 +1096,21 @@ function AddEditKeyManager(props) {
                                                 margin='dense'
                                                 name='userInfoEndpoint'
                                                 label={(
-                                                    <FormattedMessage
-                                                        id='KeyManagers.AddEditKeyManager.form.userInfoEndpoint'
-                                                        defaultMessage='UserInfo Endpoint'
-                                                    />
+                                                    <span>
+                                                        <FormattedMessage
+                                                            id='KeyManagers.AddEditKeyManager.form.userInfoEndpoint'
+                                                            defaultMessage='UserInfo Endpoint'
+                                                        />
+                                                        <span className={classes.error}>*</span>
+                                                    </span>
                                                 )}
                                                 fullWidth
                                                 variant='outlined'
                                                 value={userInfoEndpoint}
                                                 onChange={onChange}
-                                                helperText={intl.formatMessage({
+                                                error={hasErrors('userInfoEndpoint', userInfoEndpoint, validating)}
+                                                helperText={hasErrors('userInfoEndpoint', userInfoEndpoint, validating)
+                                                || intl.formatMessage({
                                                     id: 'KeyManagers.AddEditKeyManager.form.userInfoEndpoint.help',
                                                     defaultMessage: 'E.g., https://localhost:9443/oauth2/userInfo',
                                                 })}
@@ -1134,22 +1139,28 @@ function AddEditKeyManager(props) {
                                                 margin='dense'
                                                 name='scopeManagementEndpoint'
                                                 label={(
-                                                    <FormattedMessage
-                                                        id='KeyManagers.AddEditKeyManager.form.scopeManagementEndpoint'
-                                                        defaultMessage='Scope Management Endpoint'
-                                                    />
+                                                    <span>
+                                                        <FormattedMessage
+                                                            id='KeyManagers.AddEditKeyManager.
+                                                                form.scopeManagementEndpoint'
+                                                            defaultMessage='Scope Management Endpoint'
+                                                        />
+                                                        <span className={classes.error}>*</span>
+                                                    </span>
                                                 )}
                                                 fullWidth
                                                 variant='outlined'
                                                 value={scopeManagementEndpoint}
                                                 onChange={onChange}
-                                                helperText={(
-                                                    <FormattedMessage
-                                                        id='KeyManagers.AddEditKeyManager.
-                                                            form.scopeManagementEndpoint.help'
-                                                        defaultMessage='E.g, https://localhost:9443/oauth2/scope'
-                                                    />
-                                                )}
+                                                error={hasErrors('scopeManagementEndpoint',
+                                                    scopeManagementEndpoint, validating)}
+                                                helperText={hasErrors('scopeManagementEndpoint',
+                                                    scopeManagementEndpoint, validating)
+                                                || intl.formatMessage({
+                                                    id: 'KeyManagers.AddEditKeyManager.form.scopeManagementEndpoint'
+                                                        + '.help',
+                                                    defaultMessage: 'E.g, https://localhost:9443/oauth2/scope',
+                                                })}
                                             />
                                         </Box>
                                     </Grid>

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -323,6 +323,8 @@ function AddEditKeyManager(props) {
             case 'introspectionEndpoint':
             case 'tokenEndpoint':
             case 'revokeEndpoint':
+            case 'userInfoEndpoint':
+            case 'scopeManagementEndpoint':
                 if (fieldValue === '') {
                     error = intl.formatMessage({
                         id: 'KeyManagers.AddEditKeyManager.is.empty.error.key.config',
@@ -386,7 +388,9 @@ function AddEditKeyManager(props) {
                 || hasErrors('introspectionEndpoint', introspectionEndpoint, validatingActive)
                 || hasErrors('tokenEndpoint', tokenEndpoint, validatingActive)
                 || hasErrors('revokeEndpoint', revokeEndpoint, validatingActive)
-                || hasErrors('enableDirectToken', enableDirectToken, validatingActive);
+                || hasErrors('enableDirectToken', enableDirectToken, validatingActive)
+                || hasErrors('userInfoEndpoint', userInfoEndpoint, validatingActive)
+                || hasErrors('scopeManagementEndpoint', scopeManagementEndpoint, validatingActive);
         } else {
             return hasErrors('name', name, validatingActive)
                 || hasErrors('displayName', displayName, validatingActive)

--- a/tests/cypress/integration/admin/09-add-km.spec.js
+++ b/tests/cypress/integration/admin/09-add-km.spec.js
@@ -30,6 +30,8 @@ describe("Add key manager", () => {
         const clientSecret = 'test';
         const audience = 'test';
         const introspectionEp = 'https://my-tenant.auth0.com/oauth/token';
+        const userInfoEp = 'https://my-tenant.auth0.com/oauth/userInfo';
+        const scopeManagementEp = 'https://my-tenant.auth0.com/oauth/scope';
 
         cy.get('[data-testid="Key Managers"]').click();
         cy.get('.MuiButton-label').contains('Add Key Manager').click();
@@ -44,6 +46,8 @@ describe("Add key manager", () => {
         cy.wait('@importConfig', {timeout: 3000}).then(() => {
             // filing the tokens
             cy.get('input[name="introspectionEndpoint"]').clear().type(introspectionEp);
+            cy.get('input[name="userInfoEndpoint"]').clear().type(userInfoEp);
+            cy.get('input[name="scopeManagementEndpoint"]').clear().type(scopeManagementEp);
             cy.get('input[name="client_id"]').type(clientId);
             cy.get('input[name="client_secret"]').type(clientSecret);
             cy.get('input[name="audience"]').type(audience);


### PR DESCRIPTION
### Purpose
To fix the NPE error when adding WSO2-IS as Key Manager from the Admin portal.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/885

### Approach
- UI validation added for other required fields: userInfoEndpoint and scopeManagementEndpoint
- Validation added to validate before searching a value for revokeOneTimeTokenEndpoint since this is only for resident KM.

Related PR: https://github.com/wso2/carbon-apimgt/pull/11626