### PR TITLE
Fix the issue occurring when updating the Definition of an API

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -754,8 +754,14 @@ class API extends Resource {
                 file: swagger,
                 'Content-Type': 'multipart/form-data',
             };
+            const requestBody = {
+                requestBody: {
+                    file: swagger,
+                },
+            };
             return client.apis['Validation'].validateOpenAPIDefinition(
                 payload,
+                requestBody,
                 this._requestMetaData({
                     'Content-Type': 'multipart/form-data',
                 }),


### PR DESCRIPTION
## Purpose
- Fix the issue occurring when updating the Definition of an API
- Fixes https://github.com/wso2/api-manager/issues/921

## Approach
- Add requestBody to validateOpenAPIDefinition REST API call during API Definition Update Scenario similar to [1] and [2]

[1] https://github.com/wso2/apim-apps/blob/main/portals/publisher/src/main/webapp/source/src/app/data/api.js#L152-L165
[2] https://github.com/wso2/apim-apps/blob/main/portals/publisher/src/main/webapp/source/src/app/data/api.js#L175-L188