### PR TITLE
Fixing OAS definition download issue

### DIFF
--- a/portals/publisher/src/main/webapp/openapitools.json
+++ b/portals/publisher/src/main/webapp/openapitools.json
@@ -8,7 +8,7 @@
         "generatorName": "typescript-axios",
         "glob": "",
         "context": "/api/am/publisher/v4",
-        "inputSpec": "https://raw.githubusercontent.com/wso2/carbon-apimgt/v9.20.74/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml",
         "output": "#{cwd}../../src/types/generated/Publisher",
         "additionalProperties": {
           "withSeparateModelsAndApi": true,
@@ -26,7 +26,7 @@
         "generatorName": "typescript-axios",
         "glob": "",
         "context": "/api/am/service-catalog/v1",
-        "inputSpec": "https://raw.githubusercontent.com/wso2/carbon-apimgt/v9.20.74/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml",
+        "inputSpec": "https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml",
         "output": "#{cwd}../../src/types/generated/Publisher",
         "additionalProperties": {
           "withSeparateModelsAndApi": true,

--- a/portals/publisher/src/main/webapp/source/Tests/Utils/setupUtils.ts
+++ b/portals/publisher/src/main/webapp/source/Tests/Utils/setupUtils.ts
@@ -64,12 +64,13 @@ export const downloadOASDefinition = async function bundle(
         try {
             // disabled the rule to do fail re-tries
             // eslint-disable-next-line no-await-in-loop
-            bundled = await SwaggerParser.bundle(apiURL, opts);
+            bundled = await SwaggerParser.parse(apiURL, opts);
             break;
         } catch (error) {
             retries += 1;
             const retryWaitTime = retries * RE_TRY_WAIT_TIME;
             console.warn(
+                error,
                 `Attempt: ${retries} : Error while downloading ${filePath} \nRe-try in ${
                     retryWaitTime / 1000
                 } Seconds . . .`,


### PR DESCRIPTION
The download issue of the definition is fixed with this PR. Still some unit tests are failing. We need to look in to those.

Fixes : https://github.com/wso2/api-manager/issues/1015