### PR TITLE
Pass existing security_endpoints when setting endpoint_type

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -128,7 +128,8 @@ function Endpoints(props) {
                     value.endpointType === 'address',
                     tmpEndpointConfig,
                 );
-                return { ...initState, endpointConfig: { ...config } };
+                const endpointSecurity = cloneDeep(initState.endpointConfig.endpoint_security);
+                return { ...initState, endpointConfig: { ...config, endpoint_security: endpointSecurity } };
             }
             case 'set_inline_or_mocked_oas': {
                 const { endpointImplementationType, endpointConfig } = value;


### PR DESCRIPTION
> Fix https://github.com/wso2/api-manager/issues/1056
> Pass endpoint_security from initial state when updating endpoint_type. 