### PR TITLE
[Improvement] Try-Out console of WebSub API sending form-url-encoded type request

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
@@ -115,23 +115,29 @@ export default function AsyncApiUI(props) {
         } = subscription;
         const token = generateAccessToken();
         if (mode === 'subscribe') {
-            let curl = `curl -X POST '${endPoint}?hub.topic=${encodeURIComponent(topic)}&hub.callback=${encodeURIComponent(callback)}&hub.mode=${mode}`;
+            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
+            .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
+            .mode=${mode}'`;
             if (secret) {
-                curl += `&hub.secret=${secret}`;
+                curl += ` -d 'hub.secret=${secret}'`;
             }
             if (lease) {
-                curl += `&hub.lease_seconds=${lease}`;
+                curl += ` -d 'hub.lease_seconds=${lease}'`;
             }
             if (api.advertiseInfo && api.advertiseInfo.adveritsed && authorizationHeader !== '') {
-                curl += `' -H '${authorizationHeader}: ${token}'`;
+                curl += ` -H '${authorizationHeader}: ${token}'`;
             } else {
-                curl += `' -H 'Authorization: ${token}'`;
+                curl += ` -H 'Authorization: ${token}'`;
             }
             return curl;
         } else {
-            let curl = `curl -X POST '${endPoint}?hub.topic=${encodeURIComponent(topic)}&hub.callback=${encodeURIComponent(callback)}&hub.mode=${mode}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
+            .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
+            .mode=${mode}' -H 'Authorization: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                curl = `curl -X POST '${endPoint}?hub.topic=${encodeURIComponent(topic)}&hub.callback=${encodeURIComponent(callback)}&hub.mode=${mode}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
+                .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
+                .mode=${mode}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
@@ -115,9 +115,7 @@ export default function AsyncApiUI(props) {
         } = subscription;
         const token = generateAccessToken();
         if (mode === 'subscribe') {
-            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
-            .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
-            .mode=${mode}'`;
+            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}'`;
             if (secret) {
                 curl += ` -d 'hub.secret=${secret}'`;
             }
@@ -131,13 +129,9 @@ export default function AsyncApiUI(props) {
             }
             return curl;
         } else {
-            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
-            .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
-            .mode=${mode}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' - 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H 'Authorization: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub
-                .topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub
-                .mode=${mode}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         }


### PR DESCRIPTION
In the try-out console of the DevPortal, it passed the hub parameters as query parameters in the POST request. With this improvement, a curl will be generated which will pass the hub parameters in the request body as form-data and the POST request content type is 'application/x-www-form-urlencoded'.

Resolves: https://github.com/wso2/api-manager/issues/871