### PR TITLE
Adding javascript syntax highlighting to mock service code editors

### DIFF
--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -197,7 +197,8 @@ module.exports = (env, argv) => {
             Settings: 'Settings',
         },
         plugins: [
-            new MonacoWebpackPlugin({ languages: ['xml', 'json', 'yaml', 'markdown'], features: ['!gotoSymbol'] }),
+            new MonacoWebpackPlugin({ languages: ['xml', 'json', 'yaml', 'markdown', 'javascript'], 
+                features: ['!gotoSymbol'] }),
             new CleanWebpackPlugin(),
             new HtmlWebpackPlugin({
                 inject: false,


### PR DESCRIPTION
Fix for issue https://github.com/wso2/api-manager/issues/189