### PR TITLE
Fix enabling "Requires re-subscription when publishing the API" not working

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -132,7 +132,7 @@ class LifeCycleUpdate extends Component {
         if (isAPIProduct) {
             promisedUpdate = this.apiProduct.updateLcState(apiUUID, action, lifecycleChecklist);
         } else if (lifecycleChecklist.length > 0) {
-            promisedUpdate = this.api.updateLcState(apiUUID, action, lifecycleChecklist);
+            promisedUpdate = this.api.updateLcState(apiUUID, action, lifecycleChecklist.toString());
         } else {
             promisedUpdate = this.api.updateLcState(apiUUID, action);
         }


### PR DESCRIPTION
### Purpose
To fix enabling "Requires re-subscription when publishing the API" is not working.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/1307

