### PR TITLE
Add dynamic configuration loading

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/conf/settings.json
+++ b/portals/publisher/src/main/webapp/site/public/conf/settings.json
@@ -18,6 +18,7 @@
         },
         "throttlingPolicyLimit": 80,
         "operationPolicyCount": 500,
+        "documentCount": 1000,
         "propertyDisplaySuffix": "__display",
         "markdown": {
             "skipHtml": true,

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -1269,7 +1269,8 @@ class API extends Resource {
         return promised_getDocContent;
     }
 
-    getDocuments(api_id, callback, limit=1000) {
+    getDocuments(api_id, callback) {
+        const limit = Configurations.app.documentCount || 80;
         const promise_get_all = this.client.then(client => {
             return client.apis['API Documents'].getAPIDocuments(
                 {
@@ -2965,7 +2966,7 @@ class API extends Resource {
      */
     static getOperationPolicies(apiId) {
         const restApiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const limit = Configurations.app.operationPolicyCount;
+        const limit = Configurations.app.operationPolicyCount || 80;
         return restApiClient.then(client => {
             return client.apis['API Operation Policies'].getAllAPISpecificOperationPolicies(
                 {


### PR DESCRIPTION
## Purpose

- Previously, there was an issue where configuration not loaded dynamically from settings.json. It was fixed by @chanaka3d.
- Therefore now custom configuration can be added wherever necessary when fetching APIs.
- Fixed https://github.com/wso2/api-manager/issues/731
- Fixed https://github.com/wso2/api-manager/issues/1322
- Fixed https://github.com/wso2/api-manager/issues/756

## Approach
- Added configurations parameters in settings.json to load and used in APIs call.
- Default configuration value was fixed to `80`.