### PR TITLE
Add additional null check when validating description in api-categories

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/APICategories/AddEditAPICategory.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/APICategories/AddEditAPICategory.jsx
@@ -97,7 +97,7 @@ function AddEdit(props) {
                 }
                 break;
             case 'description':
-                if (value.length > 1024) {
+                if (value && value.length > 1024) {
                     error = 'API Category description is too long';
                 }
                 break;


### PR DESCRIPTION
## Purpose

- API category edit option causes an error in the admin portal for migrated API categories with no description.
- Fixed https://github.com/wso2/api-manager/issues/1340

## Approach
- Added additional null check when validating description in api-categories