### PR TITLE
Handle Error Scenario When Uploading Product Thumbnails

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/data/APIProduct.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/APIProduct.js
@@ -314,6 +314,7 @@ class APIProduct extends Resource {
             })
             .catch(error => {
                 console.error(error);
+                return new Promise.reject(error);
             });
 
         return promisedAddAPIThumbnail;


### PR DESCRIPTION
## Purpose
- Handle error scenario when uploading product thumbnails
- Related Issue: https://github.com/wso2/api-manager/issues/1280

## Approach
- When calling the product thumbnail upload API, if an error occurs, the error gets caught within the method but does not propagate the error to the caller. Hence, it does not get captured in the catch block of the caller. This PR sends the error to the caller so that it gets captured in the catch block of the caller

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/11872