### PR TITLE
Fix inconsistencies with unified search results

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/TableView/TableView.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/TableView/TableView.jsx
@@ -109,8 +109,9 @@ class TableView extends React.Component {
 
     componentDidUpdate(prevProps) {
         const { isAPIProduct, query } = this.props;
+        const { rowsPerPage, page } = this.state;
         if (isAPIProduct !== prevProps.isAPIProduct || query !== prevProps.query) {
-            this.getData();
+            this.getData(rowsPerPage, page);
         }
     }
 


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/api-manager/issues/1511
- Resolves https://github.com/wso2/api-manager/issues/1510

This PR fixes the bug where unified search results show all results disregarding the pagination.