### PR TITLE
Fix duplicate context allowed issue when a templated context is used

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -109,7 +109,13 @@ function checkContext(value, result) {
     if (tenant !== null && tenant !== undefined && tenant !== 'carbon.super') {
         contextVal = '/t/' + tenant + contextVal.toLowerCase();
     }
-    if (result.find((x) => x.context.toLowerCase() === contextVal.toLowerCase()) !== undefined) {
+    if (
+        result.find(
+            (x) =>
+                x.context.toLowerCase() === contextVal.toLowerCase() ||
+                x.contextTemplate.toLowerCase() === contextVal.toLowerCase(),
+        ) !== undefined
+    ) {
         return true;
     }
     return false;
@@ -193,13 +199,12 @@ export default function DefaultAPIForm(props) {
                         if (count > 0 && checkContext(value, result.body.list)) {
                             updateValidity({
                                 ...validity,
-                                // eslint-disable-next-line max-len
-                                context: { details: [{ message:  isWebSocket ? apiContext + ' channel already exists' : apiContext + ' context already exists' }] },
-                            });
-                        } else if (count > 0 && checkContext(value, result.body.list)) {
-                            updateValidity({
-                                ...validity,
-                                context: { details: [{ message: apiContext + ' dynamic context already exists' }] },
+                                context: {
+                                    details: [{
+                                        message: isWebSocket ? apiContext + ' channel already exists'
+                                            : apiContext + ' context already exists'
+                                    }]
+                                },
                             });
                         } else {
                             updateValidity({ ...validity, context: contextValidity, version: null });


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/api-manager/issues/1537

This PR fixes the issue where API creation is not properly validating whether the context that is being used is already available when it comes to dynamic contexts.

<img width="794" alt="image" src="https://user-images.githubusercontent.com/30475839/222120437-ad570803-9d13-4646-9cac-226f489cbe2f.png">
