### PR TITLE
Allowing to have a documentation name with spaces when adding documents for an API

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -2634,7 +2634,7 @@
   "Apis.Details.Documents.CreateEditForm.invalid.document.name.helper.text": [
     {
       "type": 0,
-      "value": "Document name cannot contain spaces or special characters"
+      "value": "Document name cannot contain special characters"
     }
   ],
   "Apis.Details.Documents.CreateEditForm.source": [

--- a/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
@@ -1213,7 +1213,7 @@
     "defaultMessage": "Document name exceeds the maximum length of 60 characters"
   },
   "Apis.Details.Documents.CreateEditForm.invalid.document.name.helper.text": {
-    "defaultMessage": "Document name cannot contain spaces or special characters"
+    "defaultMessage": "Document name cannot contain special characters"
   },
   "Apis.Details.Documents.CreateEditForm.source": {
     "defaultMessage": "Source"

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -340,7 +340,7 @@ class CreateEditForm extends React.Component {
             return (
                 <FormattedMessage
                     id='Apis.Details.Documents.CreateEditForm.invalid.document.name.helper.text'
-                    defaultMessage='Document name cannot contain spaces or special characters'
+                    defaultMessage='Document name cannot contain special characters'
                 />
             );
         } else {

--- a/portals/publisher/src/main/webapp/source/src/app/data/APIValidation.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/APIValidation.js
@@ -142,7 +142,7 @@ const definition = {
         .error((errors) => {
             return errors.map((error) => ({ ...error, message: 'Name ' + getMessage(error.type, 50) }));
         }),
-    documentName: Joi.string().max(50).regex(/^[^~!@#;:%^*()+={}|\\<>"',&$\s+[\]/]*$/).required()
+    documentName: Joi.string().max(50).regex(/^[^~!@#;:%^*()+={}|\\<>"',&$+[\]/]*$/).required()
         .error((errors) => {
             return errors.map((error) => ({ ...error, message: 'Document name ' + getMessage(error.type, 50) }));
         }),


### PR DESCRIPTION
With this fix, it allowed having a documentation name with spaces when adding documents to an API.

Fixes: https://github.com/wso2/api-manager/issues/1560 