### PR TITLE
Remove devportal and publisher session state cookie after user logout

### DIFF
--- a/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
+++ b/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
@@ -72,6 +72,12 @@
     cookie.setMaxAge(2);
     response.addCookie(cookie);
 
+    cookie = new Cookie("devportal_session_state", "");
+    cookie.setPath(context + "/");
+    cookie.setSecure(true);
+    cookie.setMaxAge(2);
+    response.addCookie(cookie);
+
     log.debug("redirecting to logout");
     String referrer = request.getParameter("referrer");
     if (referrer == null) {

--- a/portals/publisher/src/main/webapp/services/logout/logout_callback.jsp
+++ b/portals/publisher/src/main/webapp/services/logout/logout_callback.jsp
@@ -72,6 +72,12 @@
     cookie.setMaxAge(2);
     response.addCookie(cookie);
 
+    cookie = new Cookie("publisher_session_state", "");
+    cookie.setPath(context + "/");
+    cookie.setSecure(true);
+    cookie.setMaxAge(2);
+    response.addCookie(cookie);
+
     log.debug("redirecting to logout");
     response.sendRedirect(context + "/logout");
 %>


### PR DESCRIPTION
## Purpose
- Removed session state token related to publisher and devportal once user logged out from respective portal
- Related to https://github.com/wso2/api-manager/issues/1648

## Approach
- Add empty string for the cookie value once user logged out from portals
