### PR TITLE
[UI Test] Added test to check creating document with name having spaces

### DIFF
--- a/tests/cypress/integration/publisher/012-documents/00-add-edit-inline-document.spec.js
+++ b/tests/cypress/integration/publisher/012-documents/00-add-edit-inline-document.spec.js
@@ -26,9 +26,9 @@ describe("publisher-012-00 : Creating API document", () => {
     });
     before(function() {
         cy.loginToPublisher(publisher, password);
-    })
-    it.only("Creating inline document", () => {
-        const documentName = 'api_document';
+    });
+
+    const addDoc = (documentName) => {
         const documentSummary = 'api document summery';
         Utils.addAPI({}).then((apiId) => {
             cy.visit(`/publisher/apis/${apiId}/overview`);
@@ -49,5 +49,13 @@ describe("publisher-012-00 : Creating API document", () => {
             // Test is done. Now delete the api
             Utils.deleteAPI(apiId);
         });
+    };
+
+    it.only("Creating inline document", () => {
+        const documentName = 'api_document';
+        const documentName2 = 'api document name with space';
+        addDoc(documentName);
+        addDoc(documentName2);
     });
+     
 });


### PR DESCRIPTION
With this fix, it allowed having spaces in the name of documentation added under an API.

Resolves: https://github.com/wso2/api-manager/issues/1560
