### PR TITLE
Frontend changes for custom api key header feature

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -510,7 +510,7 @@ class ApiConsole extends React.Component {
         if (api && api.securityScheme) {
             isApiKeyEnabled = api.securityScheme.includes('api_key');
             if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
-                authorizationHeader = 'apikey';
+                authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
             }
         }
         let swaggerSpec = swagger;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
@@ -36,7 +36,7 @@ const SwaggerUI = (props) => {
             const { url } = req;
             const { context } = api;
             const patternToCheck = `${context}/*`;
-            if (authorizationHeader === 'apikey') {
+            if (securitySchemeType === 'API-KEY') {
                 req.headers[authorizationHeader] = accessTokenProvider();
             } else if (securitySchemeType === 'BASIC') {
                 req.headers[authorizationHeader] = 'Basic ' + accessTokenProvider();

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -454,7 +454,7 @@ function TryOutController(props) {
         isOAuthEnabled = api.securityScheme.includes('oauth2');
         isTestKeyEnabled = api.securityScheme.includes('test_auth');
         if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
-            authorizationHeader = 'apikey';
+            authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
             prefix = '';
         }
         if (isTestKeyEnabled && securitySchemeType === 'TEST') {

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
@@ -231,7 +231,7 @@ export default function GraphQLConsole() {
     if (api && api.securityScheme) {
         isApiKeyEnabled = api.securityScheme.includes('api_key');
         if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
-            authorizationHeader = 'apikey';
+            authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
         }
     }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLUI.jsx
@@ -85,7 +85,7 @@ export default function GraphQLUI(props) {
         let token;
         if (api.advertiseInfo && api.advertiseInfo.advertised) {
             token = accessTokenProvider();
-        } else if (authorizationHeader === 'apikey') {
+        } else if (securitySchemeType === 'API-KEY') {
             token = accessTokenProvider();
         } else if (securitySchemeType === 'BASIC') {
             token = 'Basic ' + accessTokenProvider();

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -195,6 +195,7 @@ function configReducer(state, configAction) {
         case 'description':
         case 'isDefaultVersion':
         case 'authorizationHeader':
+        case 'apiKeyHeader':
         case 'responseCachingEnabled':
         case 'cacheTimeout':
         case 'enableSchemaValidation':
@@ -524,7 +525,7 @@ export default function DesignConfigurations() {
                                         </Grid>
                                     </Box>
                                     <Box py={1}>
-                                        <AccessControl api={apiConfig} configDispatcher={configDispatcher}  
+                                        <AccessControl api={apiConfig} configDispatcher={configDispatcher}
                                             setIsDisabled={setErrorInAccessRoles} />
                                     </Box>
                                     <Box py={1}>
@@ -567,9 +568,9 @@ export default function DesignConfigurations() {
                                     </Box>
                                     <Box pt={2}>
                                         <Button
-                                            disabled={errorInAccessRoles || 
-                                                errorInRoleVisibility || 
-                                                restricted || 
+                                            disabled={errorInAccessRoles ||
+                                                errorInRoleVisibility ||
+                                                restricted ||
                                                 errorInTags ||
                                                 errorInExternalEndpoints}
                                             type='submit'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -130,6 +130,7 @@ function copyAPIConfig(api) {
         lifeCycleStatus: api.lifeCycleStatus,
         accessControl: api.accessControl,
         authorizationHeader: api.authorizationHeader,
+        apiKeyHeader: api.apiKeyHeader,
         responseCachingEnabled: api.responseCachingEnabled,
         cacheTimeout: api.cacheTimeout,
         visibility: api.visibility,
@@ -190,6 +191,7 @@ export default function RuntimeConfiguration() {
             case 'description':
             case 'isDefaultVersion':
             case 'authorizationHeader':
+            case 'apiKeyHeader':
             case 'responseCachingEnabled':
             case 'cacheTimeout':
             case 'enableSchemaValidation':
@@ -523,9 +525,9 @@ export default function RuntimeConfiguration() {
                                                         </Box>
                                                     </Grid>
                                                 ) : (
-                                                    <WebSubConfiguration 
-                                                        api={apiConfig} 
-                                                        configDispatcher={configDispatcher} 
+                                                    <WebSubConfiguration
+                                                        api={apiConfig}
+                                                        configDispatcher={configDispatcher}
                                                     />
                                                 )}
                                             </Paper>
@@ -592,7 +594,7 @@ export default function RuntimeConfiguration() {
                                         disabled
                                         type='submit'
                                         variant='contained'
-                                        color='primary'                     
+                                        color='primary'
                                     >
                                         <FormattedMessage
                                             id='Apis.Details.Configuration.Configuration.save'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
@@ -28,6 +28,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import AuthorizationHeader from 'AppComponents/Apis/Details/Configuration/components/AuthorizationHeader.jsx';
+import ApiKeyHeader from "AppComponents/Apis/Details/Configuration/components/ApiKeyHeader";
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -245,6 +246,7 @@ export default function ApplicationLevel(props) {
                             />
                         )}
                         <AuthorizationHeader api={api} configDispatcher={configDispatcher} />
+                        <ApiKeyHeader api={api} configDispatcher={configDispatcher} />
                         <FormControl>
                             {!hasResourceWithSecurity
                             && (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/ApiKeyHeader.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/ApiKeyHeader.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -97,7 +97,7 @@ export default function ApiKeyHeader(props) {
                         )
                     }
                     InputProps={{
-                        id: 'itest-id-apiHeaderName-input',
+                        id: 'itest-id-apiKeyHeaderName-input',
                         onBlur: ({ target: { value } }) => {
                             validateHeader(value);
                         },

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/ApiKeyHeader.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/ApiKeyHeader.jsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+import { FormattedMessage } from 'react-intl';
+import { isRestricted } from 'AppData/AuthManager';
+import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
+import API from 'AppData/api';
+import APIValidation from 'AppData/APIValidation';
+
+/**
+ *
+ *
+ * @export
+ * @param {*} props
+ * @returns
+ */
+
+export default function ApiKeyHeader(props) {
+    const { api, configDispatcher } = props;
+    const [apiFromContext] = useAPI();
+    const [isHeaderNameValid, setIsHeaderNameValid] = useState(true);
+    let hasResourceWithSecurity;
+    const apiKeyHeaderValue = api.apiKeyHeader;
+    if (apiFromContext.apiType === API.CONSTS.APIProduct) {
+        const apiList = apiFromContext.apis;
+        for (const apiInProduct in apiList) {
+            if (Object.prototype.hasOwnProperty.call(apiList, apiInProduct)) {
+                hasResourceWithSecurity = apiList[apiInProduct].operations.findIndex(
+                    (op) => op.authType !== 'None',
+                ) > -1;
+                if (hasResourceWithSecurity) {
+                    break;
+                }
+            }
+        }
+    } else {
+        hasResourceWithSecurity = apiFromContext.operations.findIndex((op) => op.authType !== 'None') > -1;
+    }
+    if (!hasResourceWithSecurity && api.apiKeyHeader !== '') {
+        configDispatcher({ action: 'apiKeyHeader', value: '' });
+    }
+
+    function validateHeader(value) {
+        const headerValidity = APIValidation.apiKeyHeader.required()
+            .validate(value, { abortEarly: false }).error;
+        if (headerValidity === null) {
+            setIsHeaderNameValid(true);
+            configDispatcher({ action: 'saveButtonDisabled', value: false });
+        } else {
+            setIsHeaderNameValid(false);
+            configDispatcher({ action: 'saveButtonDisabled', value: true });
+        }
+    }
+
+    return (
+        <Grid container spacing={1} alignItems='center'>
+            <Grid item xs={11}>
+                <TextField
+                    disabled={isRestricted(['apim:api_create'], apiFromContext) || !hasResourceWithSecurity}
+                    id='outlined-name'
+                    label={(
+                        <FormattedMessage
+                            id='Apis.Details.Configuration.Configuration.apiKey.header.label'
+                            defaultMessage='ApiKey Header'
+                        />
+                    )}
+                    value={hasResourceWithSecurity ? apiKeyHeaderValue : ' '}
+                    error={!isHeaderNameValid}
+                    helperText={
+                        (!isHeaderNameValid)
+                        && (
+                            <FormattedMessage
+                                id='Apis.Details.Configuration.ApiKeyHeader.helper.text'
+                                defaultMessage='ApiKey header name cannot contain spaces or special characters'
+                            />
+                        )
+                    }
+                    InputProps={{
+                        id: 'itest-id-apiHeaderName-input',
+                        onBlur: ({ target: { value } }) => {
+                            validateHeader(value);
+                        },
+                    }}
+                    margin='normal'
+                    variant='outlined'
+                    onChange={({ target: { value } }) => configDispatcher({
+                        action: 'apiKeyHeader',
+                        value: value === '' ? 'ApiKey' : value })}
+                    style={{ display: 'flex' }}
+                />
+            </Grid>
+            <Grid item xs={1}>
+                <Tooltip
+                    title={(
+                        <FormattedMessage
+                            id='Apis.Details.Configuration.Configuration.ApiKeyHeader.tooltip'
+                            defaultMessage={
+                                ' The header name that is used to send the api key '
+                                + 'information. "ApiKey" is the default header.'
+                            }
+                        />
+                    )}
+                    aria-label='ApiKey Header'
+                    placement='right-end'
+                    interactive
+                >
+                    <HelpOutline />
+                </Tooltip>
+            </Grid>
+        </Grid>
+    );
+}
+
+ApiKeyHeader.propTypes = {
+    api: PropTypes.shape({}).isRequired,
+    configDispatcher: PropTypes.func.isRequired,
+};

--- a/portals/publisher/src/main/webapp/source/src/app/data/APIValidation.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/APIValidation.js
@@ -150,6 +150,10 @@ const definition = {
         .error((errors) => {
             return errors.map((error) => ({ ...error, message: 'Authorization Header ' + getMessage(error.type) }));
         }),
+    apiKeyHeader: Joi.string().regex(/^[^~!@#;:%^*()+={}|\\<>"',&$\s+]*$/).required()
+        .error((errors) => {
+            return errors.map((error) => ({ ...error, message: 'Api Key Header ' + getMessage(error.type) }));
+        }),
     role: roleSchema.systemRole().role(),
     scope: scopeSchema.scopes().scope(),
     url: Joi.string().uri({ scheme: ['http', 'https'] }).error((errors) => {


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/api-manager/issues/1672

## Changes

1. Support for setting a custom value for API key header in Runtime config ( For REST, GraphQL APIs and APIProducts )
2. Necessary support for custom API key header in dev portal test consoles ( API and GraphQL consoles )

## Tests
https://github.com/wso2/apim-apps/pull/463