### PR TITLE
Add WebSocket Host to Gateway Access URL in portals 

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
@@ -109,9 +109,16 @@ export default function DeploymentOnboarding(props) {
     || (!isMutualSslOnly && !isTierAvailable)
     || api.workflowStatus === 'CREATED');
 
-    const defaultVhosts = internalGateways.map(
-        (e) => (e.vhosts && e.vhosts.length > 0 ? { env: e.name, vhost: e.vhosts[0].host } : undefined),
-    );
+    const defaultVhosts = internalGateways.map((e) => {
+        if (e.vhosts && e.vhosts.length > 0) {
+            return {
+                env: e.name,
+                vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
+            };
+        } else {
+            return undefined;
+        }
+    });
 
     const [descriptionOpen, setDescriptionOpen] = useState(false);
     const [selectedEnvironment, setSelectedEnvironment] = useState(hasOnlyOneEnvironment
@@ -354,8 +361,13 @@ export default function DeploymentOnboarding(props) {
                                                                             >
                                                                                 {row.vhosts.map(
                                                                                     (vhost) => (
-                                                                                        <MenuItem value={vhost.host}>
-                                                                                            {vhost.host}
+                                                                                        <MenuItem value = 
+                                                                                            {api.isWebSocket()
+                                                                                                ? vhost.wsHost 
+                                                                                                : vhost.host}>
+                                                                                            {api.isWebSocket() 
+                                                                                                ? vhost.wsHost 
+                                                                                                : vhost.host}
                                                                                         </MenuItem>
                                                                                     ),
                                                                                 )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -352,9 +352,15 @@ export default function Environments() {
     const [selectedVhostDeploy, setVhostsDeploy] = useState([]);
     useEffect(() => {
         if (settings) {
-            const defaultVhosts = internalGateways.map(
-                (e) => (e.vhosts && e.vhosts.length > 0 ? { env: e.name, vhost: e.vhosts[0].host } : undefined),
-            );
+            const defaultVhosts = internalGateways.map((e) => {
+                if (e.vhosts && e.vhosts.length > 0) {
+                    const env = e.name;
+                    const vhost = api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host;
+                    return { env, vhost };
+                } else {
+                    return undefined;
+                }
+            });
             setVhosts(defaultVhosts);
             setVhostsDeploy(defaultVhosts);
         }
@@ -1381,8 +1387,8 @@ export default function Environments() {
         }
 
         if (type === 'WS') {
-            endpoints.primary = 'ws://' + vhost.host + ':' + vhost.wsPort;
-            endpoints.secondary = 'wss://' + vhost.host + ':' + vhost.wssPort;
+            endpoints.primary = 'ws://' + vhost.wsHost + ':' + vhost.wsPort;
+            endpoints.secondary = 'wss://' + vhost.wssHost + ':' + vhost.wssPort;
             endpoints.combined = endpoints.secondary + ' ' + endpoints.primary;
             return endpoints;
         }
@@ -1411,9 +1417,16 @@ export default function Environments() {
     function getVhostHelperText(env, selectionList, shorten, maxTextLen) {
         const selected = selectionList && selectionList.find((v) => v.env === env);
         if (selected) {
-            const vhost = internalGateways.find((e) => e.name === env).vhosts.find(
-                (v) => v.host === selected.vhost,
-            );
+            let vhost;
+            if (api.isWebSocket() ) {
+                vhost = internalGateways.find((e) => e.name === env).vhosts.find(
+                    (v) => v.wsHost === selected.vhost,
+                );
+            } else {
+                vhost = internalGateways.find((e) => e.name === env).vhosts.find(
+                    (v) => v.host === selected.vhost,
+                );
+            }
 
             const maxtLen = maxTextLen || 30;
             if (api.isGraphql() && !shorten) {
@@ -1726,8 +1739,10 @@ export default function Environments() {
                                                                     >
                                                                         {row.vhosts.map(
                                                                             (vhost) => (
-                                                                                <MenuItem value={vhost.host}>
-                                                                                    {vhost.host}
+                                                                                <MenuItem value={api.isWebSocket() 
+                                                                                    ? vhost.wsHost : vhost.host}>
+                                                                                    {api.isWebSocket() 
+                                                                                        ? vhost.wsHost : vhost.host}
                                                                                 </MenuItem>
                                                                             ),
                                                                         )}
@@ -2231,8 +2246,10 @@ export default function Environments() {
                                                         >
                                                             {row.vhosts.map(
                                                                 (vhost) => (
-                                                                    <MenuItem value={vhost.host}>
-                                                                        {vhost.host}
+                                                                    <MenuItem value={api.isWebSocket() 
+                                                                        ? vhost.wsHost : vhost.host}>
+                                                                        {api.isWebSocket() 
+                                                                            ? vhost.wsHost : vhost.host}
                                                                     </MenuItem>
                                                                 ),
                                                             )}


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/1844
- ForwardPort https://github.com/wso2-support/apim-apps/pull/117

### Description

- Gateway Access URL should displays the host name which given for `ws_endpoint` in the `deployment.toml` file. However in the publisher and dev-portal it showed the host name given for `http_endpoint`.

