### PR TITLE
Add Logic to Process `Use as Application Owner` New Property Introduced for WSO2 IS Connector Configuration 

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -429,9 +429,23 @@ function AddEditKeyManager(props) {
             tokenType = 'DIRECT';
         }
 
-        const keymanager = {
-            ...state, tokenValidation: newTokenValidation, tokenType,
-        };
+        let keymanager = {};
+        if (type === 'WSO2-IS') {
+            const additionalPropertiesForIS = { ...additionalProperties };
+            if (!additionalPropertiesForIS.km_admin_as_app_owner) {
+                additionalPropertiesForIS.km_admin_as_app_owner = false;
+            }
+            keymanager = {
+                ...state,
+                tokenValidation: newTokenValidation,
+                tokenType,
+                additionalProperties: additionalPropertiesForIS,
+            };
+        } else {
+            keymanager = {
+                ...state, tokenValidation: newTokenValidation, tokenType,
+            };
+        }
 
         if (id) {
             promisedAddKeyManager = restApi.updateKeyManager(id, keymanager);

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
@@ -13,6 +13,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import { makeStyles } from '@material-ui/core/styles';
 import CustomInputField from 'AppComponents/KeyManagers/CustomInputField';
+import CONSTS from '../../data/Constants';
 
 const useStyles = makeStyles((theme) => ({
     inputLabel: {
@@ -43,16 +44,24 @@ export default function KeyManagerConfiguration(props) {
         let finalValue;
         const { name, value, type } = e.target;
         if (type === 'checkbox') {
-            if (additionalProperties[name]) {
-                finalValue = additionalProperties[name];
+            if (name === CONSTS.KM_ADMIN_AS_APP_OWNER_KEY) {
+                if (e.target.checked) {
+                    finalValue = true;
+                } else {
+                    finalValue = false;
+                }
             } else {
-                finalValue = [];
-            }
-            if (e.target.checked) {
-                finalValue.push(value);
-            } else {
-                const newValue = value.filter((v) => v !== e.target.value);
-                finalValue = newValue;
+                if (additionalProperties[name]) {
+                    finalValue = additionalProperties[name];
+                } else {
+                    finalValue = [];
+                }
+                if (e.target.checked) {
+                    finalValue.push(value);
+                } else {
+                    const newValue = value.filter((v) => v !== e.target.value);
+                    finalValue = newValue;
+                }
             }
         } else {
             finalValue = value;
@@ -62,7 +71,13 @@ export default function KeyManagerConfiguration(props) {
     const getComponent = (keymanagerConnectorConfiguration) => {
         let value = '';
         if (additionalProperties[keymanagerConnectorConfiguration.name]) {
-            value = additionalProperties[keymanagerConnectorConfiguration.name];
+            if (keymanagerConnectorConfiguration.name === CONSTS.KM_ADMIN_AS_APP_OWNER_KEY) {
+                if (additionalProperties[keymanagerConnectorConfiguration.name] === true) {
+                    value = CONSTS.KM_ADMIN_AS_APP_OWNER_VALUE;
+                }
+            } else {
+                value = additionalProperties[keymanagerConnectorConfiguration.name];
+            }
         }
         if (keymanagerConnectorConfiguration.type === 'input') {
             if (keymanagerConnectorConfiguration.mask) {

--- a/portals/admin/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/admin/src/main/webapp/source/src/app/data/Constants.js
@@ -27,6 +27,8 @@ const CONSTS = {
     TENANT_STATE_ACTIVE: 'ACTIVE',
     DEFAULT_MIN_SCOPES_TO_LOGIN: ['apim:api_workflow_view', 'apim:api_workflow_approve', 'apim:tenantInfo',
         'apim:admin_settings'],
+    KM_ADMIN_AS_APP_OWNER_KEY: 'km_admin_as_app_owner',
+    KM_ADMIN_AS_APP_OWNER_VALUE: 'Use as Application Owner',
 };
 
 export default CONSTS;


### PR DESCRIPTION
## Purpose
- Add Logic to Process New Property Introduced for WSO2 IS Connector Configuration
- Related Issue: https://github.com/wso2/api-manager/issues/1821

## Related PRs
https://github.com/wso2-extensions/apim-km-wso2is/pull/108
https://github.com/wso2/carbon-apimgt/pull/12027