### PR TITLE
Add UI changes to enable content encoding in lambda

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -6457,6 +6457,12 @@
       "value": "AWS Lambda Settings"
     }
   ],
+  "Apis.Details.Resources.components.operationComponents.AWSLambdaSettings.encode": [
+    {
+      "type": 0,
+      "value": "Check if request body should be base64 encoded"
+    }
+  ],
   "Apis.Details.Resources.components.operationComponents.AddParameter.add": [
     {
       "type": 0,

--- a/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
@@ -3075,6 +3075,9 @@
   "Apis.Details.Resources.components.operationComponents.AWSLambdaSettings.Title": {
     "defaultMessage": "AWS Lambda Settings"
   },
+  "Apis.Details.Resources.components.operationComponents.AWSLambdaSettings.encode": {
+    "defaultMessage": "Check if request body should be base64 encoded"
+  },
   "Apis.Details.Resources.components.operationComponents.AddParameter.add": {
     "defaultMessage": "Add"
   },

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -200,6 +200,9 @@ export default function Resources(props) {
             case 'amznResourceTimeout':
                 updatedOperation['x-amzn-resource-timeout'] = value;
                 break;
+            case 'amznResourceContentEncode':
+                updatedOperation['x-amzn-resource-content-encode'] = value;
+                break;
             case 'scopes': {
                 if (!updatedOperation.security) {
                     updatedOperation.security = [{ default: [] }];

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/AWSLambdaSettings.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/AWSLambdaSettings.jsx
@@ -169,7 +169,8 @@ export default function IntegrationDownshift(props) {
     useEffect(() => {
         if (operation['x-amzn-resource-timeout']) {
             setTimeout(operation['x-amzn-resource-timeout']);
-        } else if (operation['x-amzn-resource-content-encode']) {
+        }
+        if (operation['x-amzn-resource-content-encode']) {
             setIsBase64Encoded(operation['x-amzn-resource-content-encode']);
         }
     }, []);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/AWSLambdaSettings.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/AWSLambdaSettings.jsx
@@ -29,6 +29,10 @@ import Paper from '@material-ui/core/Paper';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Icon from '@material-ui/core/Icon';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import { FormattedMessage } from 'react-intl';
 
 /**
@@ -161,9 +165,12 @@ export default function IntegrationDownshift(props) {
         arns,
     } = props;
     const [timeout, setTimeout] = useState(50000);
+    const [isBase64Encoded, setIsBase64Encoded] = useState(operation['x-amzn-resource-content-encode']);
     useEffect(() => {
         if (operation['x-amzn-resource-timeout']) {
             setTimeout(operation['x-amzn-resource-timeout']);
+        } else if (operation['x-amzn-resource-content-encode']) {
+            setIsBase64Encoded(operation['x-amzn-resource-content-encode']);
         }
     }, []);
     const handleTimeoutMin = (event) => {
@@ -206,6 +213,14 @@ export default function IntegrationDownshift(props) {
             });
         }
     };
+    const handleIsBase64Encoded = (event) => {
+        setIsBase64Encoded(event.target.checked);
+        operationsDispatcher({
+            action: 'amznResourceContentEncode',
+            data: { target, verb, value: event.target.checked },
+        });
+        console.log('changing content encode ' + event.target.checked + ' dispatched');
+    };
     return (
         <>
             <Grid item md={12} xs={12}>
@@ -218,7 +233,7 @@ export default function IntegrationDownshift(props) {
                 </Typography>
             </Grid>
             <Grid item md={1} xs={1} />
-            <Grid item md={7} xs={7}>
+            <Grid item md={6} xs={6}>
                 <Downshift
                     id='downshift-options'
                     onSelect={(changes) => {
@@ -338,6 +353,28 @@ export default function IntegrationDownshift(props) {
                         handleTimeoutSec(event);
                     }}
                 />
+            </Grid>
+            <Grid item md={1} xs={1}>
+                <FormControl component='fieldset' className={classes.formControl}>
+                    <FormControlLabel
+                        control={(
+                            <Checkbox
+                                checked={isBase64Encoded}
+                                value={isBase64Encoded}
+                                onChange={(event) => {
+                                    handleIsBase64Encoded(event);
+                                }}
+                            />
+                        )}
+                        label='Encode'
+                    />
+                    <FormHelperText>
+                        <FormattedMessage
+                            id='Apis.Details.Resources.components.operationComponents.AWSLambdaSettings.encode'
+                            defaultMessage='Check if request body should be base64 encoded'
+                        />
+                    </FormHelperText>
+                </FormControl>
             </Grid>
             <Grid item md={1} xs={1} />
         </>


### PR DESCRIPTION
Related git issue : https://github.com/wso2/api-manager/issues/1878
Related PRs : https://github.com/wso2/carbon-apimgt/pull/12031

- In lamba, content can be sent as either encoded or not, this is goverened by the new checkbox introduced in AWS lambda Settings UI section. 

<img width="1461" alt="Screenshot 2023-05-30 at 20 22 08" src="https://github.com/wso2/carbon-apimgt/assets/28379317/c68edf2d-a097-440f-997e-e9eac0d969fc">
