### PR TITLE
Fix Navigates to a Not found page when click on document of an API product

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Listing.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Listing.jsx
@@ -120,7 +120,7 @@ const styles = theme => ({
 });
  
 function LinkGenerator(props) {
-    return props.apiType === 'APIProduct' ? (
+    return props.apiType === 'APIPRODUCT' ? (
         <Link to={'/api-products/' + props.apiId + '/documents/' + props.docId + '/details'}>{props.docName}</Link>
     ) : (
         <Link to={'/apis/' + props.apiId + '/documents/' + props.docId + '/details'}>{props.docName}</Link>


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/1608