### PR TITLE
Introduce Checkbox Type to Key Manager Configurations

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
@@ -59,6 +59,9 @@ export default function KeyManagerConfiguration(props) {
         }
         setAdditionalProperties(name, finalValue);
     };
+    const onChangeCheckBox = (e) => {
+        setAdditionalProperties(e.target.name, e.target.checked);
+    };
     const getComponent = (keymanagerConnectorConfiguration) => {
         let value = '';
         if (additionalProperties[keymanagerConnectorConfiguration.name]) {
@@ -117,6 +120,28 @@ export default function KeyManagerConfiguration(props) {
                                     <Checkbox
                                         checked={value.includes(selection)}
                                         onChange={onChange}
+                                        value={selection}
+                                        color='primary'
+                                        name={keymanagerConnectorConfiguration.name}
+                                    />
+                                )}
+                                label={selection}
+                            />
+                        ))}
+                    </FormGroup>
+                </FormControl>
+            );
+        } else if (keymanagerConnectorConfiguration.type === 'checkbox') {
+            return (
+                <FormControl component='fieldset'>
+                    <FormLabel component='legend'>{keymanagerConnectorConfiguration.label}</FormLabel>
+                    <FormGroup>
+                        {keymanagerConnectorConfiguration.values.map((selection) => (
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        checked={value === '' ? false : value}
+                                        onChange={onChangeCheckBox}
                                         value={selection}
                                         color='primary'
                                         name={keymanagerConnectorConfiguration.name}


### PR DESCRIPTION
## Purpose
- This PR will introduce the checkbox type to the Key Manager configurations.  
- Related Issue: https://github.com/wso2/api-manager/issues/1821

## Approach
- A new property has been introduced to the WSO2-IS Key Manager configurations with the checkbox type. 
- The UI will be displayed as follows.
![Screenshot from 2023-06-08 11-47-17](https://github.com/wso2-support/apim-apps/assets/30455603/3ebe9f04-7bd3-4eea-a785-0559bb6ad96e)

- The behaviour will be as follows.
  - When adding a WSO2-IS key manager, if the checkbox was not clicked, the following object will be sent to the backend
![Screenshot from 2023-06-07 09-56-29](https://github.com/wso2-support/apim-apps/assets/30455603/4015c9f3-a285-4bc8-b116-0ef85a76c036)

  - When adding a WSO2-IS key manager, if the checkbox was clicked, the following object will be sent to the backend
![Screenshot from 2023-06-07 09-46-08](https://github.com/wso2-support/apim-apps/assets/30455603/03554a2f-3f83-4dee-91e4-4b7c47e35e7e)

  - When adding a WSO2-IS key manager, if the checkbox was clicked and un-clicked, the following object will be sent to the backend
![Screenshot from 2023-06-08 11-48-58](https://github.com/wso2-support/apim-apps/assets/30455603/d00c66d0-72aa-4ecc-88f5-3c64a38bd6fb)
