### PR TITLE
Add chip disability based on scopes

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/AccessControl.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/AccessControl.jsx
@@ -264,6 +264,7 @@ export default function AccessControl(props) {
                                 key={key}
                                 size='small'
                                 label={value}
+                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
                                 onDelete={() => {
                                     handleRoleDeletion(value);
                                 }}


### PR DESCRIPTION
## Purpose

- Fixed issue where any user can delete the publisher access roles from UI of api configuration page.
- This is anyway blocked from the backend.
- Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/3409.

## Approach
- Made disable option true based on the permissions of the user in mui chip widget.