### PR TITLE
Add information icon to show product revision description.

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -61,6 +61,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import CardHeader from '@material-ui/core/CardHeader';
 import Checkbox from '@material-ui/core/Checkbox';
+import InfoIcon from '@material-ui/icons/Info';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import API from 'AppData/api';
@@ -76,6 +77,11 @@ const useStyles = makeStyles((theme) => ({
     root: {
         display: 'flex',
         flexWrap: 'wrap',
+    },
+    infoIcon: {
+        fontSize: 'medium',
+        marginLeft: theme.spacing(1),
+        verticalAlign: 'middle',
     },
     saveButton: {
         marginTop: theme.spacing(3),
@@ -143,6 +149,8 @@ const useStyles = makeStyles((theme) => ({
         marginLeft: 6.5,
     },
     textShape2: {
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 8,
         marginLeft: 115,
         height: '18px',
@@ -1192,6 +1200,61 @@ export default function Environments() {
         );
         return item6;
     }
+    let infoIconItem;
+    /**
+       * Returns modified infoIconItem
+       * @param {*} revDescription The description of the revision
+       * @returns {Object} Returns the infoIconItem
+     */
+    function ReturnInfoIconItem({ revDescription}) {
+        const [anchorEl, setAnchorEl] = useState(null);
+
+        const handlePopoverOpen = (event) => {
+            setAnchorEl(event.currentTarget);
+        };
+
+        const handlePopoverClose = () => {
+            setAnchorEl(null);
+        };
+
+        const openPopover = Boolean(anchorEl);
+        infoIconItem = (
+            <>
+                <InfoIcon className={classes.infoIcon} color='primary'
+                    onMouseEnter={handlePopoverOpen}
+                    onMouseLeave={handlePopoverClose}
+                />
+                <Popover
+                    id='mouse-over-popover'
+                    className={classes.popover}
+                    classes={{
+                        paper: classes.paper,
+
+                    }}
+                    open={openPopover}
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                        vertical: 'top',
+                        horizontal: 'right',
+                    }}
+                    transformOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    }}
+                    onClose={handlePopoverClose}
+                    disableRestoreFocus
+                >
+                    <div>
+                        <Typography variant='body2'>
+                            {revDescription}
+                        </Typography>
+                    </div>
+                </Popover>
+            </>
+
+        );
+        return infoIconItem;
+    }
 
     const items = [];
     if (!api.isRevision) {
@@ -1212,6 +1275,13 @@ export default function Environments() {
                             {item1}
                             <Grid className={classes.textShape2}>
                                 {allRevisions[revision].displayName}
+                                {allRevisions[revision].description && <>
+                                    <ReturnInfoIconItem
+                                        revDescription={allRevisions[revision].description}
+                                    />
+                                    {infoIconItem}
+                                </>
+                                }
                             </Grid>
                             <Grid>
                                 <Button
@@ -1255,6 +1325,13 @@ export default function Environments() {
                             <Grid className={classes.textShape5} />
                             <Grid className={classes.textShape2}>
                                 {allRevisions[revision].displayName}
+                                {allRevisions[revision].description && <>
+                                    <ReturnInfoIconItem
+                                        revDescription={allRevisions[revision].description}
+                                    />
+                                    {infoIconItem}
+                                </>
+                                }
                             </Grid>
                             <Grid className={classes.textPadding}>
                                 <Button


### PR DESCRIPTION
Implemented an information icon to show the product revision description only when a description is added.
Implemented a Returnbox to view the description. The Ui will be as follows.
![Screenshot from 2023-07-04 10-06-42](https://github.com/wso2/apim-apps/assets/42825038/073f3f01-907b-4678-8a93-2132ec49252e)


Resolves : https://github.com/wso2/api-manager/issues/1905