### PR TITLE
Hide "Get Test Key" button when token hashing is enabled

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/TryOutController.jsx
@@ -742,7 +742,8 @@ function TryOutController(props) {
                                         }}
                                     />
                                 )}
-                                {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST' && (
+                                {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
+                                && selectedKMObject && !selectedKMObject.enableTokenHashing && (
                                     <>
                                         <Button
                                             onClick={securitySchemeType === 'API-KEY' ? generateApiKey


### PR DESCRIPTION
### Purpose

- Resolves https://github.com/wso2/api-manager/issues/1986

This PR wii add the implementation of hiding the "Get Test Key" button when token hashing is enabled using the following config in  deployment.toml

```toml
[apim.oauth_config]
enable_token_hashing = true
```

![Screenshot from 2023-07-07 16-08-38](https://github.com/wso2-support/carbon-apimgt/assets/42825038/ebb233ab-d8e2-4939-a766-5da467abb10c)
