### PR TITLE
Support multiple internal roles mapping feature

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/AdminTable/AdminTableBody.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/AdminTable/AdminTableBody.jsx
@@ -154,6 +154,7 @@ function AdminTableBody(props) {
                                     padding={multiSelect ? 'none' : 'default'}
                                     align={index === 0 ? 'left' : 'right'}
                                     data-testid={column}
+                                    style={{ maxWidth: '800px' }}
                                 >
                                     {column}
                                 </TableCell>

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/AddRoleWizard.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/AddRoleWizard.jsx
@@ -98,8 +98,15 @@ export default function AddRoleWizard(props) {
     const handleNext = () => {
         if (!validation.role && newRole) {
             setActiveStep((prevActiveStep) => prevActiveStep + 1);
+        } else if (newRole === '') {
+            Alert.warning(
+                intl.formatMessage({
+                    id: 'RolePermissions.Common.AddRoleWizard.add.role.warn.empty',
+                    defaultMessage: 'Role name can not be empty!',
+                }),
+            );
         } else {
-            Alert.warning('Role name can not be empty!');
+            Alert.warning(validation.role);
         }
     };
 

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/AddRoleWizard.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/AddRoleWizard.jsx
@@ -157,12 +157,14 @@ export default function AddRoleWizard(props) {
                 return;
             }
             const updatedRoleAliases = [...roleAliases.list];
-            const targetRole = updatedRoleAliases.find(({ role }) => role === mappedRole);
-            if (targetRole) {
-                targetRole.aliases.push(newRole);
-            } else {
-                updatedRoleAliases.push({ role: mappedRole, aliases: [newRole] });
-            }
+            mappedRole.forEach((mappedRoleElement) => {
+                const targetRole = updatedRoleAliases.find(({ role }) => role === mappedRoleElement);
+                if (targetRole) {
+                    targetRole.aliases.push(newRole);
+                } else {
+                    updatedRoleAliases.push({ role: mappedRoleElement, aliases: [newRole] });
+                }
+            });
             PermissionAPI.updateRoleAliases(updatedRoleAliases).then((response) => {
                 setRoleAliases(response.body);
                 Alert.info(

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/SelectPermissionsStep.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/SelectPermissionsStep.jsx
@@ -55,7 +55,7 @@ export default function SelectPermissionsStep(props) {
                 />
                 <Box width={400} display='inline' pl={7} pt={2} pb={2}>
                     <Autocomplete
-                        // multiple
+                        multiple
                         value={mappedRole}
                         onChange={(e, newValue) => {
                             onMappedRoleSelect(newValue);

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
@@ -320,6 +320,7 @@ export default function ListRoles() {
                                 display='inline'
                                 fontSize={10}
                                 fontWeight='fontWeightLight'
+                                data-testid={mapping.aliases}
                             >
                                 {mapping.aliases.map((alias) => (
                                     <Box

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
@@ -312,22 +312,29 @@ export default function ListRoles() {
                 <AdminTableHead headCells={headCells} />
                 <TableBody rows={Object.entries(searchPermissionMappings).map(([role, mapping]) => {
                     return [mapping.aliases ? (
-                        <Box display='inline'>
+                        <Box display='grid'>
                             {role}
                             <Box
-                                borderRadius={16}
-                                borderColor='info.main'
-                                ml={2}
                                 mr={2}
-                                pl={1}
                                 pr={1}
-                                border={1}
                                 display='inline'
                                 fontSize={10}
                                 fontWeight='fontWeightLight'
                             >
-                                {/* TODO: Do support multiple aliases from UI ~tmkb  */}
-                                {mapping.aliases[0]}
+                                {mapping.aliases.map((alias) => (
+                                    <Box
+                                        borderRadius={16}
+                                        borderColor='info.main'
+                                        display='inline-block'
+                                        border={1}
+                                        pr={1}
+                                        mr={1}
+                                        pl={1}
+                                        mt={1}
+                                    >
+                                        {alias}
+                                    </Box>
+                                ))}
                             </Box>
                         </Box>
                     ) : role,

--- a/tests/cypress/integration/admin/07-add-scope-mapping.spec.js
+++ b/tests/cypress/integration/admin/07-add-scope-mapping.spec.js
@@ -20,10 +20,8 @@ describe("Add scope mapping", () => {
     const carbonUsername = 'admin';
     const carbonPassword = 'admin';
 
-    before(function () {
-        cy.loginToAdmin(carbonUsername, carbonPassword);
-    })
     it.only("Add scope mapping", () => {
+        cy.loginToAdmin(carbonUsername, carbonPassword);
         const roleName = 'creator';
 
         cy.get('[data-testid="Scope Assignments-child-link"]').click();
@@ -34,6 +32,29 @@ describe("Add scope mapping", () => {
         cy.get('#role-select-dropdown-popup li').contains('Internal/creator').click();
         cy.get('button.MuiButton-containedPrimary span').contains('Save').click();
         cy.get('div').contains(roleName).should('exist');
+
+        // delete
+        cy.get(`[data-testid="${roleName}-delete-btn"]`).click();
+        cy.get('[aria-labelledby="delete-confirmation"] button.MuiButton-containedPrimary').click();
+        cy.get(`[data-testid="${roleName}"]`).should('not.exist');
+    });
+    it.only("Add multiple scope mapping", () => {
+        cy.loginToAdmin(carbonUsername, carbonPassword);
+        const roleName = 'customRole';
+
+        cy.get('[data-testid="Scope Assignments-child-link"]').click();
+        cy.get('.MuiButton-label').contains('Add scope mappings').click();
+        cy.get('#role-input-field-helper-text').type(roleName);
+        cy.get('button.MuiButton-containedPrimary span').contains('Next').click();  
+        cy.get('#role-select-dropdown').click();
+        cy.get('#role-select-dropdown-popup li').contains('Internal/creator').click();
+        cy.get('#role-select-dropdown').click();
+        cy.get('#role-select-dropdown-popup li').contains('Internal/publisher').click();
+        cy.get('#role-select-dropdown').click();
+        cy.get('#role-select-dropdown-popup li').contains('Internal/subscriber').click();
+        cy.get('button.MuiButton-containedPrimary span').contains('Save').click();
+        cy.get('div').contains(roleName).should('exist');
+        cy.get('[data-testid="Internal/subscriber,Internal/creator,Internal/publisher"]').should('exist');
 
         // delete
         cy.get(`[data-testid="${roleName}-delete-btn"]`).click();


### PR DESCRIPTION
This PR adds the new feature of mapping multiple internal roles for a custom role & enhances warn messages when having UI error on Scope-Role mapping UI on the admin portal. Sample UIs are as follows.

**Warn Message when the textbox is empty**

![ss5](https://github.com/wso2/apim-apps/assets/31464477/e4858e6f-d647-4e6f-9be1-4621e602f661)

**Warn Message when having an UI error**

![ss6](https://github.com/wso2/apim-apps/assets/31464477/12fbcf7f-e058-43f5-bf84-821823bcfd21)

**When selecting multiple roles with this feature UI will be as follows**

![ss7](https://github.com/wso2/apim-apps/assets/31464477/c82a8c41-94e0-4de3-95ae-0a2b9c8e1249)

**This is how it looks in the table after mapping roles**

![ss8](https://github.com/wso2/apim-apps/assets/31464477/0b946e85-91d7-45d8-b3b1-34c34c6a81ca)

### Related PRs
[4.1.0] - https://github.com/wso2-support/apim-apps/pull/158
[4.2.0] - https://github.com/wso2-support/apim-apps/pull/159
