### PR TITLE
Downgrade java version & change distribution to fix PR build failures

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: 11.0.19+7
+          distribution: 'temurin'
       - uses: actions/setup-node@v1
         with:
           node-version: '16'


### PR DESCRIPTION
This PR fixes the PR build failures in this repo by downgrading the java version to **11.0.19+7** & changing the distribution to **temurin**.