### PR TITLE
[Main] Adding new test cases for API Publisher

### DIFF
--- a/tests/cypress/integration/devportal/000-general/04-change-password-of-a-user.spec.js
+++ b/tests/cypress/integration/devportal/000-general/04-change-password-of-a-user.spec.js
@@ -1,0 +1,69 @@
+/*
+*  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+import Utils from "@support/utils";
+import DevportalComonPage from "../../../support/pages/devportal/DevportalComonPage";
+const devportalComonPage = new DevportalComonPage();
+
+describe("Change the password from devportal", () => {
+  const username = "newuser";
+  const password = "test123";
+  const newPassword = "test456";
+
+  const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+
+  it.only("Change the password from devportal", () => {
+    cy.carbonLogin(carbonUsername, carbonPassword);
+    cy.addNewUser(username, ["Internal/subscriber"], password);
+    cy.get(".ui-dialog-buttonset", { timeout: Cypress.config().largeTimeout });
+    cy.get("button").contains("OK").click();
+    cy.get("#userTable").contains("td", "newuser").should("exist");
+    cy.carbonLogout();
+
+    cy.loginToDevportal(username, password);
+    cy.get("#userToggleButton").click();
+    cy.get("#menu-list-grow").within(() => {
+      cy.get("ul li:first").contains("Change Password").click();
+    });
+
+    //Add new password
+
+    cy.get("input#current-password").click();
+    cy.get("input#current-password").type(password);
+
+    cy.get("input#new-password").click();
+    cy.get("input#new-password").type(newPassword);
+
+    cy.get("input#repeated-new-password").click();
+    cy.get("input#repeated-new-password").type(newPassword);
+
+    cy.get("button > span").contains("Save").click();
+
+    cy.logoutFromDevportal();
+    devportalComonPage.waitUntillDevportalLoaderSpinnerExit();
+    cy.wait(3000);
+
+    //login to devportal again to verify password change
+
+    cy.loginToDevportal(username, newPassword);
+
+    cy.carbonLogin(carbonUsername, carbonPassword);
+    cy.visit(`${Utils.getAppOrigin()}/carbon/user/user-mgt.jsp`);
+    cy.deleteUser(username);
+  });
+});

--- a/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
+++ b/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
@@ -1,20 +1,20 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
- *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+*  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 import Utils from "@support/utils";
 import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
@@ -61,3 +61,4 @@ describe("Create and and publish api from scratch", () => {
     });
   });
 });
+

--- a/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
+++ b/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -24,36 +24,40 @@ let apiName;
 let testApiID;
 
 describe("Create and and publish api from scratch", () => {
-    const { publisher, password } = Utils.getUserInfo();
+  const { publisher, password } = Utils.getUserInfo();
 
-    before(function () {
-        cy.loginToPublisher(publisher, password);
-      });
+  before(function () {
+    cy.loginToPublisher(publisher, password);
+  });
 
-      it.only("Create and and publish api from scratch", () => {
+  it.only("Create and and publish api from scratch", () => {
+    cy.visit(`${Utils.getAppOrigin()}/publisher/apis/create/rest`, {
+      timeout: Cypress.config().largeTimeout,
+    });
+    publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
+    apiName = Utils.generateName().replace("-", "_");
 
-        cy.visit(`${Utils.getAppOrigin()}/publisher/apis/create/rest`);
-        publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
-         apiName = Utils.generateName().replace('-', '_');
+    cy.get("#itest-id-apiname-input", {
+      timeout: Cypress.config().largeTimeout,
+    }).type(apiName);
+    cy.get("#itest-id-apicontext-input").type("/" + apiName);
+    cy.get("#itest-id-apiversion-input").type("1.0.0");
+    cy.get("#itest-id-apiendpoint-input").type(
+      `${Utils.getAppOrigin()}/am/sample/${apiName}/v1/api`
+    );
+    cy.get("#itest-id-apiversion-input").click();
+    cy.get("body").click(0, 0);
 
-         cy.get('#itest-id-apiname-input', {timeout: Cypress.config().largeTimeout}).type(apiName);
-            cy.get('#itest-id-apicontext-input').type('/' + apiName);
-            cy.get('#itest-id-apiversion-input').type('1.0.0');
-            cy.get('#itest-id-apiendpoint-input').type(`${Utils.getAppOrigin()}/am/sample/${apiName}/v1/api`);
-            cy.get('#itest-id-apiversion-input').click()
-            cy.get('body').click(0,0);
+    cy.get("#itest-id-apicreatedefault-createnpublish").click();
 
-            cy.get('#itest-id-apicreatedefault-createnpublish').click();
+    cy.get('[data-testid="itest-api-state"]')
+      .contains("PUBLISHED")
+      .should("exist");
 
-            cy.get('[data-testid="itest-api-state"]').contains('PUBLISHED').should('exist');
+    cy.url().then((url) => {
+      testApiID = /apis\/(.*?)\/overview/.exec(url)[1];
 
-            cy.url().then(url => {
-                testApiID = /apis\/(.*?)\/overview/.exec(url)[1];
-
-                Utils.deleteAPI(testApiID);
-
-    
-            });
-
-      })
-})
+      Utils.deleteAPI(testApiID);
+    });
+  });
+});

--- a/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
+++ b/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
@@ -61,4 +61,3 @@ describe("Create and and publish api from scratch", () => {
     });
   });
 });
-

--- a/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
+++ b/tests/cypress/integration/publisher/001-api-create/07-create-and-publish-api-from-scratch.spec.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
+const publisherComonPage = new PublisherComonPage();
+
+let apiName;
+let testApiID;
+
+describe("Create and and publish api from scratch", () => {
+    const { publisher, password } = Utils.getUserInfo();
+
+    before(function () {
+        cy.loginToPublisher(publisher, password);
+      });
+
+      it.only("Create and and publish api from scratch", () => {
+
+        cy.visit(`${Utils.getAppOrigin()}/publisher/apis/create/rest`);
+        publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
+         apiName = Utils.generateName().replace('-', '_');
+
+         cy.get('#itest-id-apiname-input', {timeout: Cypress.config().largeTimeout}).type(apiName);
+            cy.get('#itest-id-apicontext-input').type('/' + apiName);
+            cy.get('#itest-id-apiversion-input').type('1.0.0');
+            cy.get('#itest-id-apiendpoint-input').type(`${Utils.getAppOrigin()}/am/sample/${apiName}/v1/api`);
+            cy.get('#itest-id-apiversion-input').click()
+            cy.get('body').click(0,0);
+
+            cy.get('#itest-id-apicreatedefault-createnpublish').click();
+
+            cy.get('[data-testid="itest-api-state"]').contains('PUBLISHED').should('exist');
+
+            cy.url().then(url => {
+                testApiID = /apis\/(.*?)\/overview/.exec(url)[1];
+
+                Utils.deleteAPI(testApiID);
+
+    
+            });
+
+      })
+})

--- a/tests/cypress/integration/publisher/002-api-resources/00-api-resource-create.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/00-api-resource-create.spec.js
@@ -166,8 +166,9 @@ describe("Resource add edit operations", () => {
 
             // Go to local scope page
             cy.visit(`/publisher/apis/${apiId}/scopes/create`);
+            
 
-            cy.wait(2000);
+            cy.wait(3000);
             // Create a local scope
             cy.get('input#name').click({force:true});
             cy.get('input#name').type(scopeName, {force:true});

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -33,7 +33,7 @@ describe("Add assign global scopes for api", () => {
 
   const addApiAndResource = (verb, apiId) => {
     // Typing the resource name
-    cy.visit(`/publisher/apis/${apiId}/resources`);
+    cy.visit(`/publisher/apis/${apiId}/resources`, { timeout: Cypress.config().largeTimeout });
     cy.get('#operation-target').type(target);
     cy.get('body').click();
     cy.get('#add-operation-selection-dropdown').click();
@@ -59,7 +59,7 @@ describe("Add assign global scopes for api", () => {
     Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
         addApiAndResource(verb, apiId);
       //create a global scope
-      cy.visit(`${Cypress.config().baseUrl}/publisher/scopes`);
+      cy.visit(`${Cypress.config().baseUrl}/publisher/scopes`, { timeout: Cypress.config().largeTimeout });
       publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
       cy.wait(5000);
       cy.get('a[href="/publisher/scopes/create"]').click({ force: true });
@@ -82,7 +82,7 @@ describe("Add assign global scopes for api", () => {
       cy.get("tbody").get("tr").contains(scopeName).should("be.visible");
 
       // Go to resources page
-      cy.visit(`/publisher/apis/${apiId}/resources`);
+      cy.visit(`/publisher/apis/${apiId}/resources`, { timeout: Cypress.config().largeTimeout });
 
       // Open the operation sub section
       cy.get(`#${verb}\\${target}`).click();

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -1,20 +1,20 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
- *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+*  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 import Utils from "@support/utils";
 import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
@@ -107,3 +107,4 @@ describe("Add assign global scopes for api", () => {
     });
   });
 });
+

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -107,4 +107,3 @@ describe("Add assign global scopes for api", () => {
     });
   });
 });
-

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -29,37 +29,38 @@ describe("Add assign global scopes for api", () => {
   const role = "internal/publisher";
   const apiName = Utils.generateName();
   const apiVersion = "1.0.0";
-  const target = '/test';
+  const target = "/test";
 
   const addApiAndResource = (verb, apiId) => {
     // Typing the resource name
-    cy.visit(`/publisher/apis/${apiId}/resources`, { timeout: Cypress.config().largeTimeout });
-    cy.get('#operation-target').type(target);
-    cy.get('body').click();
-    cy.get('#add-operation-selection-dropdown').click();
+    cy.visit(`/publisher/apis/${apiId}/resources`, {
+      timeout: Cypress.config().largeTimeout,
+    });
+    cy.get("#operation-target").type(target);
+    cy.get("body").click();
+    cy.get("#add-operation-selection-dropdown").click();
 
     // Checking all the operations
     cy.get(`#add-operation-${verb}`).click();
 
-    cy.get('body').click();
-    cy.get('#add-operation-button').click();
-    cy.get('#resources-save-operations').click();
+    cy.get("body").click();
+    cy.get("#add-operation-button").click();
+    cy.get("#resources-save-operations").click();
 
     // Validating if the resource exists after saving
-    cy.get('#resources-save-operations', { timeout: 30000 });
+    cy.get("#resources-save-operations", { timeout: 30000 });
 
-    cy.get(`#${verb}\\${target}`).should('be.visible');
-}
-
-  
+    cy.get(`#${verb}\\${target}`).should("be.visible");
+  };
 
   it("Add assign global scopes for api", () => {
-
     cy.loginToPublisher(carbonUsername, carbonPassword);
     Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
-        addApiAndResource(verb, apiId);
+      addApiAndResource(verb, apiId);
       //create a global scope
-      cy.visit(`${Cypress.config().baseUrl}/publisher/scopes`, { timeout: Cypress.config().largeTimeout });
+      cy.visit(`${Cypress.config().baseUrl}/publisher/scopes`, {
+        timeout: Cypress.config().largeTimeout,
+      });
       publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
       cy.wait(5000);
       cy.get('a[href="/publisher/scopes/create"]').click({ force: true });
@@ -75,14 +76,18 @@ describe("Add assign global scopes for api", () => {
       cy.get("#description").type(scopeDescription);
 
       cy.get('input[placeholder="Enter roles and press Enter"]').click();
-      cy.get('input[placeholder="Enter roles and press Enter"]').type(`${role}{enter}`);
+      cy.get('input[placeholder="Enter roles and press Enter"]').type(
+        `${role}{enter}`
+      );
 
-      cy.get('button > span').contains("Save").click();
+      cy.get("button > span").contains("Save").click();
 
       cy.get("tbody").get("tr").contains(scopeName).should("be.visible");
 
       // Go to resources page
-      cy.visit(`/publisher/apis/${apiId}/resources`, { timeout: Cypress.config().largeTimeout });
+      cy.visit(`/publisher/apis/${apiId}/resources`, {
+        timeout: Cypress.config().largeTimeout,
+      });
 
       // Open the operation sub section
       cy.get(`#${verb}\\${target}`).click();
@@ -98,10 +103,7 @@ describe("Add assign global scopes for api", () => {
         .contains(scopeName)
         .should("be.visible");
 
-        Utils.deleteAPI(apiId);
+      Utils.deleteAPI(apiId);
     });
-
-    
-
   });
 });

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
+const publisherComonPage = new PublisherComonPage();
+
+describe("Add assign global scopes for api", () => {
+  const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+  const verb = "post";
+  const random_number = Math.floor(Date.now() / 1000);
+  const scopeName = "test" + random_number;
+  const scopeDescription = "test scope description";
+  const role = "internal/publisher";
+  const apiName = Utils.generateName();
+  const apiVersion = "1.0.0";
+  const target = '/test';
+
+  const addApiAndResource = (verb, apiId) => {
+    // Typing the resource name
+    cy.visit(`/publisher/apis/${apiId}/resources`);
+    cy.get('#operation-target').type(target);
+    cy.get('body').click();
+    cy.get('#add-operation-selection-dropdown').click();
+
+    // Checking all the operations
+    cy.get(`#add-operation-${verb}`).click();
+
+    cy.get('body').click();
+    cy.get('#add-operation-button').click();
+    cy.get('#resources-save-operations').click();
+
+    // Validating if the resource exists after saving
+    cy.get('#resources-save-operations', { timeout: 30000 });
+
+    cy.get(`#${verb}\\${target}`).should('be.visible');
+}
+
+  
+
+  it("Add assign global scopes for api", () => {
+
+    cy.loginToPublisher(carbonUsername, carbonPassword);
+    Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
+        addApiAndResource(verb, apiId);
+      //create a global scope
+      cy.visit(`${Cypress.config().baseUrl}/publisher/scopes`);
+      publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
+      cy.wait(5000);
+      cy.get('a[href="/publisher/scopes/create"]').click({ force: true });
+
+      cy.wait(2000);
+      cy.get("input#name").click({ force: true });
+      cy.get("input#name").type(scopeName, { force: true });
+
+      cy.get("#displayName").click();
+      cy.get("#displayName").type(scopeName);
+
+      cy.get("#description").click();
+      cy.get("#description").type(scopeDescription);
+
+      cy.get('input[placeholder="Enter roles and press Enter"]').click();
+      cy.get('input[placeholder="Enter roles and press Enter"]').type(`${role}{enter}`);
+
+      cy.get('button > span').contains("Save").click();
+
+      cy.get("tbody").get("tr").contains(scopeName).should("be.visible");
+
+      // Go to resources page
+      cy.visit(`/publisher/apis/${apiId}/resources`);
+
+      // Open the operation sub section
+      cy.get(`#${verb}\\${target}`).click();
+      cy.get(`#${verb}\\${target}-operation-scope-select`, { timeout: 3000 });
+      cy.get(`#${verb}\\${target}-operation-scope-select`).click();
+      cy.get(`[data-value=${scopeName}]`).click();
+      cy.get(`[data-value=${scopeName}]`).type("{esc}");
+      // // Save the resources
+      cy.get("#resources-save-operations").click();
+
+      cy.get("#resources-save-operations", { timeout: 30000 });
+      cy.get(`#${verb}\\${target}-operation-scope-select`)
+        .contains(scopeName)
+        .should("be.visible");
+
+        Utils.deleteAPI(apiId);
+    });
+
+    
+
+  });
+});

--- a/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
+++ b/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
@@ -30,7 +30,7 @@ describe("Add tags for the api", () => {
 
   it("Add tags for the api", () => {
     Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
-      cy.visit(`/publisher/apis/${apiId}/overview`);
+      cy.visit(`/publisher/apis/${apiId}/overview`, { timeout: Cypress.config().largeTimeout });
       cy.get("#itest-api-details-portal-config-acc").click();
       cy.get("#left-menu-itemDesignConfigurations").click();
 

--- a/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
+++ b/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -21,7 +21,7 @@ import Utils from "@support/utils";
 describe("Add tags for the api", () => {
   const { publisher, password } = Utils.getUserInfo();
   const apiName = Utils.generateName();
-  const apiVersion = '1.0.0';
+  const apiVersion = "1.0.0";
   const tagName = "test";
 
   before(function () {
@@ -30,7 +30,9 @@ describe("Add tags for the api", () => {
 
   it("Add tags for the api", () => {
     Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
-      cy.visit(`/publisher/apis/${apiId}/overview`, { timeout: Cypress.config().largeTimeout });
+      cy.visit(`/publisher/apis/${apiId}/overview`, {
+        timeout: Cypress.config().largeTimeout,
+      });
       cy.get("#itest-api-details-portal-config-acc").click();
       cy.get("#left-menu-itemDesignConfigurations").click();
 

--- a/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
+++ b/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("Add tags for the api", () => {
+  const { publisher, password } = Utils.getUserInfo();
+  const apiName = Utils.generateName();
+  const apiVersion = '1.0.0';
+  const tagName = "test";
+
+  before(function () {
+    cy.loginToPublisher(publisher, password);
+  });
+
+  it("Add tags for the api", () => {
+    Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
+      cy.visit(`/publisher/apis/${apiId}/overview`);
+      cy.get("#itest-api-details-portal-config-acc").click();
+      cy.get("#left-menu-itemDesignConfigurations").click();
+
+      cy.get("#tags").click();
+      cy.get("#tags").type(`${tagName}{enter}`);
+
+      cy.get("#design-config-save-btn").scrollIntoView().click();
+      cy.get("#design-config-save-btn").then(function () {
+        cy.get('div[role="button"] span').contains(tagName).should("exist");
+      });
+
+      Utils.deleteAPI(apiId);
+    });
+  });
+});

--- a/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
+++ b/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
@@ -1,20 +1,20 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
- *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+*  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 import Utils from "@support/utils";
 
@@ -48,3 +48,4 @@ describe("Add tags for the api", () => {
     });
   });
 });
+

--- a/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
+++ b/tests/cypress/integration/publisher/005-design-config/03-add-tags-for-the-api.spec.js
@@ -48,4 +48,3 @@ describe("Add tags for the api", () => {
     });
   });
 });
-

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -117,4 +117,3 @@ describe("Depricate old versions of api before publishing", () => {
     );
   });
 });
-

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
+const publisherComonPage = new PublisherComonPage();
+
+describe("Depricate old versions of api before publishing", () => {
+  const { publisher, password } = Utils.getUserInfo();
+  const apiName = Utils.generateName().replace("-", "_");
+  const apiVersion = "1.0.0";
+  const newVersion = "2.0.0";
+
+  const deployeandPublish = (apiId) => {
+    // Going to deployments page
+    cy.get("#left-menu-itemdeployments").click();
+
+    // Deploying
+    cy.wait(5000);
+    cy.get("#add-description-btn").click();
+    cy.get("#add-description").click();
+    cy.get("#add-description").type("test");
+    cy.wait(2000);
+    cy.get("#deploy-btn", { timeout: Cypress.config().largeTimeout })
+      .should("not.have.class", "Mui-disabled")
+      .click();
+    cy.wait(2000);
+    cy.get("#undeploy-btn")
+      .should("not.have.class", "Mui-disabled")
+      .should("exist");
+
+    // Going to lifecycle page
+  };
+
+  before(function () {
+    cy.loginToPublisher(publisher, password);
+  });
+
+  it.only("Depricate old versions of api before publishing", () => {
+    Utils.addAPIWithEndpoints({ name: apiName, version: apiVersion }).then(
+      (apiId) => {
+        cy.visit(`/publisher/apis/${apiId}/overview`, {timeout: Cypress.config().largeTimeout});
+        cy.get("#itest-api-details-portal-config-acc").click();
+        cy.get("#left-menu-itemsubscriptions").click();
+        cy.get('[data-testid="policy-checkbox-silver"]').click();
+        cy.get("#subscriptions-save-btn").click();
+
+        // Going to deployments page and publish
+        deployeandPublish(apiId);
+        cy.get("#left-menu-itemlifecycle").click();
+        cy.wait(2000);
+        cy.get('[data-testid="Publish-btn"]').click();
+
+        //create new version
+        cy.get("#create-new-version-btn").click();
+        cy.wait(3000);
+        cy.get("#newVersion").type(newVersion);
+        cy.intercept("**/apis/**").as("apiGet");
+        cy.get("#createBtn", { timeout: 30000 }).click();
+        cy.get("#itest-api-name-version", { timeout: 30000 }).should(
+          "be.visible"
+        );
+        cy.wait(2000);
+        cy.get("#itest-api-name-version").contains(`${apiName} :${newVersion}`);
+
+        cy.url().then((url) => {
+          const newAPIid = url.split("/")[5];
+
+          deployeandPublish(newAPIid);
+
+          //depricate old version
+          cy.get("#left-menu-itemlifecycle").click();
+          cy.wait(2000);
+          cy.get('[type="checkbox"]').check(
+            "Deprecate old versions after publishing the API"
+          );
+          cy.get(
+            'input[value="Deprecate old versions after publishing the API"]'
+          ).should("be.checked");
+          cy.get('[data-testid="Publish-btn"]').click();
+
+          cy.visit(`/publisher/apis`, {
+            timeout: Cypress.config().largeTimeout,
+          });
+          publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
+          cy.get("#searchQuery").type(apiName).type("{enter}");
+          cy.wait(10000);
+          cy.get(`div[data-testid="card-action-${apiName}1.0.0"]`, {
+            timeout: Cypress.config().largeTimeout,
+          }).click();
+          cy.wait(3000);
+          cy.get(`div[data-testid="card-action-${apiName}1.0.0"]>div>span`, {
+            timeout: Cypress.config().largeTimeout,
+          })
+            .contains("DEPRECATED")
+            .should("exist");
+
+            Utils.deleteAPI(apiId);
+            Utils.deleteAPI(newAPIid);
+        });
+      }
+    );
+  });
+});

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -26,7 +26,7 @@ describe("Depricate old versions of api before publishing", () => {
   const apiVersion = "1.0.0";
   const newVersion = "2.0.0";
 
-  const deployeandPublish = (apiId) => {
+  const deployandPublish = (apiId) => {
     // Going to deployments page
     cy.get("#left-menu-itemdeployments").click();
 
@@ -44,7 +44,6 @@ describe("Depricate old versions of api before publishing", () => {
       .should("not.have.class", "Mui-disabled")
       .should("exist");
 
-    // Going to lifecycle page
   };
 
   before(function () {
@@ -54,14 +53,16 @@ describe("Depricate old versions of api before publishing", () => {
   it.only("Depricate old versions of api before publishing", () => {
     Utils.addAPIWithEndpoints({ name: apiName, version: apiVersion }).then(
       (apiId) => {
-        cy.visit(`/publisher/apis/${apiId}/overview`, {timeout: Cypress.config().largeTimeout});
+        cy.visit(`/publisher/apis/${apiId}/overview`, {
+          timeout: Cypress.config().largeTimeout,
+        });
         cy.get("#itest-api-details-portal-config-acc").click();
         cy.get("#left-menu-itemsubscriptions").click();
         cy.get('[data-testid="policy-checkbox-silver"]').click();
         cy.get("#subscriptions-save-btn").click();
 
         // Going to deployments page and publish
-        deployeandPublish(apiId);
+        deployandPublish(apiId);
         cy.get("#left-menu-itemlifecycle").click();
         cy.wait(2000);
         cy.get('[data-testid="Publish-btn"]').click();
@@ -81,7 +82,7 @@ describe("Depricate old versions of api before publishing", () => {
         cy.url().then((url) => {
           const newAPIid = url.split("/")[5];
 
-          deployeandPublish(newAPIid);
+          deployandPublish(newAPIid);
 
           //depricate old version
           cy.get("#left-menu-itemlifecycle").click();
@@ -94,7 +95,9 @@ describe("Depricate old versions of api before publishing", () => {
           ).should("be.checked");
           cy.get('[data-testid="Publish-btn"]').click();
 
-          cy.visit(`/publisher/apis`, { timeout: Cypress.config().largeTimeout });
+          cy.visit(`/publisher/apis`, {
+            timeout: Cypress.config().largeTimeout,
+          });
           publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
           cy.get("#searchQuery").type(apiName).type("{enter}");
           cy.wait(10000);
@@ -108,8 +111,8 @@ describe("Depricate old versions of api before publishing", () => {
             .contains("DEPRECATED")
             .should("exist");
 
-            Utils.deleteAPI(apiId);
-            Utils.deleteAPI(newAPIid);
+          Utils.deleteAPI(apiId);
+          Utils.deleteAPI(newAPIid);
         });
       }
     );

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -94,9 +94,7 @@ describe("Depricate old versions of api before publishing", () => {
           ).should("be.checked");
           cy.get('[data-testid="Publish-btn"]').click();
 
-          cy.visit(`/publisher/apis`, {
-            timeout: Cypress.config().largeTimeout,
-          });
+          cy.visit(`/publisher/apis`, { timeout: Cypress.config().largeTimeout });
           publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
           cy.get("#searchQuery").type(apiName).type("{enter}");
           cy.wait(10000);

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -43,7 +43,6 @@ describe("Depricate old versions of api before publishing", () => {
     cy.get("#undeploy-btn")
       .should("not.have.class", "Mui-disabled")
       .should("exist");
-
   };
 
   before(function () {
@@ -118,3 +117,4 @@ describe("Depricate old versions of api before publishing", () => {
     );
   });
 });
+

--- a/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
+++ b/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
+++ b/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
@@ -71,4 +71,3 @@ describe("add nested comments", () => {
     Utils.deleteAPI(testApiId);
   });
 });
-

--- a/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
+++ b/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -55,16 +55,17 @@ describe("add nested comments", () => {
       });
 
       // Deleting the comment
-        cy.get("#comment-list").within(() => {
-           cy.get("button > span").contains("Delete").click();
-            cy.intercept('DELETE', '**/comments/**').as('deleteComment')
-        })    
-            cy.get('div[role="dialog"]').find('button > span').contains('Yes').click()
-            cy.wait('@deleteComment', { timeout: 30000 })
-   
-       
+      cy.get("#comment-list").within(() => {
+        cy.get("button > span").contains("Delete").click();
+        cy.intercept("DELETE", "**/comments/**").as("deleteComment");
+      });
+      cy.get('div[role="dialog"]')
+        .find("button > span")
+        .contains("Yes")
+        .click();
+      cy.wait("@deleteComment", { timeout: 30000 });
 
-        cy.get("#comment-list").contains(comment).should("not.exist");
+      cy.get("#comment-list").contains(comment).should("not.exist");
     });
 
     Utils.deleteAPI(testApiId);

--- a/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
+++ b/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("add nested comments", () => {
+  const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+  let testApiId;
+
+  beforeEach(function () {
+    cy.loginToPublisher(carbonUsername, carbonPassword);
+  });
+
+  it.only("Add nested comments to to the api", () => {
+    const comment = "test_1";
+    const reply = "test_2";
+    Utils.addAPI({}).then((apiId) => {
+      testApiId = apiId;
+      cy.intercept("**/comments?limit=5&offset=0").as("commentsGet");
+      cy.visit(`/publisher/apis/${apiId}/comments`);
+      cy.wait("@commentsGet", { timeout: 50000 }).then(() => {
+        cy.get("#standard-multiline-flexible", {
+          timeout: Cypress.config().largeTimeout,
+        }).click({ force: true });
+        cy.wait(3000);
+        cy.get("#standard-multiline-flexible").type(comment);
+        cy.get("#add-comment-btn").click();
+
+        // Checking it's existence
+        cy.get("#comment-list").contains(comment).should("be.visible");
+
+        // Adding a reply
+        cy.get("button > span").contains("Reply").click();
+        cy.get("#comment-list").within(() => {
+          cy.get("#standard-multiline-flexible").click();
+          cy.get("#standard-multiline-flexible").type(reply);
+          cy.get("#add-comment-btn").click({ force: true });
+        });
+        cy.get("#comment-list").contains(reply).should("be.visible");
+      });
+
+      // Deleting the comment
+        cy.get("#comment-list").within(() => {
+           cy.get("button > span").contains("Delete").click();
+            cy.intercept('DELETE', '**/comments/**').as('deleteComment')
+        })    
+            cy.get('div[role="dialog"]').find('button > span').contains('Yes').click()
+            cy.wait('@deleteComment', { timeout: 30000 })
+   
+       
+
+        cy.get("#comment-list").contains(comment).should("not.exist");
+    });
+
+    Utils.deleteAPI(testApiId);
+  });
+});

--- a/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
+++ b/tests/cypress/integration/publisher/014-comments/01-add-nested-comments-to-api.spec.js
@@ -1,20 +1,20 @@
 /*
- *  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
- *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+*  Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 import Utils from "@support/utils";
 
@@ -71,3 +71,4 @@ describe("add nested comments", () => {
     Utils.deleteAPI(testApiId);
   });
 });
+


### PR DESCRIPTION
Following test cases are added to the test suite

04-depricate-old-versions.spec.js
02-add-assign-global-scopes-for-api.spec.js
03-add-tags-for-the-api.spec.js
01-add-nested-comments-to-api.spec.js

