### PR TITLE
Fix: Display of API Documents

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/Documents.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/Documents.jsx
@@ -159,7 +159,7 @@ function Documents(props) {
         const promisedApi = restApi.getDocumentsByAPIId(apiId);
         promisedApi
             .then((response) => {
-                const overviewDoc = response.body.list.filter((item) => item.otherTypeName !== '_overview');
+                const overviewDoc = response.body.list.filter((item) => item.otherTypeName !== 'overview');
                 if (api.type === 'HTTP') {
                     const swaggerDoc = { documentId: 'default', name: 'Default', type: '' };
                     overviewDoc.unshift(swaggerDoc);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/View.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/View.jsx
@@ -191,7 +191,7 @@ function View(props) {
     };
     return (
         <>
-            {(doc.summary && doc.otherTypeName !== '_overview') && (
+            {(doc.summary && doc.otherTypeName !== 'overview') && (
                 <Typography variant='body1' className={classes.docSummary}>
                     {doc.summary}
                 </Typography>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Overview.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Overview.jsx
@@ -222,7 +222,7 @@ function Overview() {
         const restApi = new API();
         return restApi.getDocumentsByAPIId(api.id)
             .then((response) => {
-                const overviewDoc = response.body.list.filter((item) => item.otherTypeName === '_overview');
+                const overviewDoc = response.body.list.filter((item) => item.otherTypeName === 'overview');
                 if (overviewDoc.length > 0) {
                     // We can override the UI with this content
                     setOverviewDocOverride(overviewDoc[0]); // Only one doc we can render

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Listing.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Listing.jsx
@@ -167,7 +167,7 @@ class Listing extends React.Component {
             const apiProduct = new APIProduct();
             const docs = apiProduct.getDocuments(api.id);
             docs.then((response) => {
-                const documentList = response.body.list.filter((item) => item.otherTypeName !== '_overview');
+                const documentList = response.body.list.filter((item) => item.otherTypeName !== 'overview');
                 documentList.sort(getSortOrder('name'));
                 this.setState({ docs: documentList });
             }).catch((errorResponse) => {
@@ -184,7 +184,7 @@ class Listing extends React.Component {
             const newApi = new API();
             const docs = newApi.getDocuments(api.id);
             docs.then((response) => {
-                const documentList = response.body.list.filter((item) => item.otherTypeName !== '_overview');
+                const documentList = response.body.list.filter((item) => item.otherTypeName !== 'overview');
                 documentList.sort(getSortOrder('name'));
                 this.setState({ docs: documentList });
             }).catch((errorResponse) => {


### PR DESCRIPTION
Fixes [Issue#12863](https://github.com/wso2/product-apim/issues/12863)
When we create API documents with **other Type=_overview.** 
Behavior on devportal and publisher portal of wso2 apim: 
**On publisher portal:** Document not getting listed on publisher portal.
**On devportal :** Content of document(other type=_overview) display in overview of published API as shown in below image.

![ApiOverview](https://github.com/wso2/apim-apps/assets/94599733/93b2f5db-9434-4309-80de-159ae1128d49)


