### PR TITLE
Uncheck and disable http checkbox when Mutual SSL is enabled

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -149,6 +149,20 @@ function TransportLevel(props) {
         });
     };
 
+    const handleMutualSSLChange = (event) => {
+        const { checked } = event.target;
+        if (checked) {
+            configDispatcher({
+                action: 'transport',
+                event: { checked: false, value: 'http' },
+            });
+        }
+        configDispatcher({
+            action: 'securityScheme',
+            event: { checked, value: API_SECURITY_MUTUAL_SSL },
+        });
+    };
+
     // Get the client certificates from backend.
     useEffect(() => {
         API.getAllClientCertificates(id).then((resp) => {
@@ -192,11 +206,7 @@ function TransportLevel(props) {
                                 <Checkbox
                                     disabled={isRestricted(['apim:api_create'], apiFromContext)}
                                     checked={isMutualSSLEnabled}
-                                    onChange={({ target: { checked, value } }) => configDispatcher({
-                                        action: 'securityScheme',
-                                        event: { checked, value },
-                                    })}
-                                    value={API_SECURITY_MUTUAL_SSL}
+                                    onChange={handleMutualSSLChange}
                                     color='primary'
                                     id='mutual-ssl-checkbox'
                                 />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -84,9 +84,9 @@ export default function Transports(props) {
                         <FormControlLabel
                             control={(
                                 <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                    disabled={isRestricted(['apim:api_create'], apiFromContext) || isMutualSSLEnabled}
                                     checked={api.transport
-                                        ? api.transport.includes('http') : null}
+                                        ? api.transport.includes('http') && !isMutualSSLEnabled : null}
                                     onChange={({ target: { checked } }) => configDispatcher({
                                         action: 'transport',
                                         event: { checked, value: 'http' },


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/2202

### Description

- According to the expected behaviour of the APIM if a user enable Mutual SSL in transport level security for an API, they could not use HTTP for that API. However in the publisher portal UI, users were able to select http even though Mutual SSL is enabled.
- In this PR HTTP checkbox will be unchecked and disabled if an user decided to enable Mutual SSL.