### PR TITLE
Fixed publish button is disabled when only mutual ssl is enabled

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -277,6 +277,8 @@ class LifeCycleUpdate extends Component {
         lcMap.set('Created', 'Create');
         lcMap.set('Retired', 'Retire');
         const isMutualSSLEnabled = api.securityScheme.includes(API_SECURITY_MUTUAL_SSL_MANDATORY);
+        const isMutualSslOnly = api.securityScheme.length === 2 && api.securityScheme.includes('mutualssl')
+            && api.securityScheme.includes(API_SECURITY_MUTUAL_SSL_MANDATORY);
         const isAppLayerSecurityMandatory = api.securityScheme.includes(
             API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY,
         );
@@ -297,7 +299,7 @@ class LifeCycleUpdate extends Component {
             }
             if (lifecycleState.event === 'Publish') {
                 const buttonDisabled = (isMutualSSLEnabled && !isCertAvailable)
-                                    || (deploymentsAvailable && !isBusinessPlanAvailable)
+                                    || (!isMutualSslOnly && deploymentsAvailable && !isBusinessPlanAvailable)
                                     || (isAPIProduct && !isBusinessPlanAvailable)
                                     || (deploymentsAvailable && !isMandatoryPropertiesAvailable);
                 // When business plans are not assigned and deployments available


### PR DESCRIPTION
## Problem
The users can create an API-only MTLS, but the user can't publish it through the Lifecycle tab. User can publish the API through the Overview page only.  

## Approach
Added an additional condition to check the isMutualSslOnly status.

Related Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/4586
Fix is taken from:
https://github.com/wso2-support/apim-apps/blob/support-9.0.432.x-full/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx#L375

