### PR TITLE
Filtering subscriptions based on subscriber by textbox filtertype

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionsTable.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionsTable.jsx
@@ -742,6 +742,7 @@ class SubscriptionsTable extends Component {
                 ),
                 options: {
                     sort: false,
+                    filterType: 'textField',
                     customBodyRender: (value, tableMeta) => {
                         if (tableMeta.rowData) {
                             let claimsObject;


### PR DESCRIPTION
## Purpose
> Subscriptions in the publisher menu can be filtered by subscriber names through an MUIDataTable. When there is a large number of subscriptions in the same page, there needs to be an option of filtering by a textbox filtertype.

## Resolves
> https://github.com/wso2/api-manager/issues/2249

