### PR TITLE
Changes spaces to hyphens in space included urls and Sets validation errors to empty array when url is valid

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
@@ -127,6 +127,7 @@ export default function ProvideOpenAPI(props) {
                     info.content = content;
                     inputsDispatcher({ action: 'preSetAPI', value: info });
                     setValidity({ ...isValid, url: null });
+                    setValidationErrors([]);
                 } else {
                     setValidity({ ...isValid, url: { message: 'OpenAPI content validation failed!' } });
                     setValidationErrors(errors);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APISecurityAudit.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APISecurityAudit.jsx
@@ -192,7 +192,7 @@ class APISecurityAudit extends Component {
                     id: 'Apis.Details.APIDefinition.AuditApi.GetReportError',
                     defaultMessage: 'Something went wrong while retrieving the API Security Report',
                 }));
-                const redirectUrl = '/apis/' + apiId + '/api definition';
+                const redirectUrl = '/apis/' + apiId + '/api-definition';
                 history.push(redirectUrl);
             });
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/GoToDefinitionLink.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/GoToDefinitionLink.jsx
@@ -43,7 +43,7 @@ export default function GoToDefinitionLink(props) {
     const classes = useStyles();
     return (
         <Box m={1}>
-            <Link to={`/apis/${api.id}/api definition`}>
+            <Link to={`/apis/${api.id}/api-definition`}>
                 <Typography className={classes.link} variant='caption'>
                     {message}
                     <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
@@ -173,7 +173,7 @@ export default function DevelopSectionMenu(props) {
                                 id: 'Apis.Details.index.business.info',
                                 defaultMessage: 'business info',
                             })}
-                            to={pathPrefix + 'business info'}
+                            to={pathPrefix + 'business-info'}
                             Icon={<BusinessIcon />}
                             id='left-menu-itembusinessinfo'
                         />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -376,7 +376,7 @@ class Details extends Component {
                     defaultMessage: 'API definition',
                 })}
                 route='api definition'
-                to={pathPrefix + 'api definition'}
+                to={pathPrefix + 'api-definition'}
                 Icon={<CodeIcon />}
                 id='left-menu-itemAPIdefinition'
             />
@@ -1017,9 +1017,9 @@ Details.subPaths = {
     BASE_PRODUCT: '/api-products/:apiprod_uuid',
     OVERVIEW: '/apis/:api_uuid/overview',
     OVERVIEW_PRODUCT: '/api-products/:apiprod_uuid/overview',
-    API_DEFINITION: '/apis/:api_uuid/api definition',
+    API_DEFINITION: '/apis/:api_uuid/api-definition',
     WSDL: '/apis/:api_uuid/wsdl',
-    API_DEFINITION_PRODUCT: '/api-products/:apiprod_uuid/api definition',
+    API_DEFINITION_PRODUCT: '/api-products/:apiprod_uuid/api-definition',
     SCHEMA_DEFINITION: '/apis/:api_uuid/schema definition',
     LIFE_CYCLE: '/apis/:api_uuid/lifecycle',
     LIFE_CYCLE_PRODUCT: '/api-products/:apiprod_uuid/lifecycle',
@@ -1042,8 +1042,8 @@ Details.subPaths = {
     SUBSCRIPTIONS: '/apis/:api_uuid/subscriptions',
     SECURITY: '/apis/:api_uuid/security',
     COMMENTS: '/apis/:api_uuid/comments',
-    BUSINESS_INFO: '/apis/:api_uuid/business info',
-    BUSINESS_INFO_PRODUCT: '/api-products/:apiprod_uuid/business info',
+    BUSINESS_INFO: '/apis/:api_uuid/business-info',
+    BUSINESS_INFO_PRODUCT: '/api-products/:apiprod_uuid/business-info',
     PROPERTIES: '/apis/:api_uuid/properties',
     PROPERTIES_PRODUCT: '/api-products/:apiprod_uuid/properties',
     NEW_VERSION: '/apis/:api_uuid/new_version',


### PR DESCRIPTION
## Purpose
Issue #2274: Throwing the 500 response when refreshing the API definition page and Business info section in the Publisher - APIM 4.2.0
Issue #2273: Previous validation errors are showing for valid API definition - APIM 4.2.0 publisher

## Overview

Issue #2274: 
When refreshing pages with space included urls, urlmalformed error is thrown as below.
```
ERROR - AuthenticationValve Error while normalizing the request URI to process the authentication: 
java.net.URISyntaxException: Illegal character in path at index 61: /publisher/apis/950a0b1a-91b4-404d-8f8b-bbdd144bb1e8/business info
	at java.net.URI$Parser.fail(URI.java:2913) ~[?:?]
	at java.net.URI$Parser.checkChars(URI.java:3084) ~[?:?]
	at java.net.URI$Parser.parseHierarchical(URI.java:3166) ~[?:?]
	at java.net.URI$Parser.parse(URI.java:3125) ~[?:?]
	at java.net.URI.<init>(URI.java:600) ~[?:?]
	at org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.getNormalizedRequestURI(AuthConfigurationUtil.java:346) ~[org.wso2.carbon.identity.auth.service_1.7.1.2.jar:?]
```

Issue #2273: Swagger validation errors which was thrown previously was seen even after adding a correct swagger URL.


## Resolves
https://github.com/wso2/api-manager/issues/2274
https://github.com/wso2/api-manager/issues/2273