### PR TITLE
Add spectralFunc.schema config to swagger linter

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
@@ -53,6 +53,7 @@ const spectralFunctions: { [key: string]: any} = {
     "undefined": spectralFunc.undefined,
     "unreferencedReusableObject": spectralFunc.unreferencedReusableObject,
     "xor": spectralFunc.xor,
+    "schema": spectralFunc.schema,
 }
 
 export const spectralSeverityMap: { [key: number]: JSX.Element } = {


### PR DESCRIPTION
## Purpose
Fixing : https://github.com/wso2/api-manager/issues/2335
Add `"schema": spectralFunc.schema` to `spectralFunctions` in linter.
