### PR TITLE
Fixing Limited view of subscription policies in Publisher portal issue

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
@@ -29,6 +29,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Paper from '@material-ui/core/Paper';
 import API from 'AppData/api';
 import { isRestricted } from 'AppData/AuthManager';
+import Configurations from 'Config';
 
 const styles = (theme) => ({
     subscriptionPoliciesPaper: {
@@ -61,7 +62,15 @@ class SubscriptionPoliciesManage extends Component {
     componentDidMount() {
         const { api } = this.props;
         const isAsyncAPI = (api.type === 'WS' || api.type === 'WEBSUB' || api.type === 'SSE' || api.type === 'ASYNC');
-        const policyPromise = isAsyncAPI ? API.asyncAPIPolicies() : API.policies('subscription');
+        const limit = Configurations.app.subscriptionPolicyLimit;
+        let policyPromise;
+        if (isAsyncAPI) {
+            policyPromise = API.asyncAPIPolicies();
+        } else if (limit) {
+            policyPromise = API.policies('subscription', limit);
+        } else {
+            policyPromise = API.policies('subscription');
+        }
         policyPromise
             .then((res) => {
                 this.setState({ subscriptionPolicies: res.body.list });


### PR DESCRIPTION
## Problem
When the subscription policies count is higher than 25, the admin portal shows the entire policies (example 40 policies) but publisher portal limit it to 25. 

## Approach
Added a new config property as `subscriptionPolicyLimit` to the settings.js.

Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/4446
Related PR: https://github.com/wso2-support/carbon-apimgt/pull/6163

If the user wants to change the maximum number of subscription policies to be displayed in the publisher portal,  User can add `subscriptionPolicyLimit` property in the `repository/deployment/server/jaggeryapps/publisher/site/public/conf/settings.js` file.
Ex- subscriptionPolicyLimit: 80
