### PR TITLE
Exclude paxlogging dependencies from the webapp libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,16 @@
                 <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
                 <version>${carbon.apimgt.imp.pkg.version.range}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-log4j2</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->
             <dependency>


### PR DESCRIPTION
This PR will exclude following dependencies from admin, publisher and devportal webapp lib folders.

- pax-logging-log4j2-1.11.10.jar
- pax-logging-api-1.11.10.jar    
- osgi.cmpn-6.0.0.jar        
- osgi.core-6.0.0.jar        