### PR TITLE
Remove domain(@carbon.super) of logged-in username when there is an external IDP

### DIFF
--- a/portals/publisher/src/main/java/org/wso2/carbon/apimgt/ui/publisher/Util.java
+++ b/portals/publisher/src/main/java/org/wso2/carbon/apimgt/ui/publisher/Util.java
@@ -149,6 +149,15 @@ public class Util {
         }
     }
 
+    public static boolean isEnableEmailUserName() {
+        boolean isEnableEmailUserName = Boolean.parseBoolean(CarbonUtils.getServerConfiguration().getFirstProperty("EnableEmailUserName"));
+        if (isEnableEmailUserName) {
+            return isEnableEmailUserName;
+        } else {
+            return false;
+        }
+    }
+
     /**
      * Deciding what to process as app context. <br>
      * If the settings.json has the following definition, <br><br>

--- a/portals/publisher/src/main/webapp/services/login/introspect.jsp
+++ b/portals/publisher/src/main/webapp/services/login/introspect.jsp
@@ -73,7 +73,15 @@
     log.debug("Introspection result json: " + introspectResult.body());
 
     if (introspectResult.statusCode() == 200) {
+        boolean isEnableEmailUserName = Util.isEnableEmailUserName();
         Map introspect = gson.fromJson(introspectResult.body(), Map.class);
+        String username = (String) introspect.get("username");
+        Pattern regPattern = Pattern.compile("(@)");
+        boolean found = regPattern.matcher(username).find();
+        int count = !found ? 0 : (int) username.chars().filter(ch -> ch == '@').count();
+        if (isEnableEmailUserName || (username.indexOf("@carbon.super") > 0 && count <= 1)) {
+            introspect.put("username", username.replace("@carbon.super", ""));
+        }
         response.setContentType("application/json");
         out.println(gson.toJson(introspect));
     } else {


### PR DESCRIPTION
## Purpose

- Domain name (@carbon.super) of logged in username cannot be omitted in the Publisher Portal when there is an external IDP.
- Fixes https://github.com/wso2/api-manager/issues/2308.

## Approach
- Added `isEnableEmailUserName = Util.isEnableEmailUserName();` method to utils.js to fetch whether the email user name is enabled or not
- Based on that, `@carbon.super` part is removed with the introspect call.