### PR TITLE
Bump REST API versions for 4.3.0

### DIFF
--- a/portals/admin/src/main/webapp/services/constants.jsp
+++ b/portals/admin/src/main/webapp/services/constants.jsp
@@ -18,7 +18,7 @@
 
 <%
     //  TODO: Wrap these consts with an object and do `require` when needed ~tmkb
-    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/admin/v4/settings";
+    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/admin/v5/settings";
     String DCR_URL_SUFFIX = "/client-registration/v0.17/register";
     String AUTHORIZE_ENDPOINT_SUFFIX = "/oauth2/authorize";
     String OIDC_LOGOUT_ENDPOINT_SUFFIX = "/oidc/logout";

--- a/portals/admin/src/main/webapp/source/dev/auth_login.js
+++ b/portals/admin/src/main/webapp/source/dev/auth_login.js
@@ -27,7 +27,7 @@ function oauthAppCache(data) {
  *
  */
 async function getSettings() {
-    const res = await fetch('https://localhost:9443/api/am/admin/v4/settings', { agent });
+    const res = await fetch('https://localhost:9443/api/am/admin/v5/settings', { agent });
     const data = await res.json();
     return data;
 }

--- a/portals/admin/src/main/webapp/source/src/app/data/Utils.js
+++ b/portals/admin/src/main/webapp/source/src/app/data/Utils.js
@@ -345,7 +345,7 @@ Utils.CONST = {
 
     LOGOUT_CALLBACK: '/services/auth/callback/logout',
     INTROSPECT: '/services/auth/introspect',
-    SWAGGER_JSON: '/api/am/admin/v4/swagger.yaml',
+    SWAGGER_JSON: '/api/am/admin/v5/swagger.yaml',
     PROTOCOL: 'https://',
 };
 

--- a/portals/devportal/src/main/webapp/services/constants.jsp
+++ b/portals/devportal/src/main/webapp/services/constants.jsp
@@ -18,7 +18,7 @@
 
 <%
     String MGT_TRANSPORT = "https://";
-    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/devportal/v3/settings";
+    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/devportal/v4/settings";
     String DCR_URL_SUFFIX = "/client-registration/v0.17/register";
     String AUTHORIZE_ENDPOINT_SUFFIX = "/oauth2/authorize";
     String OIDC_LOGOUT_ENDPOINT_SUFFIX = "/oidc/logout";

--- a/portals/devportal/src/main/webapp/source/dev/webpack/auth_login.js
+++ b/portals/devportal/src/main/webapp/source/dev/webpack/auth_login.js
@@ -28,7 +28,7 @@ function oauthAppCache(data) {
  *
  */
 async function getSettings() {
-    const res = await fetch('https://localhost:9443/api/am/devportal/v3/settings', { agent });
+    const res = await fetch('https://localhost:9443/api/am/devportal/v4/settings', { agent });
     const data = await res.json();
     return data;
 }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -638,7 +638,7 @@ class ApiConsole extends React.Component {
                                     placement='top'
                                 >
                                     <CopyToClipboard
-                                        text={location.origin + '/api/am/devportal/v3/apis/' + api.id + '/swagger?accessToken='
+                                        text={location.origin + '/api/am/devportal/v4/apis/' + api.id + '/swagger?accessToken='
                                         + accessTokenPart + '&X-WSO2-Tenant-Q=' + tenant + '&' + selectedAttribute + '='
                                         + selectedEnvironment}
                                         onCopy={this.onCopy}

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/SourceDownload.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/SourceDownload.jsx
@@ -239,7 +239,7 @@ function SourceDownload(props) {
                     placement='top'
                 >
                     <CopyToClipboard
-                        text={location.origin + '/api/am/devportal/v3/apis/' + api.id
+                        text={location.origin + '/api/am/devportal/v4/apis/' + api.id
                         + '/swagger?accessToken=' + accessTokenPart + '&X-WSO2-Tenant-Q='
                         + tenant + '&environmentName='
                         + selectedEndpoint.environmentName}

--- a/portals/devportal/src/main/webapp/source/src/app/data/Utils.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/Utils.jsx
@@ -330,7 +330,7 @@ Utils.CONST = {
     LOGIN_SIGN_UP_PATH: '/login/signup',
 
     LOGOUT_CALLBACK: '/services/auth/callback/logout',
-    SWAGGER_YAML: '/api/am/devportal/v3/swagger.yaml',
+    SWAGGER_YAML: '/api/am/devportal/v4/swagger.yaml',
     PROTOCOL: 'https://',
 };
 

--- a/portals/publisher/src/main/webapp/openapitools.json
+++ b/portals/publisher/src/main/webapp/openapitools.json
@@ -7,7 +7,7 @@
       "Publisher": {
         "generatorName": "typescript-axios",
         "glob": "",
-        "context": "/api/am/publisher/v4",
+        "context": "/api/am/publisher/v5",
         "inputSpec": "https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml",
         "output": "#{cwd}../../src/types/generated/Publisher",
         "additionalProperties": {

--- a/portals/publisher/src/main/webapp/services/constants.jsp
+++ b/portals/publisher/src/main/webapp/services/constants.jsp
@@ -17,7 +17,7 @@
 --%>
 
 <%
-    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/publisher/v4/settings";
+    String SETTINGS_REST_API_URL_SUFFIX = "/api/am/publisher/v5/settings";
     String SERVICE_CATALOG_SETTINGS_REST_API_URL_SUFFIX = "/api/am/service-catalog/v1/settings";
     String DCR_URL_SUFFIX = "/client-registration/v0.17/register";
     String AUTHORIZE_ENDPOINT_SUFFIX = "/oauth2/authorize";

--- a/portals/publisher/src/main/webapp/services/dev_proxy/auth_login.js
+++ b/portals/publisher/src/main/webapp/services/dev_proxy/auth_login.js
@@ -29,7 +29,7 @@ function oauthAppCache(data) {
  *
  */
 async function getSettings() {
-    const res = await fetch('https://localhost:9443/api/am/publisher/v4/settings', { agent });
+    const res = await fetch('https://localhost:9443/api/am/publisher/v5/settings', { agent });
     const data = await res.json();
     return data;
 }

--- a/portals/publisher/src/main/webapp/source/Tests/Utils/restAPI.mock.tsx
+++ b/portals/publisher/src/main/webapp/source/Tests/Utils/restAPI.mock.tsx
@@ -69,7 +69,7 @@ const createMockHandler = (apiMapping: OASBackendMapping) => async (
       headers: headers.all(),
       query,
     };
-    if (req.url.pathname === "/api/am/publisher/v4/swagger.yaml") {
+    if (req.url.pathname === "/api/am/publisher/v5/swagger.yaml") {
       // Temporary fix for removing x-example $refs
       await apiMapping.oasBackend.init();
       const oasDef = thisAPIBackend.document;

--- a/portals/publisher/src/main/webapp/source/src/app/data/Utils.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/Utils.js
@@ -650,7 +650,7 @@ Utils.CONST = {
     LOGOUT_CALLBACK: '/services/auth/callback/logout',
     INTROSPECT: '/services/auth/introspect',
     SERVICE_CATALOG_SWAGGER_YAML: '/api/am/service-catalog/v1/oas.yaml',
-    SWAGGER_YAML: '/api/am/publisher/v4/swagger.yaml',
+    SWAGGER_YAML: '/api/am/publisher/v5/swagger.yaml',
     PROTOCOL: 'https://',
     API_CLIENT: 'apiClient',
     SERVICE_CATALOG_CLIENT: 'serviceCatalogClient',

--- a/portals/publisher/src/main/webapp/source/src/app/webWorkers/swagger.worker.js
+++ b/portals/publisher/src/main/webapp/source/src/app/webWorkers/swagger.worker.js
@@ -20,7 +20,7 @@ import SwaggerClient from 'swagger-client';
 // Parse the swagger definition in the worker thread and
 // pass the parsed plain JS object to main thread via postMessage
 SwaggerClient.resolve({
-    url: '/api/am/publisher/v4/swagger.yaml',
+    url: '/api/am/publisher/v5/swagger.yaml',
     requestInterceptor: (request) => {
         request.headers.Accept = 'text/yaml';
     },

--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -83,11 +83,11 @@ module.exports = (env, argv) => {
                     target: 'https://localhost:9443/publisher',
                     secure: false,
                 },
-                '/api/am/publisher/v4/swagger.yaml': {
-                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml' : 'https://localhost:9443/api/am/publisher/v4/swagger.yaml',
+                '/api/am/publisher/v5/swagger.yaml': {
+                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.publisher.v1/src/main/resources/publisher-api.yaml' : 'https://localhost:9443/api/am/publisher/v5/swagger.yaml',
                     secure: false,
                     changeOrigin: true,
-                    pathRewrite: { '^/api/am/publisher/v4/swagger.yaml': '' },
+                    pathRewrite: { '^/api/am/publisher/v5/swagger.yaml': '' },
                 },
                 '/api/am/service-catalog/v1/oas.yaml': {
                     target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml' : 'https://localhost:8081/api/am/service-catalog/v1/oas.yaml',
@@ -97,7 +97,7 @@ module.exports = (env, argv) => {
                 },
                 '/api/am': {
                     target: isTestBuild ? 'http://localhost:4010' : 'https://localhost:9443',
-                    // pathRewrite: { '^/api/am/publisher/v4/': '' },
+                    // pathRewrite: { '^/api/am/publisher/v5/': '' },
                     secure: false,
                 },
                 '/publisher/services': {

--- a/tests/cypress/integration/admin/10-advanced-configurations.spec.js
+++ b/tests/cypress/integration/admin/10-advanced-configurations.spec.js
@@ -30,7 +30,7 @@ describe("Advanced Configurations", () => {
         
         cy.get('[data-testid="Advanced-child-link"]').click();
 
-        cy.intercept('GET', 'https://localhost:9443/api/am/admin/v4/tenant-config', {
+        cy.intercept('GET', 'https://localhost:9443/api/am/admin/v5/tenant-config', {
             statusCode: 200,
             body: advanceConfFalseJson
             
@@ -40,7 +40,7 @@ describe("Advanced Configurations", () => {
         cy.wait(3000);
         cy.get('[data-testid="monaco-editor-save"]').click();
 
-        cy.intercept('GET', 'https://localhost:9443/api/am/admin/v4/tenant-config', {
+        cy.intercept('GET', 'https://localhost:9443/api/am/admin/v5/tenant-config', {
             statusCode: 200,
             body: advanceConfTrueJson
         })

--- a/tests/cypress/integration/devportal/001-applications/04-exchange-key-managers.spec.js
+++ b/tests/cypress/integration/devportal/001-applications/04-exchange-key-managers.spec.js
@@ -22,26 +22,26 @@ describe("Developer portal smoke tests", () => {
     it.only("Exchange grant UI Test", () => {
         cy.loginToDevportal(carbonUsername, carbonPassword)
 
-        cy.intercept("GET", "/api/am/devportal/v3/applications?sortBy=name&sortOrder=asc&limit=10&offset=0",
+        cy.intercept("GET", "/api/am/devportal/v4/applications?sortBy=name&sortOrder=asc&limit=10&offset=0",
             {fixture: 'applicationsList.json'});
         cy.visit(`/devportal`);
         cy.visit(`/devportal/applications`);
-        cy.intercept('GET', `/api/am/devportal/v3/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3`, {fixture:'defaultApplication.json'});
+        cy.intercept('GET', `/api/am/devportal/v4/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3`, {fixture:'defaultApplication.json'});
         cy.get('table:nth-of-type(1) a[href]').contains('DefaultApplication').click();
-        cy.intercept('GET', '/api/am/devportal/v3/throttling-policies/application/Unlimited', {fixtures:'throttlingPolicy.json'})
+        cy.intercept('GET', '/api/am/devportal/v4/throttling-policies/application/Unlimited', {fixtures:'throttlingPolicy.json'})
         cy.visit(`/devportal/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/productionkeys/oauth`);
-        cy.intercept("GET", "/api/am/devportal/v3/key-managers", {fixture:'devportalKeyManagerlisting.json'}).as('loadKeyManagers');
+        cy.intercept("GET", "/api/am/devportal/v4/key-managers", {fixture:'devportalKeyManagerlisting.json'}).as('loadKeyManagers');
         cy.wait('@loadKeyManagers');
-        cy.intercept('GET', `/api/am/devportal/v3/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'oauthKeys.json'});
+        cy.intercept('GET', `/api/am/devportal/v4/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'oauthKeys.json'});
         cy.get('#SampleExternalKM').click();
         cy.get('#exchange-token').click();
         cy.get('#responsive-dialog-title h2').should('contain','Resident Key Manager Consumer Key and Secret Not Available');
         cy.visit(`/devportal/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/productionkeys/oauth`);
         cy.get('#ResidentKeyManager').click();
-        cy.intercept('POST',`/api/am/devportal/v3/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/generate-keys`, {fixture:'generatedKeys.json'});
-        cy.intercept('GET', `/api/am/devportal/v3/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'updatedOauthkeys.json'});
+        cy.intercept('POST',`/api/am/devportal/v4/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/generate-keys`, {fixture:'generatedKeys.json'});
+        cy.intercept('GET', `/api/am/devportal/v4/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'updatedOauthkeys.json'});
         cy.get('#generate-keys').click();
-        cy.intercept('GET', `/api/am/devportal/v3/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'updatedOauthkeys.json'});
+        cy.intercept('GET', `/api/am/devportal/v4/applications/844ec54e-70d3-4f9b-9b48-25853e857fc3/oauth-keys`, {fixture:'updatedOauthkeys.json'});
         cy.get('#SampleExternalKM').click();
         cy.get('#exchange-token').click();
         cy.get('#curl-to-generate-access-token-btn').should('be.disabled');

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -709,7 +709,7 @@ Cypress.Commands.add('publishSolaceApi', (apiName = null) => {
     cy.get('#panel2a-header h6').contains('apim/car-co/api/V1/json/{region_id}/{make}/{model}/{vin}/{event_type}').should('exist');
     cy.get('[data-testid="itest-api-config"]').click();
 
-    cy.intercept('GET','/api/am/publisher/v4/settings',{fixture : 'solaceEnvironmentResponse.json'}).as('getSettings');
+    cy.intercept('GET','/api/am/publisher/v5/settings',{fixture : 'solaceEnvironmentResponse.json'}).as('getSettings');
     cy.reload();
     //Check solace deployments and deploy
     cy.get('#left-menu-itemdeployments').click();
@@ -720,7 +720,7 @@ Cypress.Commands.add('publishSolaceApi', (apiName = null) => {
         cy.get('[data-testid="api-org-name"] input').should('have.value','wso2dev');
         cy.get('#deploy-btn-solace').click({force:true});
         cy.intercept('**/deploy-revision**', { statusCode: 201, fixture: 'api_artifacts/solaceDeployedStatus.json' }).as('deployedStatus');
-        cy.intercept('/api/am/publisher/v4/apis/*/revisions**', { statusCode: 200, fixture: 'api_artifacts/solaceDeployedQuery.json' }).as('deployedRevision');
+        cy.intercept('/api/am/publisher/v5/apis/*/revisions**', { statusCode: 200, fixture: 'api_artifacts/solaceDeployedQuery.json' }).as('deployedRevision');
         cy.wait('@deployedStatus');
         cy.wait('@deployedRevision');
 
@@ -735,18 +735,18 @@ Cypress.Commands.add('publishSolaceApi', (apiName = null) => {
 
 Cypress.Commands.add('viewSolaceApi', (apiName = null) => {
 
-    cy.intercept('GET','/api/am/devportal/v3/apis?limit=10&offset=0',{fixture:'api_artifacts/publishedApis.json'}).as('publishedApis');
-    cy.intercept('GET','/api/am/devportal/v3/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e',{fixture:'api_artifacts/mockSolaceApi.json'}).as('mockSolaceApi');
-    cy.intercept('GET','/api/am/devportal/v3/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/ratings',{statusCode:200,fixture:'api_artifacts/solaceApiRatings.json'});
-    cy.intercept('GET','/api/am/devportal/v3/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/thumbnail',{statusCode:204});
-    cy.intercept('GET','/api/am/devportal/v3/subscriptions**',{fixture:'api_artifacts/solaceApiSubscriptionsOverview.json'}).as('solaceApiSubscriptionsOverview');
-    cy.intercept('GET','/api/am/devportal/v3/subscriptions?apiId=27dea111-28a9-44a5-a14d-87f6ca61bd2e&limit=25',{fixture:'api_artifacts/solaceApiSubscriptionsLimit25.json'}).as('solaceApiSubscriptionsLimit25');
-    cy.intercept('GET','/api/am/devportal/v3/subscriptions?apiId=27dea111-28a9-44a5-a14d-87f6ca61bd2e&limit=5000',{fixture:'api_artifacts/solaceApiSubscriptionsLimit5000.json'}).as('solaceApiSubscriptionsLimit5000');
-    cy.intercept('GET','/api/am/devportal/v3/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/comments**',{statusCode:200});
-    cy.intercept('GET','/api/am/devportal/v3/applications?limit=5000',{fixture:'api_artifacts/solaceApiApplications.json'});
-    cy.intercept('GET','/api/am/devportal/v3/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/documents',{fixture:'api_artifacts/solaceApiDocuments.json'});
-    cy.intercept('GET','/api/am/devportal/v3/settings',{fixture:'api_artifacts/solaceApiSettings.json'}).as('solaceApiSettings');
-    cy.intercept('GET','/api/am/devportal/v3/throttling-policies/subscription',{fixture:'api_artifacts/solaceApiThrottling.json'}).as('solaceApiThrottling');
+    cy.intercept('GET','/api/am/devportal/v4/apis?limit=10&offset=0',{fixture:'api_artifacts/publishedApis.json'}).as('publishedApis');
+    cy.intercept('GET','/api/am/devportal/v4/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e',{fixture:'api_artifacts/mockSolaceApi.json'}).as('mockSolaceApi');
+    cy.intercept('GET','/api/am/devportal/v4/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/ratings',{statusCode:200,fixture:'api_artifacts/solaceApiRatings.json'});
+    cy.intercept('GET','/api/am/devportal/v4/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/thumbnail',{statusCode:204});
+    cy.intercept('GET','/api/am/devportal/v4/subscriptions**',{fixture:'api_artifacts/solaceApiSubscriptionsOverview.json'}).as('solaceApiSubscriptionsOverview');
+    cy.intercept('GET','/api/am/devportal/v4/subscriptions?apiId=27dea111-28a9-44a5-a14d-87f6ca61bd2e&limit=25',{fixture:'api_artifacts/solaceApiSubscriptionsLimit25.json'}).as('solaceApiSubscriptionsLimit25');
+    cy.intercept('GET','/api/am/devportal/v4/subscriptions?apiId=27dea111-28a9-44a5-a14d-87f6ca61bd2e&limit=5000',{fixture:'api_artifacts/solaceApiSubscriptionsLimit5000.json'}).as('solaceApiSubscriptionsLimit5000');
+    cy.intercept('GET','/api/am/devportal/v4/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/comments**',{statusCode:200});
+    cy.intercept('GET','/api/am/devportal/v4/applications?limit=5000',{fixture:'api_artifacts/solaceApiApplications.json'});
+    cy.intercept('GET','/api/am/devportal/v4/apis/27dea111-28a9-44a5-a14d-87f6ca61bd2e/documents',{fixture:'api_artifacts/solaceApiDocuments.json'});
+    cy.intercept('GET','/api/am/devportal/v4/settings',{fixture:'api_artifacts/solaceApiSettings.json'}).as('solaceApiSettings');
+    cy.intercept('GET','/api/am/devportal/v4/throttling-policies/subscription',{fixture:'api_artifacts/solaceApiThrottling.json'}).as('solaceApiThrottling');
 
     cy.wait('@publishedApis',{ timeout:10000}).then(()=> {
         cy.get('[data-testid="solace-label"]').should('exist');
@@ -988,7 +988,7 @@ Cypress.Commands.add('updateTenantConfig', (username, password, tenant, config) 
     })
     // Try to improve this
     // Better to modify the API response accordingly instead of mocking the entire API call
-    cy.intercept('GET', 'https://localhost:9443/api/am/admin/v4/tenant-config', {
+    cy.intercept('GET', 'https://localhost:9443/api/am/admin/v5/tenant-config', {
         statusCode: 200,
         body: config
     });

--- a/tests/cypress/support/utils.js
+++ b/tests/cypress/support/utils.js
@@ -58,7 +58,7 @@ export default class Utils {
                         const curl = `curl -k -X POST \
                         -H "Content-Type: application/json" \
                         -d '${newPayload}' \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis/import-openapi"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis/import-openapi"`;
                         cy.exec(curl).then(result => {
                             const apiId = JSON.parse(result.stdout);
                             resolve(apiId.id);
@@ -85,7 +85,7 @@ export default class Utils {
                         const curl = `curl -k -X POST \
                         -H "Content-Type: application/json" \
                         -d '${newPayload}' \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis"`;
                         cy.exec(curl).then(result => {
                             cy.log(result.stdout);
                             cy.log(result.stderr);
@@ -117,7 +117,7 @@ export default class Utils {
                     .then((token) => {
                         const curl = `curl -k -X POST \
                         -H "Content-Type: application/json" \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis/change-lifecycle?action=Publish&apiId=${apiId}"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis/change-lifecycle?action=Publish&apiId=${apiId}"`;
                         cy.exec(curl).then(result => {
                             resolve(result.stdout);
                         })
@@ -138,7 +138,7 @@ export default class Utils {
                         const curl = `curl -k -X POST \
                         -H "Content-Type: application/json" \
                         -d '${payload}' \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis/${apiId}/revisions"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis/${apiId}/revisions"`;
                         cy.exec(curl).then(result => {
                             var resultJSON = JSON.parse(result.stdout);
                             cy.log(resultJSON);
@@ -161,7 +161,7 @@ export default class Utils {
                         const curl = `curl -k -X POST \
                         -H "Content-Type: application/json" \
                         -d '${payload}' \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis/${apiId}/deploy-revision?revisionId=${revisionId}"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis/${apiId}/deploy-revision?revisionId=${revisionId}"`;
                         cy.exec(curl).then(result => {
                             resolve(result.stdout);
                         })
@@ -187,7 +187,7 @@ export default class Utils {
                     .then((token) => {
                         const curl = `curl -k -X DELETE \
                         -H "Content-Type: application/json" \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/apis/${apiId}"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/apis/${apiId}"`;
                         cy.exec(curl).then(result => {
                             resolve(result.stdout);
                         })
@@ -211,7 +211,7 @@ export default class Utils {
                     .then((token) => {
                         const curl = `curl -k -X DELETE \
                         -H "Content-Type: application/json" \
-                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v4/api-products/${productId}"`;
+                        -H "Authorization: Bearer ${token}"  "${Cypress.config().baseUrl}/api/am/publisher/v5/api-products/${productId}"`;
                         cy.exec(curl).then(result => {
                             resolve(result.stdout);
                         })


### PR DESCRIPTION
Fixing : https://github.com/wso2/api-manager/issues/2408
Main issue : https://github.com/wso2/api-manager/issues/2412

publisher : v4--> v5 (major version: v5 , latest version : v5)
admin : v4 --> v5 (major version: v5 , latest version : v5)
devportal : v3 --> v4 (major version: v4 , latest version : v4)
gateway : v2.2 --> v2.3 (major version: v2 , latest version : v2.3)
serviceCatelog : v1.1 --> v1.2 (major version: v1 , latest version : v1.2)
devops : v0 --> v0.1 (major version: v0 , latest version : v0.1)