### PR TITLE
Add an improvement to an edge case in Global Policies

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -9064,7 +9064,13 @@
   "GlobalPolicies.Listing.onboarding.policies.tooltip": [
     {
       "type": 0,
-      "value": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Click below to create your first global policy"
+      "value": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Click below to create your first global policy."
+    }
+  ],
+  "GlobalPolicies.Listing.onboarding.policies.tooltip.not.allowed": [
+    {
+      "type": 0,
+      "value": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Please contact a privileged user to create a global policy."
     }
   ],
   "GlobalPolicies.Listing.policies.title.add.new.policy": [

--- a/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
@@ -4333,7 +4333,10 @@
     "defaultMessage": "Let’s get started!"
   },
   "GlobalPolicies.Listing.onboarding.policies.tooltip": {
-    "defaultMessage": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Click below to create your first global policy"
+    "defaultMessage": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Click below to create your first global policy."
+  },
+  "GlobalPolicies.Listing.onboarding.policies.tooltip.not.allowed": {
+    "defaultMessage": "Global policies provide you the ability to deploy policy mappings to all the APIs deployed in a specific gateway and not just one single API. Please contact a privileged user to create a global policy."
   },
   "GlobalPolicies.Listing.policies.title.add.new.policy": {
     "defaultMessage": "Add new global policy"

--- a/portals/publisher/src/main/webapp/source/src/app/components/GlobalPolicies/Listing/Listing.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/GlobalPolicies/Listing/Listing.tsx
@@ -1019,14 +1019,21 @@ const Listing: React.FC = () => {
                             iconName={globalPolicyAddIcon}
                         />
                     </Onboarding>
-                    : <Onboarding subTitle={
-                        <FormattedMessage
-                            id='GlobalPolicies.Listing.onboarding.policies.tooltip.not.allowed'
-                            defaultMessage='Global policies provide you the ability to deploy policy mappings to 
-                            all the APIs deployed in a specific gateway and not just one single 
-                            API. Please contact a privileged user to create a global policy.'
-                        />
-                    }
+                    : <Onboarding 
+                        title={
+                            <FormattedMessage
+                                id='GlobalPolicies.Listing.onboarding.create.new'
+                                defaultMessage='Let’s get started!'
+                            />
+                        }
+                        subTitle={
+                            <FormattedMessage
+                                id='GlobalPolicies.Listing.onboarding.policies.tooltip.not.allowed'
+                                defaultMessage='Global policies provide you the ability to deploy policy mappings to 
+                                all the APIs deployed in a specific gateway and not just one single 
+                                API. Please contact a privileged user to create a global policy.'
+                            />
+                        }
                     />
                 }
             </>    

--- a/portals/publisher/src/main/webapp/source/src/app/components/GlobalPolicies/Listing/Listing.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/GlobalPolicies/Listing/Listing.tsx
@@ -989,34 +989,47 @@ const Listing: React.FC = () => {
      */
     if (policies && policies.length === 0 && !loading) {
         return (
-            <Onboarding
-                title={
-                    <FormattedMessage
-                        id='GlobalPolicies.Listing.onboarding.create.new'
-                        defaultMessage='Let’s get started!'
-                    />
-                }
-                subTitle={
-                    <FormattedMessage
-                        id='GlobalPolicies.Listing.onboarding.policies.tooltip'
-                        defaultMessage='Global policies provide you the ability to deploy policy mappings to 
-                        all the APIs deployed in a specific gateway and not just one single 
-                        API. Click below to create your first global policy'
-                    />
-                }
-            >
-                <OnboardingMenuCard
-                    id='itest-id-create-global-policy'
-                    to='global-policies/create'
-                    name={(
-                        <FormattedMessage
-                            id='Global.Policies'
-                            defaultMessage='Global Policies'
+            <>
+                {!isRestricted(['apim:gateway_policy_manage']) ? 
+                    <Onboarding
+                        title={
+                            <FormattedMessage
+                                id='GlobalPolicies.Listing.onboarding.create.new'
+                                defaultMessage='Let’s get started!'
+                            />
+                        }
+                        subTitle={
+                            <FormattedMessage
+                                id='GlobalPolicies.Listing.onboarding.policies.tooltip'
+                                defaultMessage='Global policies provide you the ability to deploy policy mappings to 
+                                all the APIs deployed in a specific gateway and not just one single 
+                                API. Click below to create your first global policy.'
+                            />
+                        }
+                    >
+                        <OnboardingMenuCard 
+                            id='itest-id-create-global-policy'
+                            to='global-policies/create'
+                            name={(
+                                <FormattedMessage
+                                    id='Global.Policies'
+                                    defaultMessage='Global Policies'
+                                />
+                            )} 
+                            iconName={globalPolicyAddIcon}
                         />
-                    )} 
-                    iconName={globalPolicyAddIcon}
-                />
-            </Onboarding>
+                    </Onboarding>
+                    : <Onboarding subTitle={
+                        <FormattedMessage
+                            id='GlobalPolicies.Listing.onboarding.policies.tooltip.not.allowed'
+                            defaultMessage='Global policies provide you the ability to deploy policy mappings to 
+                            all the APIs deployed in a specific gateway and not just one single 
+                            API. Please contact a privileged user to create a global policy.'
+                        />
+                    }
+                    />
+                }
+            </>    
         );
     }
 


### PR DESCRIPTION
In current implementation, if a publisher who has privileges only to view Global Policies logged in to the publisher and in that scenario, system does not have any global policies, he will get redirected to the welcome page. Currently welcome page of Global Policies give a button to create a Global Policies. 

Since that user does not has the privileges to create a user, he will not be able to access the button and will get redirected to the not found page. But showing that button is misleading, we have improved the code to give a proper message to show that user cannot create global policies as user does not have the right privileges. We also removed the button.

New Improvement 
<img width="1512" alt="image" src="https://github.com/wso2/apim-apps/assets/38649090/217f8346-ba32-4714-929d-c2eeeb65ee6a">
