### PR TITLE
Fix cypress test failures

### DIFF
--- a/tests/cypress/integration/devportal/002-subscriptions/03-change-subscription-tier-on-an-application.spec.js
+++ b/tests/cypress/integration/devportal/002-subscriptions/03-change-subscription-tier-on-an-application.spec.js
@@ -60,8 +60,8 @@ describe("Change subscription tier of an application", () => {
 
                 // Edit the subscription
                 cy.get(`#edit-api-subscription-${apiId}`).click();
-                cy.get('#outlined-select-currency').click();
-                cy.get('li[data-value="Silver"]').click();
+                cy.get('#application-policy').click();
+                cy.contains('.MuiAutocomplete-option', 'Silver').click();
                 cy.get('button span').contains('Update').click();
 
                 // Checking the update is success.

--- a/tests/cypress/integration/devportal/003-test/00-tryout-api-invocations-from-swagger-console.spec.js
+++ b/tests/cypress/integration/devportal/003-test/00-tryout-api-invocations-from-swagger-console.spec.js
@@ -37,7 +37,11 @@ describe("Tryout API invocations", () => {
             testApiId = apiId;
             apiContext = apiName;
             Utils.publishAPI(apiId).then(() => {
-                cy.visit(`publisher/apis/${apiId}/deployments`);
+                
+                cy.visit(`publisher/apis/${apiId}/overview`).then(() => {
+                    // Wait for the left menu item to become visible
+                    cy.get('#left-menu-itemdeployments').should('be.visible').click();
+                });
                 cy.get('#deploy-btn').should('not.have.class', 'Mui-disabled').click({force:true});
                 cy.wait(3000);
                 cy.contains('Deployments');

--- a/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
+++ b/tests/cypress/integration/publisher/002-api-resources/02-add-assign-global-scopes-for-api.spec.js
@@ -91,17 +91,15 @@ describe("Add assign global scopes for api", () => {
 
       // Open the operation sub section
       cy.get(`#${verb}\\${target}`).click();
-      cy.get(`#${verb}\\${target}-operation-scope-select`, { timeout: 3000 });
-      cy.get(`#${verb}\\${target}-operation-scope-select`).click();
-      cy.get(`[data-value=${scopeName}]`).click();
-      cy.get(`[data-value=${scopeName}]`).type("{esc}");
+      cy.get(`#${verb}\\${target}-operation-scope-autocomplete`, { timeout: 3000 });
+      cy.get(`#${verb}\\${target}-operation-scope-autocomplete`).click();
+      cy.get(`#${verb}\\${target}-operation-scope-${scopeName}`).click();
       // // Save the resources
       cy.get("#resources-save-operations").click();
 
       cy.get("#resources-save-operations", { timeout: 30000 });
-      cy.get(`#${verb}\\${target}-operation-scope-select`)
-        .contains(scopeName)
-        .should("be.visible");
+      cy.get(`#${verb}\\${target}-operation-scope-autocomplete`);
+      cy.contains('span', scopeName).should('exist');
 
       Utils.deleteAPI(apiId);
     });


### PR DESCRIPTION
This PR fixes test failures in test files below.

- change-subscription-tier-on-an-application.spec.js
- tryout-api-invocations-from-swagger-console.spec.js
- add-assign-global-scopes-for-api.spec.js