### PR TITLE
Fix Deployments Page Loading Issue

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -330,9 +330,11 @@ class Details extends Component {
             const promisedApi = API.get(apiUUID);
             promisedApi
                 .then((api) => {
-                    this.setState({ api });
-                    this.getRevision();
-                    this.getDeployedEnv();
+                    this.setState({ api }, () => {
+                        // This code will run after the state has been updated
+                        this.getRevision();
+                        this.getDeployedEnv();
+                    });
                 })
                 .catch((error) => {
                     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
### Purpose
- This PR adds a fix to overcome the loading issue of the Deployments page
- Related Issue: https://github.com/wso2/api-manager/issues/2518

### Approach
- The getRevision and getDeployedEnv functions use the apiType property of the api object
- These functions are called after the setState function which sets the api object
- But the setState function does not immediately apply this change
- Hence, ensured the getRevision and getDeployedEnv functions are executed after the state has been updated by adding them to the callback of the setState function