### PR TITLE
Refactor: Use useRef for dynamic securityScheme and authorizationHeader access

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import 'swagger-ui-react/swagger-ui.css';
 import SwaggerUILib from 'swagger-ui-react';
@@ -27,6 +27,17 @@ const SwaggerUI = (props) => {
         spec, accessTokenProvider, authorizationHeader, api, securitySchemeType,
     } = props;
 
+    const securitySchemeRef = useRef(props.securitySchemeType);
+    const authorizationHeaderRef = useRef(props.authorizationHeader);
+
+    useEffect(() => {
+        securitySchemeRef.current = props.securitySchemeType;
+    }, [props.securitySchemeType]);
+
+    useEffect(() => {
+        authorizationHeaderRef.current = props.authorizationHeader;
+    }, [props.authorizationHeader]);
+
     const componentProps = {
         spec,
         validatorUrl: null,
@@ -35,17 +46,19 @@ const SwaggerUI = (props) => {
         requestInterceptor: (req) => {
             const { url } = req;
             const { context } = api;
+            const currentSecuritySchemeType = securitySchemeRef.current;
+            const currentAuthHeader = authorizationHeaderRef.current;
             const patternToCheck = `${context}/*`;
-            if (securitySchemeType === 'API-KEY') {
-                req.headers[authorizationHeader] = accessTokenProvider();
-            } else if (securitySchemeType === 'BASIC') {
-                req.headers[authorizationHeader] = 'Basic ' + accessTokenProvider();
-            } else if (securitySchemeType === 'TEST') {
-                req.headers[authorizationHeader] = accessTokenProvider();
+            if (currentSecuritySchemeType === 'API-KEY') {
+                req.headers[currentAuthHeader] = accessTokenProvider();
+            } else if (currentSecuritySchemeType === 'BASIC') {
+                req.headers[currentAuthHeader] = 'Basic ' + accessTokenProvider();
+            } else if (currentSecuritySchemeType === 'TEST') {
+                req.headers[currentAuthHeader] = accessTokenProvider();
             } else if (api.advertiseInfo && api.advertiseInfo.advertised && authorizationHeader !== '') {
-                req.headers[authorizationHeader] = accessTokenProvider();
+                req.headers[currentAuthHeader] = accessTokenProvider();
             } else {
-                req.headers[authorizationHeader] = 'Bearer ' + accessTokenProvider();
+                req.headers[currentAuthHeader] = 'Bearer ' + accessTokenProvider();
             }
             if (url.endsWith(patternToCheck)) {
                 req.url = url.substring(0, url.length - 2);
@@ -64,8 +77,7 @@ const SwaggerUI = (props) => {
     useEffect(() => {
         if (!layoutRender) return;
         const len = document.querySelectorAll('.opblock .authorization__btn');
-        let i = 0;
-        for (; i < len.length; i++) {
+        for (let i = 0; i < len.length; i++) {
             len[i].remove();
         }
         document.querySelector('.schemes select').setAttribute('id', 'schemes');
@@ -88,6 +100,7 @@ const SwaggerUI = (props) => {
 SwaggerUI.propTypes = {
     accessTokenProvider: PropTypes.func.isRequired,
     authorizationHeader: PropTypes.string.isRequired,
+    securitySchemeType: PropTypes.string.isRequired,
     api: PropTypes.shape({
         context: PropTypes.string.isRequired,
     }).isRequired,


### PR DESCRIPTION
- Implemented useRef to maintain the current values of securityScheme and authorizationHeader, ensuring the latest state is accessed within closures.

Git Issues: https://github.com/wso2/api-manager/issues/2603, https://github.com/wso2/api-manager/issues/2564