### PR TITLE
Fix null check in TransportLevel

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -194,7 +194,7 @@ function TransportLevel(props) {
     let mandatoryValue = API_SECURITY_MUTUAL_SSL_OPTIONAL;
     // If not mutual ssl security is selected, no mandatory values should be pre-selected
     if (!isMutualSSLEnabled) {
-        mandatoryValue = 'null';
+        mandatoryValue = null;
     } else if (
         !(securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2) || securityScheme.includes(API_SECURITY_BASIC_AUTH)
             || securityScheme.includes(API_SECURITY_API_KEY))


### PR DESCRIPTION
- This PR fixes the issue https://github.com/wso2/api-manager/issues/2606
- Due to the type of the null, the initialization of mandatoryValue sets incorrectly. This PR fixes the issue.