### PR TITLE
Update openapi match support to 3.x.x

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/operationUtils.js
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/operationUtils.js
@@ -17,7 +17,7 @@
  */
 
 const VERSIONS = {
-    V3: new RegExp('[3][.][0][.][0-9]'),
+    V3: new RegExp('[3][.][0-9][.][0-9]'),
     V2: new RegExp('[2][.][0]'),
 };
 /**


### PR DESCRIPTION
Previously regex supported OpenAPI 3.1.x. Now it supports OpenAPI 3.x.x.
Fixes https://github.com/wso2/api-manager/issues/2643