### PR TITLE
4.3.0 dependency upgrades

### DIFF
--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -70,7 +70,6 @@
                 "react-syntax-highlighter": "^15.5.0",
                 "react-tagcloud": "^2.3.1",
                 "remark-gfm": "^3.0.1",
-                "sanitize-html": "^2.13.0",
                 "stream-browserify": "^3.0.0",
                 "subscriptions-transport-ws": "^0.11.0",
                 "swagger-client": "^3.18.5",
@@ -14402,6 +14401,7 @@
         },
         "node_modules/htmlparser2": {
             "version": "8.0.1",
+            "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -21265,10 +21265,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/parse-srcset": {
-            "version": "1.0.2",
-            "license": "MIT"
-        },
         "node_modules/parse5": {
             "version": "7.1.2",
             "dev": true,
@@ -24287,62 +24283,6 @@
             "version": "2.1.2",
             "license": "MIT"
         },
-        "node_modules/sanitize-html": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-            "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
-            "dependencies": {
-                "deepmerge": "^4.2.2",
-                "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^8.0.0",
-                "is-plain-object": "^5.0.0",
-                "parse-srcset": "^1.0.2",
-                "postcss": "^8.3.11"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/sanitize-html/node_modules/picocolors": {
-            "version": "1.0.0",
-            "license": "ISC"
-        },
-        "node_modules/sanitize-html/node_modules/postcss": {
-            "version": "8.4.21",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.4",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/sax": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
@@ -25184,13 +25124,6 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-js": {
-            "version": "1.0.2",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -39468,6 +39401,7 @@
         },
         "htmlparser2": {
             "version": "8.0.1",
+            "dev": true,
             "requires": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -44097,9 +44031,6 @@
             "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
             "dev": true
         },
-        "parse-srcset": {
-            "version": "1.0.2"
-        },
         "parse5": {
             "version": "7.1.2",
             "dev": true,
@@ -46119,38 +46050,6 @@
         "safer-buffer": {
             "version": "2.1.2"
         },
-        "sanitize-html": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-            "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
-            "requires": {
-                "deepmerge": "^4.2.2",
-                "escape-string-regexp": "^4.0.0",
-                "htmlparser2": "^8.0.0",
-                "is-plain-object": "^5.0.0",
-                "parse-srcset": "^1.0.2",
-                "postcss": "^8.3.11"
-            },
-            "dependencies": {
-                "escape-string-regexp": {
-                    "version": "4.0.0"
-                },
-                "is-plain-object": {
-                    "version": "5.0.0"
-                },
-                "picocolors": {
-                    "version": "1.0.0"
-                },
-                "postcss": {
-                    "version": "8.4.21",
-                    "requires": {
-                        "nanoid": "^3.3.4",
-                        "picocolors": "^1.0.0",
-                        "source-map-js": "^1.0.2"
-                    }
-                }
-            }
-        },
         "sax": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
@@ -46751,9 +46650,6 @@
         },
         "source-map": {
             "version": "0.6.1"
-        },
-        "source-map-js": {
-            "version": "1.0.2"
         },
         "source-map-resolve": {
             "version": "0.5.3",

--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -19,7 +19,7 @@
                 "@mui/icons-material": "^5.15.6",
                 "@mui/lab": "^5.0.0-alpha.162",
                 "@mui/material": "^5.15.6",
-                "@stoplight/elements": "^7.7.9",
+                "@stoplight/elements": "^8.1.0",
                 "@ui5/webcomponents-icons": "^1.9.3",
                 "ajv": "^8.12.0",
                 "async-mutex": "^0.4.0",
@@ -2480,19 +2480,21 @@
             "license": "MIT"
         },
         "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "6.2.1",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+            "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
             "hasInstallScript": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "6.2.1",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+            "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "6.2.1"
+                "@fortawesome/fontawesome-common-types": "6.5.1"
             },
             "engines": {
                 "node": ">=6"
@@ -2500,7 +2502,8 @@
         },
         "node_modules/@fortawesome/react-fontawesome": {
             "version": "0.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+            "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
             "dependencies": {
                 "prop-types": "^15.8.1"
             },
@@ -4838,7 +4841,8 @@
         },
         "node_modules/@react-hook/debounce": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-3.0.0.tgz",
+            "integrity": "sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==",
             "dependencies": {
                 "@react-hook/latest": "^1.0.2"
             },
@@ -4848,28 +4852,32 @@
         },
         "node_modules/@react-hook/event": {
             "version": "1.2.6",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
+            "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
             "peerDependencies": {
                 "react": ">=16.8"
             }
         },
         "node_modules/@react-hook/latest": {
             "version": "1.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+            "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
             "peerDependencies": {
                 "react": ">=16.8"
             }
         },
         "node_modules/@react-hook/passive-layout-effect": {
             "version": "1.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
             "peerDependencies": {
                 "react": ">=16.8"
             }
         },
         "node_modules/@react-hook/resize-observer": {
             "version": "1.2.6",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.6.tgz",
+            "integrity": "sha512-DlBXtLSW0DqYYTW3Ft1/GQFZlTdKY5VAFIC4+km6IK5NiPPDFchGbEJm1j6pSgMqPRHbUQgHJX7RaR76ic1LWA==",
             "dependencies": {
                 "@juggle/resize-observer": "^3.3.1",
                 "@react-hook/latest": "^1.0.2",
@@ -4881,7 +4889,8 @@
         },
         "node_modules/@react-hook/size": {
             "version": "2.1.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/size/-/size-2.1.2.tgz",
+            "integrity": "sha512-BmE5asyRDxSuQ9p14FUKJ0iBRgV9cROjqNG9jT/EjCM+xHha1HVqbPoT+14FQg1K7xIydabClCibUY4+1tw/iw==",
             "dependencies": {
                 "@react-hook/passive-layout-effect": "^1.2.0",
                 "@react-hook/resize-observer": "^1.2.1"
@@ -4892,7 +4901,8 @@
         },
         "node_modules/@react-hook/throttle": {
             "version": "2.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
+            "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
             "dependencies": {
                 "@react-hook/latest": "^1.0.2"
             },
@@ -4902,7 +4912,8 @@
         },
         "node_modules/@react-hook/window-size": {
             "version": "3.1.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@react-hook/window-size/-/window-size-3.1.1.tgz",
+            "integrity": "sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==",
             "dependencies": {
                 "@react-hook/debounce": "^3.0.0",
                 "@react-hook/event": "^1.2.1",
@@ -5135,18 +5146,19 @@
             }
         },
         "node_modules/@stoplight/elements": {
-            "version": "7.7.9",
-            "license": "Apache-2.0",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/elements/-/elements-8.1.0.tgz",
+            "integrity": "sha512-iDvosKKkrPGrPSc6WIBwcNeQcMNHQF8pS37lDMn+4ZSxD3Rv2ARYb74Kq2dvYlWT6nQdinvZrjl3e76RgDSomQ==",
             "dependencies": {
-                "@stoplight/elements-core": "~7.7.9",
-                "@stoplight/http-spec": "^5.1.4",
+                "@stoplight/elements-core": "~8.1.0",
+                "@stoplight/http-spec": "^7.0.2",
                 "@stoplight/json": "^3.18.1",
-                "@stoplight/mosaic": "^1.33.0",
-                "@stoplight/types": "^13.7.0",
+                "@stoplight/mosaic": "^1.51.3",
+                "@stoplight/types": "^14.1.1",
                 "@stoplight/yaml": "^4.2.3",
                 "classnames": "^2.2.6",
                 "file-saver": "^2.0.5",
-                "lodash": "^4.17.19",
+                "lodash": "^4.17.21",
                 "react-query": "^3.34.19",
                 "react-router-dom": "^5.2.0"
             },
@@ -5159,28 +5171,29 @@
             }
         },
         "node_modules/@stoplight/elements-core": {
-            "version": "7.7.21",
-            "resolved": "https://registry.npmjs.org/@stoplight/elements-core/-/elements-core-7.7.21.tgz",
-            "integrity": "sha512-G29WvM2c5T0C2l3SvOlY8ZlK3927Xgj2OBP12tjltCMHjQRmH/g7HXtFRkm/UQ/ODLv/I8Hs8lZXHdZ/wTp7iw==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/elements-core/-/elements-core-8.1.1.tgz",
+            "integrity": "sha512-jd1pYdspwa7RWiYcF8fa/R47KWePrM+EistsBqQMk0xJZok52aHi9z2UrmPzJwF54brVNfrWu0lToWYWgTdmrw==",
             "dependencies": {
-                "@stoplight/http-spec": "^5.1.4",
+                "@stoplight/http-spec": "^7.0.3",
                 "@stoplight/json": "^3.18.1",
                 "@stoplight/json-schema-ref-parser": "^9.0.5",
                 "@stoplight/json-schema-sampler": "0.2.3",
-                "@stoplight/json-schema-viewer": "^4.10.2",
-                "@stoplight/markdown-viewer": "^5.6.0",
-                "@stoplight/mosaic": "^1.33.0",
-                "@stoplight/mosaic-code-editor": "^1.33.0",
-                "@stoplight/mosaic-code-viewer": "^1.33.0",
+                "@stoplight/json-schema-tree": "^4.0.0",
+                "@stoplight/json-schema-viewer": "^4.15.1",
+                "@stoplight/markdown-viewer": "^5.7.0",
+                "@stoplight/mosaic": "^1.51.3",
+                "@stoplight/mosaic-code-editor": "^1.51.3",
+                "@stoplight/mosaic-code-viewer": "^1.51.3",
                 "@stoplight/path": "^1.3.2",
-                "@stoplight/react-error-boundary": "^2.0.0",
-                "@stoplight/types": "^13.7.0",
+                "@stoplight/react-error-boundary": "^3.0.0",
+                "@stoplight/types": "^14.1.1",
                 "@stoplight/yaml": "^4.2.3",
                 "classnames": "^2.2.6",
-                "httpsnippet-lite": "^3.0.1",
+                "httpsnippet-lite": "^3.0.5",
                 "jotai": "1.3.9",
                 "json-schema": "^0.4.0",
-                "lodash": "^4.17.19",
+                "lodash": "^4.17.21",
                 "nanoid": "^3.1.32",
                 "prop-types": "^15.7.2",
                 "react-query": "^3.34.19",
@@ -5199,27 +5212,62 @@
                 "react-dom": ">=16.8"
             }
         },
+        "node_modules/@stoplight/elements-core/node_modules/@stoplight/types": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+            "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+            "dependencies": {
+                "@types/json-schema": "^7.0.4",
+                "utility-types": "^3.10.0"
+            },
+            "engines": {
+                "node": "^12.20 || >=14.13"
+            }
+        },
+        "node_modules/@stoplight/elements/node_modules/@stoplight/types": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+            "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+            "dependencies": {
+                "@types/json-schema": "^7.0.4",
+                "utility-types": "^3.10.0"
+            },
+            "engines": {
+                "node": "^12.20 || >=14.13"
+            }
+        },
         "node_modules/@stoplight/http-spec": {
-            "version": "5.5.2",
-            "license": "Apache-2.0",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@stoplight/http-spec/-/http-spec-7.0.3.tgz",
+            "integrity": "sha512-r9Y8rT4RbqY7NWqSXjiqtBq0Nme2K5cArSX9gDPeuud8F4CwbizP7xkUwLdwDdHgoJkyIQ3vkFJpHzUVCQeOOA==",
             "dependencies": {
                 "@stoplight/json": "^3.18.1",
-                "@stoplight/json-schema-generator": "1.0.1",
-                "@stoplight/types": "^13.6.0",
+                "@stoplight/json-schema-generator": "1.0.2",
+                "@stoplight/types": "14.1.0",
                 "@types/json-schema": "7.0.11",
                 "@types/swagger-schema-official": "~2.0.22",
                 "@types/type-is": "^1.6.3",
                 "fnv-plus": "^1.3.1",
-                "lodash.isequalwith": "^4.4.0",
-                "lodash.pick": "^4.4.0",
-                "lodash.pickby": "^4.6.0",
+                "lodash": "^4.17.21",
                 "openapi3-ts": "^2.0.2",
-                "postman-collection": "^4.1.2",
-                "tslib": "^2.3.1",
+                "postman-collection": "^4.1.3",
+                "tslib": "^2.6.2",
                 "type-is": "^1.6.18"
             },
             "engines": {
                 "node": ">=14.13"
+            }
+        },
+        "node_modules/@stoplight/http-spec/node_modules/@stoplight/types": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.0.tgz",
+            "integrity": "sha512-fL8Nzw03+diALw91xHEHA5Q0WCGeW9WpPgZQjodNUWogAgJ56aJs03P9YzsQ1J6fT7/XjDqHMgn7/RlsBzB/SQ==",
+            "dependencies": {
+                "@types/json-schema": "^7.0.4",
+                "utility-types": "^3.10.0"
+            },
+            "engines": {
+                "node": "^12.20 || >=14.13"
             }
         },
         "node_modules/@stoplight/json": {
@@ -5276,14 +5324,15 @@
             }
         },
         "node_modules/@stoplight/json-schema-generator": {
-            "version": "1.0.1",
-            "license": "MIT",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-generator/-/json-schema-generator-1.0.2.tgz",
+            "integrity": "sha512-FzSLFoIZc6Lmw3oRE7kU6YUrl5gBmUs//rY59jdFipBoSyTPv5NyqeyTg5mvT6rY1F3qTLU3xgzRi/9Pb9eZpA==",
             "dependencies": {
+                "cross-fetch": "^3.1.5",
                 "json-promise": "1.1.x",
                 "minimist": "1.2.6",
                 "mkdirp": "0.5.x",
-                "pretty-data": "0.40.x",
-                "request": "2.x.x"
+                "pretty-data": "0.40.x"
             },
             "bin": {
                 "json-schema-generator": "bin/cli.js"
@@ -5338,9 +5387,9 @@
             }
         },
         "node_modules/@stoplight/json-schema-viewer": {
-            "version": "4.15.1",
-            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-viewer/-/json-schema-viewer-4.15.1.tgz",
-            "integrity": "sha512-xvu0ctzEce2FYSrgDNYYuENlWndiELJ4f7ng39xjyBw2hMl0QoBy8JlhCrAIiRM1tVs8cmBc/ENQk7GsdJ7Ejg==",
+            "version": "4.16.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-viewer/-/json-schema-viewer-4.16.0.tgz",
+            "integrity": "sha512-5IYPI7sEbyQq2QyDhU9MqDGi9/KhNvaKsG+VOVelTcSqs56Vg9ASbSr/U6dISi5FK0FEfTh6FUggToUAzpr4NQ==",
             "dependencies": {
                 "@stoplight/json": "^3.20.1",
                 "@stoplight/json-schema-tree": "^4.0.0",
@@ -5358,6 +5407,21 @@
                 "@stoplight/markdown-viewer": "^5",
                 "@stoplight/mosaic": "^1.32",
                 "@stoplight/mosaic-code-viewer": "^1.32",
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/@stoplight/json-schema-viewer/node_modules/@stoplight/react-error-boundary": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
+            "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
+            "dependencies": {
+                "@sentry/react": "^6.13.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
                 "react": ">=16.8",
                 "react-dom": ">=16.8"
             }
@@ -5483,6 +5547,21 @@
                 "@stoplight/mosaic-code-viewer": "^1.24.4",
                 "react": ">=16.14",
                 "react-dom": ">=16.14"
+            }
+        },
+        "node_modules/@stoplight/markdown-viewer/node_modules/@stoplight/react-error-boundary": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
+            "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
+            "dependencies": {
+                "@sentry/react": "^6.13.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
             }
         },
         "node_modules/@stoplight/markdown/node_modules/@stoplight/types": {
@@ -5783,9 +5862,9 @@
             }
         },
         "node_modules/@stoplight/mosaic": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic/-/mosaic-1.51.3.tgz",
-            "integrity": "sha512-3C4bAvfG85sO2j6S4saseDbwS4sekmZ9CJy+vwpDK8EaBTy8GEon9TKTkwRiJ9VbFVCNhMVI/xucKuHHMMfYsQ==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic/-/mosaic-1.52.0.tgz",
+            "integrity": "sha512-9gUSmjEK6KWnSBLGgwEW7fOWXLbKew+lEAJKuoIk0EfNdTwJ6IJrK+Fy4r1Wp/7nRkTwpP1QL1cd4wcxi8EK/A==",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -5802,7 +5881,6 @@
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -5818,9 +5896,9 @@
             }
         },
         "node_modules/@stoplight/mosaic-code-editor": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.51.3.tgz",
-            "integrity": "sha512-tbjA3PFE8XPClO5VMvwbkBeUXwGsDvtckEawU4ZFvh31+Ga9v+qsMgTfqyvYFK9fXNVIKoOclsB1D3c4tLyIiw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.52.0.tgz",
+            "integrity": "sha512-T5pqblBp/FvrA63Ihvt6pXN2F6S10UY++HvMs6/AYs93oACrcn0ZhikOoIDP2xkLr8V7l5nSEyurOVjd7Je8+w==",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -5829,13 +5907,12 @@
                 "@react-types/radio": "3.1.2",
                 "@react-types/shared": "3.9.0",
                 "@react-types/switch": "3.1.2",
-                "@stoplight/mosaic": "1.51.3",
-                "@stoplight/mosaic-code-viewer": "1.51.3",
+                "@stoplight/mosaic": "1.52.0",
+                "@stoplight/mosaic-code-viewer": "1.52.0",
                 "@stoplight/types": "^13.7.0",
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -5896,9 +5973,9 @@
             }
         },
         "node_modules/@stoplight/mosaic-code-viewer": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.51.3.tgz",
-            "integrity": "sha512-S+efac0brZrFw4mt75dLCJim4tBilmr80HoIwrCgc3opqdmFlGvksu+bwp3pIJu2Hk/JQxrLu+eZ4DZ7TgDc8Q==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.52.0.tgz",
+            "integrity": "sha512-gadCSJhyE5a05OUhmH+zrvERbGd3NmLIzTKt28FcLejcImKcccsG4ezJpLualY2q/kMm2jkR8eJ+SwF8yfNR9A==",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -5907,12 +5984,11 @@
                 "@react-types/radio": "3.1.2",
                 "@react-types/shared": "3.9.0",
                 "@react-types/switch": "3.1.2",
-                "@stoplight/mosaic": "1.51.3",
+                "@stoplight/mosaic": "1.52.0",
                 "@stoplight/types": "^13.7.0",
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -6052,18 +6128,14 @@
             }
         },
         "node_modules/@stoplight/react-error-boundary": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
-            "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
-            "dependencies": {
-                "@sentry/react": "^6.13.2"
-            },
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-3.0.0.tgz",
+            "integrity": "sha512-lFuTpGy2fu4hffmRTnJot1URa9/ifVLyPPQg62WW3RYo9LsxxHF0PrnFzAeXEQb40g1kc55S/oX6zQc8YJrKXg==",
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": ">=16.8"
             }
         },
         "node_modules/@stoplight/spectral-core": {
@@ -7057,8 +7129,9 @@
             "dev": true
         },
         "node_modules/@types/swagger-schema-official": {
-            "version": "2.0.22",
-            "license": "MIT"
+            "version": "2.0.25",
+            "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.25.tgz",
+            "integrity": "sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg=="
         },
         "node_modules/@types/tapable": {
             "version": "1.0.8",
@@ -7078,8 +7151,9 @@
             "license": "MIT"
         },
         "node_modules/@types/type-is": {
-            "version": "1.6.3",
-            "license": "MIT",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@types/type-is/-/type-is-1.6.6.tgz",
+            "integrity": "sha512-fs1KHv/f9OvmTMsu4sBNaUu32oyda9Y9uK25naJG8gayxNrfqGIjPQsbLIYyfe7xFkppnPlJB+BuTldOaX9bXw==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -8020,13 +8094,6 @@
             "version": "2.0.6",
             "license": "MIT"
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "node_modules/asn1.js": {
             "version": "5.4.1",
             "dev": true,
@@ -8042,13 +8109,6 @@
             "version": "4.12.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/assertion-error": {
             "version": "1.1.0",
@@ -8155,17 +8215,6 @@
             "engines": {
                 "node": ">=0.11"
             }
-        },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.12.0",
-            "license": "MIT"
         },
         "node_modules/axe-core": {
             "version": "4.6.2",
@@ -8630,13 +8679,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "node_modules/bfj": {
             "version": "6.1.2",
             "dev": true,
@@ -8652,8 +8694,9 @@
             }
         },
         "node_modules/big-integer": {
-            "version": "1.6.51",
-            "license": "Unlicense",
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
             "engines": {
                 "node": ">=0.6"
             }
@@ -8875,7 +8918,8 @@
         },
         "node_modules/broadcast-channel": {
             "version": "3.7.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+            "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
             "dependencies": {
                 "@babel/runtime": "^7.7.2",
                 "detect-node": "^2.1.0",
@@ -9234,10 +9278,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ]
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "license": "Apache-2.0"
         },
         "node_modules/ccount": {
             "version": "2.0.1",
@@ -9993,6 +10033,7 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
@@ -10163,6 +10204,14 @@
                 "node": ">=10.14",
                 "npm": ">=6",
                 "yarn": ">=1"
+            }
+        },
+        "node_modules/cross-fetch": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+            "dependencies": {
+                "node-fetch": "^2.6.12"
             }
         },
         "node_modules/cross-spawn": {
@@ -10359,16 +10408,6 @@
             "version": "1.0.8",
             "dev": true,
             "license": "BSD-2-Clause"
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/data-urls": {
             "version": "2.0.0",
@@ -10837,7 +10876,8 @@
         },
         "node_modules/dom-helpers": {
             "version": "3.4.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+            "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
             "dependencies": {
                 "@babel/runtime": "^7.1.2"
             }
@@ -10954,14 +10994,6 @@
             "version": "0.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "license": "MIT",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -12516,13 +12548,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT"
-        },
         "node_modules/faker": {
             "version": "4.1.0",
             "license": "MIT"
@@ -12610,6 +12635,7 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -12924,29 +12950,8 @@
         },
         "node_modules/fnv-plus": {
             "version": "1.3.1",
-            "license": "MIT"
-        },
-        "node_modules/focus-trap": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-            "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-            "dependencies": {
-                "tabbable": "^6.2.0"
-            }
-        },
-        "node_modules/focus-trap-react": {
-            "version": "10.2.3",
-            "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.3.tgz",
-            "integrity": "sha512-YXBpFu/hIeSu6NnmV2xlXzOYxuWkoOtar9jzgp3lOmjWLWY59C/b8DtDHEAV4SPU07Nd/t+nS/SBNGkhUBFmEw==",
-            "dependencies": {
-                "focus-trap": "^7.5.4",
-                "tabbable": "^6.2.0"
-            },
-            "peerDependencies": {
-                "prop-types": "^15.8.1",
-                "react": ">=16.3.0",
-                "react-dom": ">=16.3.0"
-            }
+            "resolved": "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz",
+            "integrity": "sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw=="
         },
         "node_modules/follow-redirects": {
             "version": "1.15.5",
@@ -12985,13 +12990,6 @@
         "node_modules/foreach": {
             "version": "2.0.6",
             "license": "MIT"
-        },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/form-data": {
             "version": "4.0.0",
@@ -13275,13 +13273,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/github-from-package": {
@@ -13869,44 +13860,6 @@
             "version": "2.0.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/har-validator/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/har-validator/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -14538,19 +14491,6 @@
             "version": "0.1.0",
             "license": "Apache-2.0"
         },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
-            }
-        },
         "node_modules/http2-client": {
             "version": "1.3.5",
             "license": "MIT"
@@ -14591,7 +14531,8 @@
         },
         "node_modules/hyphenate-style-name": {
             "version": "1.0.4",
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -15326,6 +15267,7 @@
         },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-weakmap": {
@@ -15413,10 +15355,6 @@
                 "node-fetch": "^2.6.1",
                 "whatwg-fetch": "^3.4.1"
             }
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "license": "MIT"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -17833,7 +17771,8 @@
         },
         "node_modules/js-sha3": {
             "version": "0.8.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -17850,10 +17789,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "license": "MIT"
         },
         "node_modules/jsdom": {
             "version": "16.7.0",
@@ -17995,14 +17930,16 @@
         },
         "node_modules/json-promise": {
             "version": "1.1.8",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/json-promise/-/json-promise-1.1.8.tgz",
+            "integrity": "sha512-rz31P/7VfYnjQFrF60zpPTT0egMPlc8ZvIQHWs4ZtNZNnAXRmXo6oS+6eyWr5sEMG03OVhklNrTXxiIRYzoUgQ==",
             "dependencies": {
                 "bluebird": "*"
             }
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "node_modules/json-schema-compare": {
             "version": "0.2.2",
@@ -18067,10 +18004,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "license": "ISC"
-        },
         "node_modules/json5": {
             "version": "2.2.3",
             "devOptional": true,
@@ -18125,19 +18058,6 @@
             "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/jss": {
@@ -18413,10 +18333,6 @@
             "version": "4.5.0",
             "license": "MIT"
         },
-        "node_modules/lodash.isequalwith": {
-            "version": "4.4.0",
-            "license": "MIT"
-        },
         "node_modules/lodash.isobject": {
             "version": "3.0.2",
             "license": "MIT"
@@ -18447,10 +18363,7 @@
         },
         "node_modules/lodash.pick": {
             "version": "4.4.0",
-            "license": "MIT"
-        },
-        "node_modules/lodash.pickby": {
-            "version": "4.6.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.throttle": {
@@ -18694,16 +18607,18 @@
             }
         },
         "node_modules/match-sorter": {
-            "version": "6.3.1",
-            "license": "MIT",
+            "version": "6.3.4",
+            "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
+            "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
             "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "remove-accents": "0.4.2"
+                "@babel/runtime": "^7.23.8",
+                "remove-accents": "0.5.0"
             }
         },
         "node_modules/match-sorter/node_modules/remove-accents": {
-            "version": "0.4.2",
-            "license": "MIT"
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+            "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
         },
         "node_modules/material-design-icons": {
             "version": "3.0.1",
@@ -19601,7 +19516,8 @@
         },
         "node_modules/microseconds": {
             "version": "0.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+            "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
         },
         "node_modules/miller-rabin": {
             "version": "4.0.1",
@@ -20087,12 +20003,14 @@
             "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ=="
         },
         "node_modules/nano-memoize": {
-            "version": "v1.3.1",
-            "license": "MIT"
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/nano-memoize/-/nano-memoize-1.3.1.tgz",
+            "integrity": "sha512-wQiW3xHptgGlec/Zbo7oq6Zz4kKoK8TaIIs1irTO9iJOGTIG3lnQRUJfH73bJ/rn7MOE4sTdSU+ALPGEidaijQ=="
         },
         "node_modules/nano-time": {
             "version": "1.0.0",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+            "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
             "dependencies": {
                 "big-integer": "^1.6.16"
             }
@@ -20342,8 +20260,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.8",
-            "license": "MIT",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -20766,13 +20685,6 @@
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
         },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "license": "MIT",
@@ -21014,7 +20926,8 @@
         },
         "node_modules/oblivious-set": {
             "version": "1.0.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+            "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
         },
         "node_modules/obuf": {
             "version": "1.1.2",
@@ -21165,7 +21078,8 @@
         },
         "node_modules/openapi3-ts": {
             "version": "2.0.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+            "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
             "dependencies": {
                 "yaml": "^1.10.2"
             }
@@ -21733,8 +21647,9 @@
             }
         },
         "node_modules/polished": {
-            "version": "4.2.2",
-            "license": "MIT",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+            "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
             "dependencies": {
                 "@babel/runtime": "^7.17.8"
             },
@@ -21998,7 +21913,11 @@
         },
         "node_modules/pretty-data": {
             "version": "0.40.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
+            "integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==",
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/pretty-error": {
             "version": "2.1.2",
@@ -22819,7 +22738,8 @@
         },
         "node_modules/react-overflow-list": {
             "version": "0.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/react-overflow-list/-/react-overflow-list-0.5.0.tgz",
+            "integrity": "sha512-+UegukgQ10E4ll3txz4DJyrnCgZ3eDVuv5dvR8ziyG5FfgCDZcUKeKhIgbU90oyqQa21aH4oLOoGKt0TiYJRmg==",
             "dependencies": {
                 "react-use": "^17.3.1"
             },
@@ -22836,8 +22756,9 @@
             "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
         },
         "node_modules/react-query": {
-            "version": "3.39.2",
-            "license": "MIT",
+            "version": "3.39.3",
+            "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+            "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "broadcast-channel": "^3.4.1",
@@ -24114,61 +24035,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/request/node_modules/qs": {
-            "version": "6.5.3",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/request/node_modules/uuid": {
-            "version": "3.4.0",
-            "license": "MIT",
-            "bin": {
-                "uuid": "bin/uuid"
             }
         },
         "node_modules/require-directory": {
@@ -25473,29 +25339,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/sshpk": {
-            "version": "1.17.0",
-            "license": "MIT",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/stack-generator": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -26572,11 +26415,6 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
-        "node_modules/tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-        },
         "node_modules/table": {
             "version": "6.8.1",
             "dev": true,
@@ -26911,17 +26749,6 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/tr46": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -27008,7 +26835,8 @@
         },
         "node_modules/ts-keycode-enum": {
             "version": "1.0.6",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ts-keycode-enum/-/ts-keycode-enum-1.0.6.tgz",
+            "integrity": "sha512-DF8+Cf/FJJnPRxwz8agCoDelQXKZWQOS/gnnwx01nZ106tPJdB3BgJ9QTtLwXgR82D8O+nTjuZzWgf0Rg4vuRA=="
         },
         "node_modules/ts-loader": {
             "version": "9.5.1",
@@ -27279,16 +27107,13 @@
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "license": "Unlicense"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -27683,7 +27508,8 @@
         },
         "node_modules/unload": {
             "version": "2.2.0",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+            "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
             "dependencies": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "^2.0.4"
@@ -28087,18 +27913,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
             }
         },
         "node_modules/vfile": {
@@ -29467,7 +29281,8 @@
         },
         "node_modules/zustand": {
             "version": "3.7.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+            "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
             "engines": {
                 "node": ">=12.7.0"
             },
@@ -31099,16 +30914,22 @@
             "dev": true
         },
         "@fortawesome/fontawesome-common-types": {
-            "version": "6.2.1"
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+            "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A=="
         },
         "@fortawesome/fontawesome-svg-core": {
-            "version": "6.2.1",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+            "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "6.2.1"
+                "@fortawesome/fontawesome-common-types": "6.5.1"
             }
         },
         "@fortawesome/react-fontawesome": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+            "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
             "requires": {
                 "prop-types": "^15.8.1"
             }
@@ -32655,24 +32476,34 @@
         },
         "@react-hook/debounce": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-3.0.0.tgz",
+            "integrity": "sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==",
             "requires": {
                 "@react-hook/latest": "^1.0.2"
             }
         },
         "@react-hook/event": {
             "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
+            "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
             "requires": {}
         },
         "@react-hook/latest": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+            "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
             "requires": {}
         },
         "@react-hook/passive-layout-effect": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
             "requires": {}
         },
         "@react-hook/resize-observer": {
             "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.6.tgz",
+            "integrity": "sha512-DlBXtLSW0DqYYTW3Ft1/GQFZlTdKY5VAFIC4+km6IK5NiPPDFchGbEJm1j6pSgMqPRHbUQgHJX7RaR76ic1LWA==",
             "requires": {
                 "@juggle/resize-observer": "^3.3.1",
                 "@react-hook/latest": "^1.0.2",
@@ -32681,6 +32512,8 @@
         },
         "@react-hook/size": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@react-hook/size/-/size-2.1.2.tgz",
+            "integrity": "sha512-BmE5asyRDxSuQ9p14FUKJ0iBRgV9cROjqNG9jT/EjCM+xHha1HVqbPoT+14FQg1K7xIydabClCibUY4+1tw/iw==",
             "requires": {
                 "@react-hook/passive-layout-effect": "^1.2.0",
                 "@react-hook/resize-observer": "^1.2.1"
@@ -32688,12 +32521,16 @@
         },
         "@react-hook/throttle": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
+            "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
             "requires": {
                 "@react-hook/latest": "^1.0.2"
             }
         },
         "@react-hook/window-size": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@react-hook/window-size/-/window-size-3.1.1.tgz",
+            "integrity": "sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==",
             "requires": {
                 "@react-hook/debounce": "^3.0.0",
                 "@react-hook/event": "^1.2.1",
@@ -32896,44 +32733,58 @@
             }
         },
         "@stoplight/elements": {
-            "version": "7.7.9",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/elements/-/elements-8.1.0.tgz",
+            "integrity": "sha512-iDvosKKkrPGrPSc6WIBwcNeQcMNHQF8pS37lDMn+4ZSxD3Rv2ARYb74Kq2dvYlWT6nQdinvZrjl3e76RgDSomQ==",
             "requires": {
-                "@stoplight/elements-core": "~7.7.9",
-                "@stoplight/http-spec": "^5.1.4",
+                "@stoplight/elements-core": "~8.1.0",
+                "@stoplight/http-spec": "^7.0.2",
                 "@stoplight/json": "^3.18.1",
-                "@stoplight/mosaic": "^1.33.0",
-                "@stoplight/types": "^13.7.0",
+                "@stoplight/mosaic": "^1.51.3",
+                "@stoplight/types": "^14.1.1",
                 "@stoplight/yaml": "^4.2.3",
                 "classnames": "^2.2.6",
                 "file-saver": "^2.0.5",
-                "lodash": "^4.17.19",
+                "lodash": "^4.17.21",
                 "react-query": "^3.34.19",
                 "react-router-dom": "^5.2.0"
+            },
+            "dependencies": {
+                "@stoplight/types": {
+                    "version": "14.1.1",
+                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+                    "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.4",
+                        "utility-types": "^3.10.0"
+                    }
+                }
             }
         },
         "@stoplight/elements-core": {
-            "version": "7.7.21",
-            "resolved": "https://registry.npmjs.org/@stoplight/elements-core/-/elements-core-7.7.21.tgz",
-            "integrity": "sha512-G29WvM2c5T0C2l3SvOlY8ZlK3927Xgj2OBP12tjltCMHjQRmH/g7HXtFRkm/UQ/ODLv/I8Hs8lZXHdZ/wTp7iw==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/elements-core/-/elements-core-8.1.1.tgz",
+            "integrity": "sha512-jd1pYdspwa7RWiYcF8fa/R47KWePrM+EistsBqQMk0xJZok52aHi9z2UrmPzJwF54brVNfrWu0lToWYWgTdmrw==",
             "requires": {
-                "@stoplight/http-spec": "^5.1.4",
+                "@stoplight/http-spec": "^7.0.3",
                 "@stoplight/json": "^3.18.1",
                 "@stoplight/json-schema-ref-parser": "^9.0.5",
                 "@stoplight/json-schema-sampler": "0.2.3",
-                "@stoplight/json-schema-viewer": "^4.10.2",
-                "@stoplight/markdown-viewer": "^5.6.0",
-                "@stoplight/mosaic": "^1.33.0",
-                "@stoplight/mosaic-code-editor": "^1.33.0",
-                "@stoplight/mosaic-code-viewer": "^1.33.0",
+                "@stoplight/json-schema-tree": "^4.0.0",
+                "@stoplight/json-schema-viewer": "^4.15.1",
+                "@stoplight/markdown-viewer": "^5.7.0",
+                "@stoplight/mosaic": "^1.51.3",
+                "@stoplight/mosaic-code-editor": "^1.51.3",
+                "@stoplight/mosaic-code-viewer": "^1.51.3",
                 "@stoplight/path": "^1.3.2",
-                "@stoplight/react-error-boundary": "^2.0.0",
-                "@stoplight/types": "^13.7.0",
+                "@stoplight/react-error-boundary": "^3.0.0",
+                "@stoplight/types": "^14.1.1",
                 "@stoplight/yaml": "^4.2.3",
                 "classnames": "^2.2.6",
-                "httpsnippet-lite": "^3.0.1",
+                "httpsnippet-lite": "^3.0.5",
                 "jotai": "1.3.9",
                 "json-schema": "^0.4.0",
-                "lodash": "^4.17.19",
+                "lodash": "^4.17.21",
                 "nanoid": "^3.1.32",
                 "prop-types": "^15.7.2",
                 "react-query": "^3.34.19",
@@ -32943,25 +32794,47 @@
                 "urijs": "^1.19.11",
                 "util": "^0.12.4",
                 "xml-formatter": "^2.6.1"
+            },
+            "dependencies": {
+                "@stoplight/types": {
+                    "version": "14.1.1",
+                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
+                    "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.4",
+                        "utility-types": "^3.10.0"
+                    }
+                }
             }
         },
         "@stoplight/http-spec": {
-            "version": "5.5.2",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@stoplight/http-spec/-/http-spec-7.0.3.tgz",
+            "integrity": "sha512-r9Y8rT4RbqY7NWqSXjiqtBq0Nme2K5cArSX9gDPeuud8F4CwbizP7xkUwLdwDdHgoJkyIQ3vkFJpHzUVCQeOOA==",
             "requires": {
                 "@stoplight/json": "^3.18.1",
-                "@stoplight/json-schema-generator": "1.0.1",
-                "@stoplight/types": "^13.6.0",
+                "@stoplight/json-schema-generator": "1.0.2",
+                "@stoplight/types": "14.1.0",
                 "@types/json-schema": "7.0.11",
                 "@types/swagger-schema-official": "~2.0.22",
                 "@types/type-is": "^1.6.3",
                 "fnv-plus": "^1.3.1",
-                "lodash.isequalwith": "^4.4.0",
-                "lodash.pick": "^4.4.0",
-                "lodash.pickby": "^4.6.0",
+                "lodash": "^4.17.21",
                 "openapi3-ts": "^2.0.2",
-                "postman-collection": "^4.1.2",
-                "tslib": "^2.3.1",
+                "postman-collection": "^4.1.3",
+                "tslib": "^2.6.2",
                 "type-is": "^1.6.18"
+            },
+            "dependencies": {
+                "@stoplight/types": {
+                    "version": "14.1.0",
+                    "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.0.tgz",
+                    "integrity": "sha512-fL8Nzw03+diALw91xHEHA5Q0WCGeW9WpPgZQjodNUWogAgJ56aJs03P9YzsQ1J6fT7/XjDqHMgn7/RlsBzB/SQ==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.4",
+                        "utility-types": "^3.10.0"
+                    }
+                }
             }
         },
         "@stoplight/json": {
@@ -33011,13 +32884,15 @@
             }
         },
         "@stoplight/json-schema-generator": {
-            "version": "1.0.1",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-generator/-/json-schema-generator-1.0.2.tgz",
+            "integrity": "sha512-FzSLFoIZc6Lmw3oRE7kU6YUrl5gBmUs//rY59jdFipBoSyTPv5NyqeyTg5mvT6rY1F3qTLU3xgzRi/9Pb9eZpA==",
             "requires": {
+                "cross-fetch": "^3.1.5",
                 "json-promise": "1.1.x",
                 "minimist": "1.2.6",
                 "mkdirp": "0.5.x",
-                "pretty-data": "0.40.x",
-                "request": "2.x.x"
+                "pretty-data": "0.40.x"
             }
         },
         "@stoplight/json-schema-merge-allof": {
@@ -33066,9 +32941,9 @@
             }
         },
         "@stoplight/json-schema-viewer": {
-            "version": "4.15.1",
-            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-viewer/-/json-schema-viewer-4.15.1.tgz",
-            "integrity": "sha512-xvu0ctzEce2FYSrgDNYYuENlWndiELJ4f7ng39xjyBw2hMl0QoBy8JlhCrAIiRM1tVs8cmBc/ENQk7GsdJ7Ejg==",
+            "version": "4.16.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/json-schema-viewer/-/json-schema-viewer-4.16.0.tgz",
+            "integrity": "sha512-5IYPI7sEbyQq2QyDhU9MqDGi9/KhNvaKsG+VOVelTcSqs56Vg9ASbSr/U6dISi5FK0FEfTh6FUggToUAzpr4NQ==",
             "requires": {
                 "@stoplight/json": "^3.20.1",
                 "@stoplight/json-schema-tree": "^4.0.0",
@@ -33080,6 +32955,14 @@
                 "lodash": "^4.17.19"
             },
             "dependencies": {
+                "@stoplight/react-error-boundary": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
+                    "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
+                    "requires": {
+                        "@sentry/react": "^6.13.2"
+                    }
+                },
                 "jotai": {
                     "version": "1.13.1",
                     "resolved": "https://registry.npmjs.org/jotai/-/jotai-1.13.1.tgz",
@@ -33335,12 +33218,22 @@
                 "unist-builder": "^3.0.0",
                 "unist-util-select": "^4.0.1",
                 "unist-util-visit": "^3.1.0"
+            },
+            "dependencies": {
+                "@stoplight/react-error-boundary": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
+                    "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
+                    "requires": {
+                        "@sentry/react": "^6.13.2"
+                    }
+                }
             }
         },
         "@stoplight/mosaic": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic/-/mosaic-1.51.3.tgz",
-            "integrity": "sha512-3C4bAvfG85sO2j6S4saseDbwS4sekmZ9CJy+vwpDK8EaBTy8GEon9TKTkwRiJ9VbFVCNhMVI/xucKuHHMMfYsQ==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic/-/mosaic-1.52.0.tgz",
+            "integrity": "sha512-9gUSmjEK6KWnSBLGgwEW7fOWXLbKew+lEAJKuoIk0EfNdTwJ6IJrK+Fy4r1Wp/7nRkTwpP1QL1cd4wcxi8EK/A==",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -33357,7 +33250,6 @@
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -33419,9 +33311,9 @@
             }
         },
         "@stoplight/mosaic-code-editor": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.51.3.tgz",
-            "integrity": "sha512-tbjA3PFE8XPClO5VMvwbkBeUXwGsDvtckEawU4ZFvh31+Ga9v+qsMgTfqyvYFK9fXNVIKoOclsB1D3c4tLyIiw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.52.0.tgz",
+            "integrity": "sha512-T5pqblBp/FvrA63Ihvt6pXN2F6S10UY++HvMs6/AYs93oACrcn0ZhikOoIDP2xkLr8V7l5nSEyurOVjd7Je8+w==",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -33430,13 +33322,12 @@
                 "@react-types/radio": "3.1.2",
                 "@react-types/shared": "3.9.0",
                 "@react-types/switch": "3.1.2",
-                "@stoplight/mosaic": "1.51.3",
-                "@stoplight/mosaic-code-viewer": "1.51.3",
+                "@stoplight/mosaic": "1.52.0",
+                "@stoplight/mosaic-code-viewer": "1.52.0",
                 "@stoplight/types": "^13.7.0",
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -33484,9 +33375,9 @@
             }
         },
         "@stoplight/mosaic-code-viewer": {
-            "version": "1.51.3",
-            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.51.3.tgz",
-            "integrity": "sha512-S+efac0brZrFw4mt75dLCJim4tBilmr80HoIwrCgc3opqdmFlGvksu+bwp3pIJu2Hk/JQxrLu+eZ4DZ7TgDc8Q==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.52.0.tgz",
+            "integrity": "sha512-gadCSJhyE5a05OUhmH+zrvERbGd3NmLIzTKt28FcLejcImKcccsG4ezJpLualY2q/kMm2jkR8eJ+SwF8yfNR9A==",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",
                 "@fortawesome/react-fontawesome": "^0.2.0",
@@ -33495,12 +33386,11 @@
                 "@react-types/radio": "3.1.2",
                 "@react-types/shared": "3.9.0",
                 "@react-types/switch": "3.1.2",
-                "@stoplight/mosaic": "1.51.3",
+                "@stoplight/mosaic": "1.52.0",
                 "@stoplight/types": "^13.7.0",
                 "clsx": "^1.1.1",
                 "copy-to-clipboard": "^3.3.1",
                 "dom-helpers": "^3.3.1",
-                "focus-trap-react": "^10.2.3",
                 "lodash.get": "^4.4.2",
                 "nano-memoize": "^1.2.1",
                 "polished": "^4.1.3",
@@ -33554,12 +33444,10 @@
             "version": "1.3.2"
         },
         "@stoplight/react-error-boundary": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-2.0.0.tgz",
-            "integrity": "sha512-r9cyaaH2h0kFe5c0aP+yJuY9CyXgfbBaMO6660M/wRQXqM49K5Ul7kexE4ei2cqYgo+Cd6ALl6RXSZFYwf2kCA==",
-            "requires": {
-                "@sentry/react": "^6.13.2"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@stoplight/react-error-boundary/-/react-error-boundary-3.0.0.tgz",
+            "integrity": "sha512-lFuTpGy2fu4hffmRTnJot1URa9/ifVLyPPQg62WW3RYo9LsxxHF0PrnFzAeXEQb40g1kc55S/oX6zQc8YJrKXg==",
+            "requires": {}
         },
         "@stoplight/spectral-core": {
             "version": "1.18.3",
@@ -34476,7 +34364,9 @@
             "dev": true
         },
         "@types/swagger-schema-official": {
-            "version": "2.0.22"
+            "version": "2.0.25",
+            "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.25.tgz",
+            "integrity": "sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg=="
         },
         "@types/tapable": {
             "version": "1.0.8",
@@ -34494,7 +34384,9 @@
             "version": "2.0.2"
         },
         "@types/type-is": {
-            "version": "1.6.3",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/@types/type-is/-/type-is-1.6.6.tgz",
+            "integrity": "sha512-fs1KHv/f9OvmTMsu4sBNaUu32oyda9Y9uK25naJG8gayxNrfqGIjPQsbLIYyfe7xFkppnPlJB+BuTldOaX9bXw==",
             "requires": {
                 "@types/node": "*"
             }
@@ -35150,12 +35042,6 @@
         "asap": {
             "version": "2.0.6"
         },
-        "asn1": {
-            "version": "0.2.6",
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "asn1.js": {
             "version": "5.4.1",
             "dev": true,
@@ -35171,9 +35057,6 @@
                     "dev": true
                 }
             }
-        },
-        "assert-plus": {
-            "version": "1.0.0"
         },
         "assertion-error": {
             "version": "1.1.0",
@@ -35242,12 +35125,6 @@
             "version": "5.7.7",
             "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
             "integrity": "sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ=="
-        },
-        "aws-sign2": {
-            "version": "0.7.0"
-        },
-        "aws4": {
-            "version": "1.12.0"
         },
         "axe-core": {
             "version": "4.6.2",
@@ -35569,12 +35446,6 @@
             "version": "0.6.1",
             "dev": true
         },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "bfj": {
             "version": "6.1.2",
             "dev": true,
@@ -35586,7 +35457,9 @@
             }
         },
         "big-integer": {
-            "version": "1.6.51"
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="
         },
         "big.js": {
             "version": "5.2.2",
@@ -35754,6 +35627,8 @@
         },
         "broadcast-channel": {
             "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+            "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
             "requires": {
                 "@babel/runtime": "^7.7.2",
                 "detect-node": "^2.1.0",
@@ -36001,9 +35876,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz",
             "integrity": "sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==",
             "devOptional": true
-        },
-        "caseless": {
-            "version": "0.12.0"
         },
         "ccount": {
             "version": "2.0.1"
@@ -36516,7 +36388,8 @@
             "integrity": "sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ=="
         },
         "core-util-is": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "cosmiconfig": {
             "version": "7.1.0",
@@ -36645,6 +36518,14 @@
             "dev": true,
             "requires": {
                 "cross-spawn": "^7.0.1"
+            }
+        },
+        "cross-fetch": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+            "requires": {
+                "node-fetch": "^2.6.12"
             }
         },
         "cross-spawn": {
@@ -36788,12 +36669,6 @@
         "damerau-levenshtein": {
             "version": "1.0.8",
             "dev": true
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "data-urls": {
             "version": "2.0.0",
@@ -37116,6 +36991,8 @@
         },
         "dom-helpers": {
             "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+            "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
             "requires": {
                 "@babel/runtime": "^7.1.2"
             }
@@ -37197,13 +37074,6 @@
         "duplexer": {
             "version": "0.1.2",
             "dev": true
-        },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
         },
         "ee-first": {
             "version": "1.1.1",
@@ -38272,9 +38142,6 @@
                 "write-json-file": "^4.1.1"
             }
         },
-        "extsprintf": {
-            "version": "1.3.0"
-        },
         "faker": {
             "version": "4.1.0"
         },
@@ -38335,7 +38202,8 @@
             "version": "3.1.1"
         },
         "fast-json-stable-stringify": {
-            "version": "2.1.0"
+            "version": "2.1.0",
+            "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -38569,24 +38437,9 @@
             "dev": true
         },
         "fnv-plus": {
-            "version": "1.3.1"
-        },
-        "focus-trap": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-            "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-            "requires": {
-                "tabbable": "^6.2.0"
-            }
-        },
-        "focus-trap-react": {
-            "version": "10.2.3",
-            "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.3.tgz",
-            "integrity": "sha512-YXBpFu/hIeSu6NnmV2xlXzOYxuWkoOtar9jzgp3lOmjWLWY59C/b8DtDHEAV4SPU07Nd/t+nS/SBNGkhUBFmEw==",
-            "requires": {
-                "focus-trap": "^7.5.4",
-                "tabbable": "^6.2.0"
-            }
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz",
+            "integrity": "sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw=="
         },
         "follow-redirects": {
             "version": "1.15.5",
@@ -38605,9 +38458,6 @@
         },
         "foreach": {
             "version": "2.0.6"
-        },
-        "forever-agent": {
-            "version": "0.6.1"
         },
         "form-data": {
             "version": "4.0.0",
@@ -38800,12 +38650,6 @@
         "get-value": {
             "version": "2.0.6",
             "dev": true
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "github-from-package": {
             "version": "0.0.0",
@@ -39231,34 +39075,6 @@
         "handle-thing": {
             "version": "2.0.1",
             "dev": true
-        },
-        "har-schema": {
-            "version": "2.0.0"
-        },
-        "har-validator": {
-            "version": "5.1.5",
-            "requires": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "6.12.6",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "0.4.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-                }
-            }
         },
         "has": {
             "version": "1.0.3",
@@ -39716,14 +39532,6 @@
         "http-reasons": {
             "version": "0.1.0"
         },
-        "http-signature": {
-            "version": "1.2.0",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
-        },
         "http2-client": {
             "version": "1.3.5"
         },
@@ -39753,7 +39561,9 @@
             "dev": true
         },
         "hyphenate-style-name": {
-            "version": "1.0.4"
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
         },
         "iconv-lite": {
             "version": "0.6.3",
@@ -40168,7 +39978,8 @@
             }
         },
         "is-typedarray": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "dev": true
         },
         "is-weakmap": {
             "version": "2.0.1",
@@ -40229,9 +40040,6 @@
                 "node-fetch": "^2.6.1",
                 "whatwg-fetch": "^3.4.1"
             }
-        },
-        "isstream": {
-            "version": "0.1.2"
         },
         "istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -41971,7 +41779,9 @@
             "version": "0.4.12"
         },
         "js-sha3": {
-            "version": "0.8.0"
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         },
         "js-tokens": {
             "version": "4.0.0"
@@ -41983,9 +41793,6 @@
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
-        },
-        "jsbn": {
-            "version": "0.1.1"
         },
         "jsdom": {
             "version": "16.7.0",
@@ -42087,12 +41894,16 @@
         },
         "json-promise": {
             "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/json-promise/-/json-promise-1.1.8.tgz",
+            "integrity": "sha512-rz31P/7VfYnjQFrF60zpPTT0egMPlc8ZvIQHWs4ZtNZNnAXRmXo6oS+6eyWr5sEMG03OVhklNrTXxiIRYzoUgQ==",
             "requires": {
                 "bluebird": "*"
             }
         },
         "json-schema": {
-            "version": "0.4.0"
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "json-schema-compare": {
             "version": "0.2.2",
@@ -42145,9 +41956,6 @@
             "version": "1.0.1",
             "dev": true
         },
-        "json-stringify-safe": {
-            "version": "5.0.1"
-        },
         "json5": {
             "version": "2.2.3",
             "devOptional": true
@@ -42181,15 +41989,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
             "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
-        },
-        "jsprim": {
-            "version": "1.4.2",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            }
         },
         "jss": {
             "version": "10.10.0",
@@ -42383,9 +42182,6 @@
         "lodash.isequal": {
             "version": "4.5.0"
         },
-        "lodash.isequalwith": {
-            "version": "4.4.0"
-        },
         "lodash.isobject": {
             "version": "3.0.2"
         },
@@ -42408,10 +42204,8 @@
             "version": "4.6.2"
         },
         "lodash.pick": {
-            "version": "4.4.0"
-        },
-        "lodash.pickby": {
-            "version": "4.6.0"
+            "version": "4.4.0",
+            "dev": true
         },
         "lodash.throttle": {
             "version": "4.1.1",
@@ -42576,14 +42370,18 @@
             "version": "0.7.0"
         },
         "match-sorter": {
-            "version": "6.3.1",
+            "version": "6.3.4",
+            "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
+            "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
             "requires": {
-                "@babel/runtime": "^7.12.5",
-                "remove-accents": "0.4.2"
+                "@babel/runtime": "^7.23.8",
+                "remove-accents": "0.5.0"
             },
             "dependencies": {
                 "remove-accents": {
-                    "version": "0.4.2"
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+                    "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
                 }
             }
         },
@@ -43095,7 +42893,9 @@
             }
         },
         "microseconds": {
-            "version": "0.2.0"
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+            "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
         },
         "miller-rabin": {
             "version": "4.0.1",
@@ -43442,10 +43242,14 @@
             }
         },
         "nano-memoize": {
-            "version": "v1.3.1"
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/nano-memoize/-/nano-memoize-1.3.1.tgz",
+            "integrity": "sha512-wQiW3xHptgGlec/Zbo7oq6Zz4kKoK8TaIIs1irTO9iJOGTIG3lnQRUJfH73bJ/rn7MOE4sTdSU+ALPGEidaijQ=="
         },
         "nano-time": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+            "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
             "requires": {
                 "big-integer": "^1.6.16"
             }
@@ -43628,7 +43432,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.8",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             },
@@ -43906,9 +43712,6 @@
                 "yaml": "^1.10.0"
             }
         },
-        "oauth-sign": {
-            "version": "0.9.0"
-        },
         "object-assign": {
             "version": "4.1.1"
         },
@@ -44058,7 +43861,9 @@
             }
         },
         "oblivious-set": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+            "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
         },
         "obuf": {
             "version": "1.1.2",
@@ -44171,6 +43976,8 @@
         },
         "openapi3-ts": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+            "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
             "requires": {
                 "yaml": "^1.10.2"
             }
@@ -44545,7 +44352,9 @@
             }
         },
         "polished": {
-            "version": "4.2.2",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+            "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
             "requires": {
                 "@babel/runtime": "^7.17.8"
             }
@@ -44730,7 +44539,9 @@
             }
         },
         "pretty-data": {
-            "version": "0.40.0"
+            "version": "0.40.0",
+            "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
+            "integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ=="
         },
         "pretty-error": {
             "version": "2.1.2",
@@ -45289,6 +45100,8 @@
         },
         "react-overflow-list": {
             "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/react-overflow-list/-/react-overflow-list-0.5.0.tgz",
+            "integrity": "sha512-+UegukgQ10E4ll3txz4DJyrnCgZ3eDVuv5dvR8ziyG5FfgCDZcUKeKhIgbU90oyqQa21aH4oLOoGKt0TiYJRmg==",
             "requires": {
                 "react-use": "^17.3.1"
             }
@@ -45299,7 +45112,9 @@
             "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
         },
         "react-query": {
-            "version": "3.39.2",
+            "version": "3.39.3",
+            "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+            "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
             "requires": {
                 "@babel/runtime": "^7.5.5",
                 "broadcast-channel": "^3.4.1",
@@ -46155,47 +45970,6 @@
         },
         "repeat-string": {
             "version": "1.6.1"
-        },
-        "request": {
-            "version": "2.88.2",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "2.3.3",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.3"
-                },
-                "uuid": {
-                    "version": "3.4.0"
-                }
-            }
         },
         "require-directory": {
             "version": "2.1.1"
@@ -47090,20 +46864,6 @@
                 }
             }
         },
-        "sshpk": {
-            "version": "1.17.0",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
         "stack-generator": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -47900,11 +47660,6 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
-        "tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-        },
         "table": {
             "version": "6.8.1",
             "dev": true,
@@ -48140,13 +47895,6 @@
             "version": "1.0.1",
             "dev": true
         },
-        "tough-cookie": {
-            "version": "2.5.0",
-            "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            }
-        },
         "tr46": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -48208,7 +47956,9 @@
             "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
         },
         "ts-keycode-enum": {
-            "version": "1.0.6"
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/ts-keycode-enum/-/ts-keycode-enum-1.0.6.tgz",
+            "integrity": "sha512-DF8+Cf/FJJnPRxwz8agCoDelQXKZWQOS/gnnwx01nZ106tPJdB3BgJ9QTtLwXgR82D8O+nTjuZzWgf0Rg4vuRA=="
         },
         "ts-loader": {
             "version": "9.5.1",
@@ -48406,12 +48156,10 @@
         },
         "tunnel-agent": {
             "version": "0.6.0",
+            "optional": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
-        },
-        "tweetnacl": {
-            "version": "0.14.5"
         },
         "type-check": {
             "version": "0.4.0",
@@ -48674,6 +48422,8 @@
         },
         "unload": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+            "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
             "requires": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "^2.0.4"
@@ -48955,14 +48705,6 @@
         "vary": {
             "version": "1.1.2",
             "dev": true
-        },
-        "verror": {
-            "version": "1.10.0",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
         },
         "vfile": {
             "version": "4.2.1",
@@ -49925,6 +49667,8 @@
         },
         "zustand": {
             "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+            "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
             "requires": {}
         },
         "zwitch": {

--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -48,7 +48,7 @@
                 "material-design-icons": "^3.0.1",
                 "mui-datatables": "^4.3.0",
                 "mui-markdown": "^1.1.13",
-                "openapi-to-postmanv2": "^4.16.0",
+                "openapi-to-postmanv2": "^4.20.0",
                 "prop-types": "^15.8.1",
                 "qs": "^6.11.0",
                 "query-string": "^7.1.3",
@@ -17841,6 +17841,7 @@
         },
         "node_modules/js-yaml": {
             "version": "3.14.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -21096,8 +21097,9 @@
             }
         },
         "node_modules/openapi-to-postmanv2": {
-            "version": "4.16.0",
-            "license": "Apache-2.0",
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-4.20.0.tgz",
+            "integrity": "sha512-b6hUW8HYK2h8xleR04dcBR8rLBUCJBLVbSLEYloTndfhbmPK57P2LYi4pL+599ub5rGOXcU2LZ/5mm47IjVmrg==",
             "dependencies": {
                 "ajv": "8.11.0",
                 "ajv-draft-04": "1.0.0",
@@ -21105,13 +21107,13 @@
                 "async": "3.2.4",
                 "commander": "2.20.3",
                 "graphlib": "2.1.8",
-                "js-yaml": "3.14.1",
+                "js-yaml": "4.1.0",
                 "json-schema-merge-allof": "0.8.1",
                 "lodash": "4.17.21",
                 "oas-resolver-browser": "2.5.6",
                 "object-hash": "3.0.0",
                 "path-browserify": "1.0.1",
-                "postman-collection": "4.1.5",
+                "postman-collection": "4.2.1",
                 "swagger2openapi": "7.0.8",
                 "traverse": "0.6.6",
                 "yaml": "1.10.2"
@@ -21137,60 +21139,29 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/openapi-to-postmanv2/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "node_modules/openapi-to-postmanv2/node_modules/commander": {
             "version": "2.20.3",
             "license": "MIT"
         },
-        "node_modules/openapi-to-postmanv2/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "license": "ISC",
+        "node_modules/openapi-to-postmanv2/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/openapi-to-postmanv2/node_modules/postman-collection": {
-            "version": "4.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@faker-js/faker": "5.5.3",
-                "file-type": "3.9.0",
-                "http-reasons": "0.1.0",
-                "iconv-lite": "0.6.3",
-                "liquid-json": "0.3.1",
-                "lodash": "4.17.21",
-                "mime-format": "2.0.1",
-                "mime-types": "2.1.35",
-                "postman-url-encoder": "3.0.5",
-                "semver": "7.3.7",
-                "uuid": "8.3.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/openapi-to-postmanv2/node_modules/semver": {
-            "version": "7.3.7",
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/openapi-to-postmanv2/node_modules/traverse": {
             "version": "0.6.6",
             "license": "MIT"
-        },
-        "node_modules/openapi-to-postmanv2/node_modules/yallist": {
-            "version": "4.0.0",
-            "license": "ISC"
         },
         "node_modules/openapi3-ts": {
             "version": "2.0.2",
@@ -21906,8 +21877,9 @@
             "license": "MIT"
         },
         "node_modules/postman-collection": {
-            "version": "4.1.6",
-            "license": "Apache-2.0",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
+            "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
             "dependencies": {
                 "@faker-js/faker": "5.5.3",
                 "file-type": "3.9.0",
@@ -21918,7 +21890,7 @@
                 "mime-format": "2.0.1",
                 "mime-types": "2.1.35",
                 "postman-url-encoder": "3.0.5",
-                "semver": "7.3.8",
+                "semver": "7.5.4",
                 "uuid": "8.3.2"
             },
             "engines": {
@@ -21927,7 +21899,8 @@
         },
         "node_modules/postman-collection/node_modules/lru-cache": {
             "version": "6.0.0",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -21936,8 +21909,9 @@
             }
         },
         "node_modules/postman-collection/node_modules/semver": {
-            "version": "7.3.8",
-            "license": "ISC",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -21950,7 +21924,8 @@
         },
         "node_modules/postman-collection/node_modules/yallist": {
             "version": "4.0.0",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/postman-url-encoder": {
             "version": "3.0.5",
@@ -42003,6 +41978,7 @@
         },
         "js-yaml": {
             "version": "3.14.1",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -44141,7 +44117,9 @@
             }
         },
         "openapi-to-postmanv2": {
-            "version": "4.16.0",
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/openapi-to-postmanv2/-/openapi-to-postmanv2-4.20.0.tgz",
+            "integrity": "sha512-b6hUW8HYK2h8xleR04dcBR8rLBUCJBLVbSLEYloTndfhbmPK57P2LYi4pL+599ub5rGOXcU2LZ/5mm47IjVmrg==",
             "requires": {
                 "ajv": "8.11.0",
                 "ajv-draft-04": "1.0.0",
@@ -44149,13 +44127,13 @@
                 "async": "3.2.4",
                 "commander": "2.20.3",
                 "graphlib": "2.1.8",
-                "js-yaml": "3.14.1",
+                "js-yaml": "4.1.0",
                 "json-schema-merge-allof": "0.8.1",
                 "lodash": "4.17.21",
                 "oas-resolver-browser": "2.5.6",
                 "object-hash": "3.0.0",
                 "path-browserify": "1.0.1",
-                "postman-collection": "4.1.5",
+                "postman-collection": "4.2.1",
                 "swagger2openapi": "7.0.8",
                 "traverse": "0.6.6",
                 "yaml": "1.10.2"
@@ -44170,42 +44148,24 @@
                         "uri-js": "^4.2.2"
                     }
                 },
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+                },
                 "commander": {
                     "version": "2.20.3"
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
                     "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "postman-collection": {
-                    "version": "4.1.5",
-                    "requires": {
-                        "@faker-js/faker": "5.5.3",
-                        "file-type": "3.9.0",
-                        "http-reasons": "0.1.0",
-                        "iconv-lite": "0.6.3",
-                        "liquid-json": "0.3.1",
-                        "lodash": "4.17.21",
-                        "mime-format": "2.0.1",
-                        "mime-types": "2.1.35",
-                        "postman-url-encoder": "3.0.5",
-                        "semver": "7.3.7",
-                        "uuid": "8.3.2"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.7",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
+                        "argparse": "^2.0.1"
                     }
                 },
                 "traverse": {
                     "version": "0.6.6"
-                },
-                "yallist": {
-                    "version": "4.0.0"
                 }
             }
         },
@@ -44688,7 +44648,9 @@
             "dev": true
         },
         "postman-collection": {
-            "version": "4.1.6",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
+            "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
             "requires": {
                 "@faker-js/faker": "5.5.3",
                 "file-type": "3.9.0",
@@ -44699,24 +44661,30 @@
                 "mime-format": "2.0.1",
                 "mime-types": "2.1.35",
                 "postman-url-encoder": "3.0.5",
-                "semver": "7.3.8",
+                "semver": "7.5.4",
                 "uuid": "8.3.2"
             },
             "dependencies": {
                 "lru-cache": {
                     "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "requires": {
                         "yallist": "^4.0.0"
                     }
                 },
                 "semver": {
-                    "version": "7.3.8",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
                 },
                 "yallist": {
-                    "version": "4.0.0"
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },

--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -24,7 +24,7 @@
                 "ajv": "^8.12.0",
                 "async-mutex": "^0.4.0",
                 "autosuggest-highlight": "^3.3.4",
-                "axios": "^0.27.2",
+                "axios": "^0.28.0",
                 "base64url": "3.0.1",
                 "btoa": "^1.2.1",
                 "caniuse-api": "^1.6.1",
@@ -8176,11 +8176,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.27.2",
-            "license": "MIT",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axobject-query": {
@@ -35276,10 +35278,13 @@
             "dev": true
         },
         "axios": {
-            "version": "0.27.2",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
             "requires": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "axobject-query": {

--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -70,7 +70,7 @@
                 "react-syntax-highlighter": "^15.5.0",
                 "react-tagcloud": "^2.3.1",
                 "remark-gfm": "^3.0.1",
-                "sanitize-html": "^2.8.1",
+                "sanitize-html": "^2.13.0",
                 "stream-browserify": "^3.0.0",
                 "subscriptions-transport-ws": "^0.11.0",
                 "swagger-client": "^3.18.5",
@@ -24447,8 +24447,9 @@
             "license": "MIT"
         },
         "node_modules/sanitize-html": {
-            "version": "2.8.1",
-            "license": "MIT",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+            "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
             "dependencies": {
                 "deepmerge": "^4.2.2",
                 "escape-string-regexp": "^4.0.0",
@@ -46377,7 +46378,9 @@
             "version": "2.1.2"
         },
         "sanitize-html": {
-            "version": "2.8.1",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+            "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
             "requires": {
                 "deepmerge": "^4.2.2",
                 "escape-string-regexp": "^4.0.0",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -36,7 +36,7 @@
         "@mui/icons-material": "^5.15.6",
         "@mui/lab": "^5.0.0-alpha.162",
         "@mui/material": "^5.15.6",
-        "@stoplight/elements": "^7.7.9",
+        "@stoplight/elements": "^8.1.0",
         "@ui5/webcomponents-icons": "^1.9.3",
         "ajv": "^8.12.0",
         "async-mutex": "^0.4.0",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -65,7 +65,7 @@
         "material-design-icons": "^3.0.1",
         "mui-datatables": "^4.3.0",
         "mui-markdown": "^1.1.13",
-        "openapi-to-postmanv2": "^4.16.0",
+        "openapi-to-postmanv2": "^4.20.0",
         "prop-types": "^15.8.1",
         "qs": "^6.11.0",
         "query-string": "^7.1.3",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -87,7 +87,6 @@
         "react-syntax-highlighter": "^15.5.0",
         "react-tagcloud": "^2.3.1",
         "remark-gfm": "^3.0.1",
-        "sanitize-html": "^2.13.0",
         "stream-browserify": "^3.0.0",
         "subscriptions-transport-ws": "^0.11.0",
         "swagger-client": "^3.18.5",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -41,7 +41,7 @@
         "ajv": "^8.12.0",
         "async-mutex": "^0.4.0",
         "autosuggest-highlight": "^3.3.4",
-        "axios": "^0.27.2",
+        "axios": "^0.28.0",
         "base64url": "3.0.1",
         "btoa": "^1.2.1",
         "caniuse-api": "^1.6.1",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -87,7 +87,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "react-tagcloud": "^2.3.1",
         "remark-gfm": "^3.0.1",
-        "sanitize-html": "^2.8.1",
+        "sanitize-html": "^2.13.0",
         "stream-browserify": "^3.0.0",
         "subscriptions-transport-ws": "^0.11.0",
         "swagger-client": "^3.18.5",

--- a/portals/devportal/src/main/webapp/site/public/locales/converter/package-lock.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/converter/package-lock.json
@@ -1,51 +1,31 @@
 {
   "name": "converter",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "converter",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "translate": "^3.0.0"
+      }
+    },
+    "node_modules/translate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/translate/-/translate-3.0.0.tgz",
+      "integrity": "sha512-cGKtG5QuV6ZR3IP9FMlqWMGtYz1f7vMqgPsh441PbvHa11WaN8urLI4Up/UtvIsu2tg3h3f5kHUFJDWKHa4S6w==",
+      "funding": {
+        "url": "https://www.paypal.me/franciscopresencia/19"
+      }
+    }
+  },
   "dependencies": {
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "translate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/translate/-/translate-1.1.0.tgz",
-      "integrity": "sha512-eVyjulnoKo65S5VaYhL628rvhLiGmY2SVgwRJ/fWFpb+VUrECxKsE529whI8l+PPicp1Lhht3r9jD9MI4CyGrw==",
-      "requires": {
-        "node-fetch": "^1.7.3"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/translate/-/translate-3.0.0.tgz",
+      "integrity": "sha512-cGKtG5QuV6ZR3IP9FMlqWMGtYz1f7vMqgPsh441PbvHa11WaN8urLI4Up/UtvIsu2tg3h3f5kHUFJDWKHa4S6w=="
     }
   }
 }

--- a/portals/devportal/src/main/webapp/site/public/locales/converter/package.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/converter/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "translate": "^1.1.0"
+    "translate": "^3.0.0"
   }
 }


### PR DESCRIPTION
Current changes has been done

In In apim-apps/portals/devportal/src/main/webapp

- axios to 0.28.0
- sanitize-html to 2.13.0
- openapi-to-postmanv2 to 4.20.0
- @stoplight/elements to 8.1.0

In apim-apps/portals/devportal/src/main/webapp/site/public/locales/converter

- translate to 3.0.0