### PR TITLE
[Master] Add additional lifeCycleStatus check for prototype APIs

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
@@ -78,7 +78,8 @@ export default function APISecurity(props) {
     } else {
         isEndpointAvailable = apiContext.api.endpointConfig !== null;
         isPrototyped = apiContext.api.endpointConfig !== null
-             && apiContext.api.endpointConfig.implementation_status === 'prototyped';
+             && apiContext.api.endpointConfig.implementation_status === 'prototyped'
+             && apiContext.api.lifeCycleStatus === 'PROTOTYPED';
     }
 
     const haveMultiLevelSecurity = securityScheme.includes(API_SECURITY_MUTUAL_SSL)

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
@@ -100,7 +100,7 @@ function Endpoints(props) {
     const { api } = props;
 
     const isPrototypedAvailable = api.endpointConfig !== null
-        && api.endpointConfig.implementation_status === 'prototyped';
+        && api.endpointConfig.implementation_status === 'prototyped' && api.lifeCycleStatus === 'PROTOTYPED';
 
     /**
      * Check whether the endpoint configuration is dynamic

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -227,7 +227,8 @@ function EndpointOverview(props) {
         } else if (apiObject.endpointImplementationType === 'MOCKED_OAS') {
             return endpointTypes[7];
         } else if (apiObject.endpointImplementationType === 'ENDPOINT'
-            && apiObject.endpointConfig.implementation_status === 'prototyped') {
+            && apiObject.endpointConfig.implementation_status === 'prototyped'
+            && api.lifeCycleStatus === 'PROTOTYPED') {
             return endpointTypes[3];
         } else if (type === 'http') {
             if (typeChangeConfirmation.serviceInfo) {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -458,7 +458,7 @@ function Endpoints(props) {
             }
         } else {
             let isValidEndpoint = false;
-            if (endpointConfig.implementation_status === 'prototyped') {
+            if (endpointConfig.implementation_status === 'prototyped' && api.lifeCycleStatus === 'PROTOTYPED') {
                 if (implementationType === 'ENDPOINT') {
                     if (endpointConfig.production_endpoints && endpointConfig.production_endpoints.url === '') {
                         return {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/CheckboxLabels.jsx
@@ -106,7 +106,7 @@ export default function CheckboxLabels(props) {
         isMandatoryPropertiesAvailable, isMandatoryPropertiesConfigured
     } = props;
     const isEndpointAvailable = !isAPIProduct
-        ? api.endpointConfig !== null && !api.endpointConfig.implementation_status
+        ? api.endpointConfig !== null
         : false;
     const lcState = isAPIProduct ? api.state : api.lifeCycleStatus;
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
@@ -53,7 +53,8 @@ const showEndpoint = (api, type) => {
 function Endpoints(props) {
     const { parentClasses, api } = props;
     const isPrototypedAvailable = api.endpointConfig !== null
-        && api.endpointConfig.implementation_status === 'prototyped';
+        && api.endpointConfig.implementation_status === 'prototyped'
+        && api.lifeCycleStatus === 'PROTOTYPED';
     const productionEndpointSecurity = api.endpointConfig && api.endpointConfig.endpoint_security
         && api.endpointConfig.endpoint_security.production.type;
     const sandboxEndpointSecurity = api.endpointConfig && api.endpointConfig.endpoint_security


### PR DESCRIPTION
With this fix when migrating from 2.6.0 to later versions, for prototype APIs if the lifecycle state is created or published, HTTP/REST Endpoint is selected and it shows production & sandbox endpoints. If the lifecycle state is pre-released it shows the prototype endpoint.