### PR TITLE
Add: Validation for Policy Upload

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
@@ -106,20 +106,16 @@ const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
     const intl = useIntl();
 
     const handleDrop = (policyDefinition: any) => {
-        if(policyDefinition===null || policyDefinition===undefined) {
-            APIMAlert.error(intl.formatMessage({
-                id: 'Uploading.Policies.Error',
-                defaultMessage: 'Incompatible file type',
-            }));
-        }
-        if (policyDefinition[0].name.endsWith('.j2') || policyDefinition[0].name.endsWith('.xml')) {
+        if (policyDefinition && policyDefinition[0] && 
+                (policyDefinition[0].name.endsWith('.j2') || 
+                policyDefinition[0].name.endsWith('.xml'))) {
             setPolicyDefinitionFile(policyDefinition);
-        } else {
-            APIMAlert.error(intl.formatMessage({
-                id: 'Uploading.Policies.Error',
-                defaultMessage: 'Incompatible file type',
-            }));
+            return;
         }
+        APIMAlert.error(intl.formatMessage({
+            id: 'Uploading.Policies.Error',
+            defaultMessage: 'Incompatible file type',
+        }));
     };
 
     const renderPolicyFileDropzone = () => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
@@ -21,7 +21,7 @@ import { styled } from '@mui/material/styles';
 import { List, IconButton , Theme } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import ListItem from '@mui/material/ListItem';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
@@ -35,9 +35,10 @@ import clsx from 'clsx';
 import Icon from '@mui/material/Icon';
 import { HelpOutline } from '@mui/icons-material';
 import { green, red } from '@mui/material/colors';
-
+import APIMAlert from 'AppComponents/Shared/Alert';
 
 const PREFIX = 'UploadPolicyDropzone';
+
 
 const classes = {
     dropZoneWrapper: `${PREFIX}-dropZoneWrapper`,
@@ -102,10 +103,23 @@ const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
     policyDefinitionFile,
     setPolicyDefinitionFile,
 }) => {
-
+    const intl = useIntl();
 
     const handleDrop = (policyDefinition: any) => {
-        setPolicyDefinitionFile(policyDefinition);
+        if(policyDefinition===null || policyDefinition===undefined) {
+            APIMAlert.error(intl.formatMessage({
+                id: 'Uploading.Policies.Error',
+                defaultMessage: 'Incompatible file type',
+            }));
+        }
+        if (policyDefinition[0].name.endsWith('.j2') || policyDefinition[0].name.endsWith('.xml')) {
+            setPolicyDefinitionFile(policyDefinition);
+        } else {
+            APIMAlert.error(intl.formatMessage({
+                id: 'Uploading.Policies.Error',
+                defaultMessage: 'Incompatible file type',
+            }));
+        }
     };
 
     const renderPolicyFileDropzone = () => {


### PR DESCRIPTION
### Purpose
- Currently, any type of file can be uploaded on a policy creation. Need to restrict the file types to `.j2` and `.xml`

<img width="1220" alt="Screenshot 2024-03-25 at 18 14 06" src="https://github.com/wso2/apim-apps/assets/43112139/eb2fe4e3-1365-4d8d-a0aa-0b1afb7108b5">

Fixes: https://github.com/wso2/api-manager/issues/2663