### PR TITLE
Fix API lifecycle labels are not aligned issue when delete disabled

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/APICards/ApiThumbClassic.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/APICards/ApiThumbClassic.jsx
@@ -79,7 +79,11 @@ const StyledCard = styled(Card)((
 
     [`& .${classes.apiDetails}`]: { padding: theme.spacing(1), paddingBottom: 0 },
 
-    [`& .${classes.apiActions}`]: { justifyContent: 'space-between', padding: `0px 0px ${theme.spacing(1)} 8px` },
+    [`& .${classes.apiActions}`]: { 
+        justifyContent: 'space-between',
+        padding: `0px 0px ${theme.spacing(1)} 8px`,
+        height: 48
+    },
 
     [`& .${classes.deleteProgress}`]: {
         color: green[200],


### PR DESCRIPTION
Related Issue: https://github.com/wso2/api-manager/issues/2493

<img width="527" alt="image" src="https://github.com/wso2/apim-apps/assets/43110114/6430646e-06a4-4329-a05c-d0f2b4cc9204">
