### PR TITLE
Fix https://github.com/wso2/api-manager/issues/2834

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -6669,12 +6669,6 @@
       "value": "Name/Content Type"
     }
   ],
-  "Apis.Details.Resources.components.operationComponents.ListParameter.parameter.spec.error": [
-    {
-      "type": 0,
-      "value": "Error in resolving the definition!"
-    }
-  ],
   "Apis.Details.Resources.components.operationComponents.ListParameter.parameter.type": [
     {
       "type": 0,

--- a/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/raw.en.json
@@ -3183,9 +3183,6 @@
   "Apis.Details.Resources.components.operationComponents.ListParameter.parameter.name": {
     "defaultMessage": "Name/Content Type"
   },
-  "Apis.Details.Resources.components.operationComponents.ListParameter.parameter.spec.error": {
-    "defaultMessage": "Error in resolving the definition!"
-  },
   "Apis.Details.Resources.components.operationComponents.ListParameter.parameter.type": {
     "defaultMessage": "Parameter Type"
   },

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -29,7 +29,7 @@ import Banner from 'AppComponents/Shared/Banner';
 import API from 'AppData/api';
 import CircularProgress from '@mui/material/CircularProgress';
 import PropTypes from 'prop-types';
-import SwaggerParser from '@apidevtools/swagger-parser';
+import SwaggerClient from 'swagger-client';
 import { isRestricted } from 'AppData/AuthManager';
 import CONSTS from 'AppData/Constants';
 import Configurations from 'Config';
@@ -363,18 +363,15 @@ export default function Resources(props) {
         /*
         * Used SwaggerParser.validate() because we can get the errors as well.
         */
-        SwaggerParser.validate(specCopy, (err, result) => {
-            setResolvedSpec(() => {
-                const errors = err ? [err] : [];
-                return {
-                    spec: result,
-                    errors,
-                };
+        SwaggerClient.resolve({ spec: specCopy })
+            .then(specR => {
+                setResolvedSpec(specR);
+            })
+            .finally(() => {
+                operationsDispatcher({ action: 'init', data: rawSpec.paths });
+                setOpenAPISpec(rawSpec);
+                setSecurityDefScopesFromSpec(rawSpec);
             });
-        });
-        operationsDispatcher({ action: 'init', data: rawSpec.paths });
-        setOpenAPISpec(rawSpec);
-        setSecurityDefScopesFromSpec(rawSpec);
     }
 
     /**

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/ListParameters.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/ListParameters.jsx
@@ -72,12 +72,7 @@ export default function ListParameters(props) {
                 disableActions
                 dense
                 type='error'
-                message={(
-                    <FormattedMessage
-                        id='Apis.Details.Resources.components.operationComponents.ListParameter.parameter.spec.error'
-                        defaultMessage='Error in resolving the definition!'
-                    />
-                )}
+                message='Error in resolving the definition!'
             />
         );
     }


### PR DESCRIPTION
### Fix https://github.com/wso2/api-manager/issues/2834
1. Undefined is printed in the UI become the component only handles errors or strings. Changed the FromattedMessage to string.

2. SwaggerParser fails to resolve the spec when external https refs are available. Changed it to SwaggerClient's resolve.
