### PR TITLE
Fix Can't view APIs via publisher portal due to missing the sandbox in endpoint security

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Endpoints.jsx
@@ -56,9 +56,9 @@ function Endpoints(props) {
         && api.endpointConfig.implementation_status === 'prototyped'
         && api.lifeCycleStatus === 'PROTOTYPED';
     const productionEndpointSecurity = api.endpointConfig && api.endpointConfig.endpoint_security
-        && api.endpointConfig.endpoint_security.production.type;
+        && api.endpointConfig.endpoint_security.production && api.endpointConfig.endpoint_security.production.type;
     const sandboxEndpointSecurity = api.endpointConfig && api.endpointConfig.endpoint_security
-        && api.endpointConfig.endpoint_security.sandbox.type;
+        && api.endpointConfig.endpoint_security.sandbox && api.endpointConfig.endpoint_security.sandbox.type;
     const authTypes = {
         NONE: 'None',
         BASIC: 'Basic Auth',


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/2828