### PR TITLE
[DevPortal] Fix issue of Dev Portal does not redirect to the Webhook API overview page from subscriptions page

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -220,13 +220,13 @@ class SubscriptionTableData extends React.Component {
     render() {
         const {
             subscription: {
-                apiInfo, status, throttlingPolicy, subscriptionId, apiId, requestedThrottlingPolicy, applicationId,
+                apiInfo, status, throttlingPolicy, subscriptionId, apiId, requestedThrottlingPolicy,
             },
         } = this.props;
         const {
             openMenu, isMonetizedAPI, isDynamicUsagePolicy, openMenuEdit, selectedTier, tiers,
         } = this.state;
-        let link = (
+        const link = (
             <Link
                 to={tiers.length === 0 ? '' : '/apis/' + apiId}
                 style={{ cursor: tiers.length === 0 ? 'default' : '' }}
@@ -236,16 +236,6 @@ class SubscriptionTableData extends React.Component {
                 <MDIcon path={mdiOpenInNew} size='12px' />
             </Link>
         );
-        if (apiInfo.type === 'WEBSUB') {
-            link = (
-                <Link
-                    to={tiers.length === 0 ? '' : '/applications/' + applicationId + '/webhooks/' + apiId}
-                    style={{ cursor: tiers.length === 0 ? 'default' : '' }}
-                >
-                    {apiInfo.name + ' - ' + apiInfo.version}
-                </Link>
-            );
-        }
         return (
             <TableRow hover>
                 <TableCell>


### PR DESCRIPTION
## Purpose
To fix the issue "Subscribed Webhook API" for an application within the Dev Portal does not redirect to the Webhook API overview page.

## Goals
fixes https://github.com/wso2/api-manager/issues/2809

## Approach
Webhook APIs' redirect link creation process was modified to follow the same process as other APIs.

