### PR TITLE
Set the `Leave As-Is` option as the default selected value when creating the SOAP API

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AdvancedConfig/AdvanceEndpointConfig.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AdvancedConfig/AdvanceEndpointConfig.jsx
@@ -100,7 +100,7 @@ function AdvanceEndpointConfig(props) {
     const [advanceConfigObj, setAdvanceConfig] = useState(() => {
         const config = {};
         if (isSOAPEndpoint) {
-            config.format = 'soap11';
+            config.format = 'leave-as-is';
             config.optimize = 'leave-as-is';
         }
         config.actionDuration = '30000';


### PR DESCRIPTION
This update will set the `Leave As-Is` option as the default selected value when creating the SOAP API

- Resolves : https://github.com/wso2/api-manager/issues/2867