### PR TITLE
Fix the issue of not showing all the tags under Tags/API categories in the devportal

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -252,7 +252,8 @@ class CommonListingLegacy extends React.Component {
      */
     componentDidMount() {
         const restApiClient = new API();
-        const promisedTags = restApiClient.getAllTags();
+        const tagsLimit = -1;
+        const promisedTags = restApiClient.getAllTags(tagsLimit);
         promisedTags
             .then((response) => {
                 this.setState({ allTags: response.body.list });

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/TagCloudListing.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/TagCloudListing.jsx
@@ -84,9 +84,10 @@ const Root = styled('main')((
 export default function TagCloudListing() {
     const theme = useTheme();
     const [allTags, setAllTags] = useState(null);
+    const tagsLimit = -1;
     useEffect(() => {
         const restApiClient = new API();
-        const promisedTags = restApiClient.getAllTags();
+        const promisedTags = restApiClient.getAllTags(tagsLimit);
         promisedTags
             .then((response) => {
                 setAllTags(response.body.list);

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -677,9 +677,9 @@ export default class API extends Resource {
      * Get all tags
      * @returns {promise} promise all tags of APIs
      */
-    getAllTags() {
+    getAllTags(limit = 25) {
         const promiseGet = this.client.then((client) => {
-            return client.apis.Tags.get_tags(this._requestMetaData());
+            return client.apis.Tags.get_tags({ limit }, this._requestMetaData());
         }).catch((error) => {
             console.error(error);
         });


### PR DESCRIPTION
When the Devportal UI is loaded and the Tags/API categories section is selected, they can only see the 25 Tags which is the default value. With this update, it will show all the added tags in that section.

Fixes: https://github.com/wso2/api-manager/issues/2947