### PR TITLE
Fix wrong toast display issue on the sample service catalog creation using a read only user

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -60,10 +60,6 @@ function Onboarding() {
         const inlineContent = getSampleOpenAPI();
         try {
             await ServiceCatalog.addService(serviceMetadata, inlineContent);
-            Alert.info(intl.formatMessage({
-                id: 'ServiceCatalog.Listing.Onboarding.add.sample.success',
-                defaultMessage: 'Sample Service added successfully!',
-            }));
         } catch (error) {
             setDeployStatus({ inprogress: false, completed: false, error });
             console.error(error);
@@ -73,6 +69,10 @@ function Onboarding() {
             }));
         }
         setDeployStatus({ inprogress: false, completed: true, error: false });
+        Alert.info(intl.formatMessage({
+            id: 'ServiceCatalog.Listing.Onboarding.add.sample.success',
+            defaultMessage: 'Sample Service added successfully!',
+        }));
     };
     if (deployStatus.completed && !deployStatus.error) {
         const url = '/service-catalog';

--- a/portals/publisher/src/main/webapp/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/ServiceCatalog/Listing/Onboarding.jsx
@@ -60,6 +60,10 @@ function Onboarding() {
         const inlineContent = getSampleOpenAPI();
         try {
             await ServiceCatalog.addService(serviceMetadata, inlineContent);
+            Alert.info(intl.formatMessage({
+                id: 'ServiceCatalog.Listing.Onboarding.add.sample.success',
+                defaultMessage: 'Sample Service added successfully!',
+            }));
         } catch (error) {
             setDeployStatus({ inprogress: false, completed: false, error });
             console.error(error);
@@ -69,10 +73,6 @@ function Onboarding() {
             }));
         }
         setDeployStatus({ inprogress: false, completed: true, error: false });
-        Alert.info(intl.formatMessage({
-            id: 'ServiceCatalog.Listing.Onboarding.add.sample.success',
-            defaultMessage: 'Sample Service added successfully!',
-        }));
     };
     if (deployStatus.completed && !deployStatus.error) {
         const url = '/service-catalog';

--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = (env, argv) => {
                     pathRewrite: { '^/api/am/publisher/v4/swagger.yaml': '' },
                 },
                 '/api/am/service-catalog/v1/oas.yaml': {
-                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml' : 'https://localhost:8081/api/am/service-catalog/v1/oas.yaml',
+                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml' : 'https://localhost:9443/api/am/service-catalog/v1/oas.yaml',
                     secure: false,
                     changeOrigin: true,
                     pathRewrite: { '^/api/am/service-catalog/v1/oas.yaml': '' },

--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = (env, argv) => {
                     pathRewrite: { '^/api/am/publisher/v4/swagger.yaml': '' },
                 },
                 '/api/am/service-catalog/v1/oas.yaml': {
-                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml' : 'https://localhost:9443/api/am/service-catalog/v1/oas.yaml',
+                    target: isTestBuild ? 'https://raw.githubusercontent.com/wso2/carbon-apimgt/master/components/apimgt/org.wso2.carbon.apimgt.rest.api.service.catalog/src/main/resources/service-catalog-api.yaml' : 'https://localhost:8081/api/am/service-catalog/v1/oas.yaml',
                     secure: false,
                     changeOrigin: true,
                     pathRewrite: { '^/api/am/service-catalog/v1/oas.yaml': '' },


### PR DESCRIPTION
## Purpose
Mistakenly display a success toast to the read only users on creation button click in the service catalog page of the Publisher portal.

## Fix
Display success toast only after getting a success response. Also updated the webpack config file to run the service catalog page on the 8081 port without an issue

Resolves https://github.com/wso2/api-manager/issues/1573