### PR TITLE
Fix Gateway environment name overflowing with longer text

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
@@ -335,6 +335,12 @@ export default function DeploymentOnboarding(props) {
                                                     >
                                                         <Box height='100%'>
                                                             <CardHeader
+                                                                sx={{
+                                                                    width: 'inherit',
+                                                                    "& .MuiCardHeader-content": {
+                                                                        overflow: "hidden"
+                                                                    }
+                                                                }}
                                                                 action={(
                                                                     <Checkbox
                                                                         id={row.name.split(' ').join('')}
@@ -350,9 +356,20 @@ export default function DeploymentOnboarding(props) {
                                                                     />
                                                                 )}
                                                                 title={(
-                                                                    <Typography variant='subtitle2'>
-                                                                        {row.displayName}
-                                                                    </Typography>
+                                                                    <Tooltip
+                                                                        title={(
+                                                                            <>
+                                                                                <Typography color='inherit'>
+                                                                                    {row.displayName}
+                                                                                </Typography>
+                                                                            </>
+                                                                        )}
+                                                                        placement='bottom'
+                                                                    >
+                                                                        <Typography noWrap variant='subtitle2'>
+                                                                            {row.displayName}
+                                                                        </Typography>
+                                                                    </Tooltip>
                                                                 )}
                                                                 subheader={(
                                                                     <Typography


### PR DESCRIPTION
## Purpose
This PR fixes the issue of gateway environment names overflowing with longer text on the deployments page

Fixes https://github.com/wso2/api-manager/issues/1846