### PR TITLE
Fix Gateway environment name overflowing with longer text

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -2159,6 +2159,12 @@ export default function Environments() {
                                             >
                                                 <Box height='100%'>
                                                     <CardHeader
+                                                        sx={{
+                                                            width: 'inherit',
+                                                            "& .MuiCardHeader-content": {
+                                                                overflow: "hidden"
+                                                            }
+                                                        }}
                                                         action={
                                                             <>
                                                                 {allEnvRevision && allEnvRevision.some(o1 => {
@@ -2196,9 +2202,20 @@ export default function Environments() {
                                                                 }
                                                             </>}
                                                         title={(
-                                                            <Typography variant='subtitle2'>
-                                                                {row.displayName}
-                                                            </Typography>
+                                                            <Tooltip
+                                                                title={(
+                                                                    <>
+                                                                        <Typography color='inherit'>
+                                                                            {row.displayName}
+                                                                        </Typography>
+                                                                    </>
+                                                                )}
+                                                                placement='bottom'
+                                                            >
+                                                                <Typography noWrap variant='subtitle2'>
+                                                                    {row.displayName}
+                                                                </Typography>
+                                                            </Tooltip>
                                                         )}
                                                         subheader={(
                                                             <Typography


### PR DESCRIPTION
## Purpose
This PR fixes the issue of gateway environment names overflowing with longer text on the Deploy New Revision popup
Related to PR https://github.com/wso2/apim-apps/pull/713

Fixes https://github.com/wso2/api-manager/issues/1846

## Fix
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b7a3319e-9456-44b6-96a5-bad56483e5c0">
