### PR TITLE
Fix issues related to document markdown editor and tryout console in publisher portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/TextEditor.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/TextEditor.jsx
@@ -64,6 +64,8 @@ const StyledDialog = styled(Dialog)({
     },
     [`& .${classes.splitWrapper}`]: {
         padding: 0,
+        height: 'calc(100vh - 64px)',
+        overflow: 'hidden',
     },
     [`& .${classes.docName}`]: {
         alignItems: 'center',
@@ -193,6 +195,7 @@ function TextEditor(props) {
                         editorState={editorState}
                         wrapperClassName='draftjs-wrapper'
                         editorClassName='draftjs-editor'
+                        editorStyle={{ height: 'calc(100vh - 128px)', overflowY: 'auto' }}
                         onEditorStateChange={onEditorStateChange}
                     />
                 </div>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
@@ -111,7 +111,7 @@ const tasksReducer = (state, action) => {
 const TryOutConsole = () => {
 
     const [api] = useAPI();
-    const [apiKey, setAPIKey] = useState('');
+    const [apiKey, setAPIKey] = useState(null);
     const [deployments, setDeployments] = useState([]);
     const [selectedDeployment, setSelectedDeployment] = useState();
     const [oasDefinition, setOasDefinition] = useState();
@@ -283,7 +283,7 @@ const TryOutConsole = () => {
         const currentSelection = deployments.find((deployment) => deployment.name === selectedGWEnvironment);
         setSelectedDeployment(currentSelection);
     };
-    const decodedJWT = useMemo(() => Utils.decodeJWT(apiKey), [apiKey]);
+    const decodedJWT = useMemo(() => Utils.decodeJWT(apiKey || ''), [apiKey]);
     const isAPIRetired = api.lifeCycleStatus === 'RETIRED';
 
     const accessTokenProvider = () => {
@@ -291,7 +291,7 @@ const TryOutConsole = () => {
             return advAuthHeaderValue;
         }
         return apiKey;
-    };
+    }; 
 
     const getAuthorizationHeader = () => {
         if (isAdvertised) {
@@ -326,6 +326,9 @@ const TryOutConsole = () => {
                                                 defaultMessage='Internal API Key'
                                             />
                                         )}
+                                        InputLabelProps={{
+                                            shrink: true,
+                                        }}
                                         type='password'
                                         value={apiKey}
                                         helperText={decodedJWT ? (
@@ -455,7 +458,7 @@ const TryOutConsole = () => {
                         advertiseInfo={api.advertiseInfo}
                     />
                 )}
-                {updatedOasDefinition ? (
+                {updatedOasDefinition && apiKey !== null ? (
                     <Suspense
                         fallback={(
                             <CircularProgress />


### PR DESCRIPTION
## Purpose

- Authorization header missing in "Try out" page in the Publisher Portal
- Markdown Controls in the Documents Section Disappear in Long Documents
- Related to https://github.com/wso2/api-manager/issues/3005 and https://github.com/wso2/api-manager/issues/3019
## Implementation

- Add component based styling to markdown editor.
- Handle API key  validations with component rendering in TryOutConsole react component.