### PR TITLE
Fix add document not working in publisher portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -916,4 +916,4 @@ const ForwardedCreateEditForm = forwardRef((props, ref) => {
     return <CreateEditForm ref={childRef} {...props} />;
 });
 
-export default injectIntl(ForwardedCreateEditForm);
+export default injectIntl(ForwardedCreateEditForm,{ forwardRef: true });


### PR DESCRIPTION
## Purpose

- To fix the bug identified where the add document button in publisher is not working.

## Implementation

- Set forwardRef to true in injectIntl function to allow the ref to be based to the Higher order component.