### PR TITLE
Ensure correct internal API key is used in publisher portal try out

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/SwaggerUI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/SwaggerUI.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import 'swagger-ui-react/swagger-ui.css';
 import './swagger-ui-overrides.css';
@@ -39,6 +39,12 @@ const SwaggerUI = (props) => {
     const {
         spec, accessTokenProvider, authorizationHeader, api,
     } = props;
+    const accessTokenProviderRef = useRef(accessTokenProvider);
+
+    useEffect(() => {
+        accessTokenProviderRef.current = accessTokenProvider;
+    }, [accessTokenProvider]);
+
     const componentProps = {
         spec,
         validatorUrl: null,
@@ -48,7 +54,7 @@ const SwaggerUI = (props) => {
             const { url } = req;
             const { context, version } = api;
             const patternToCheck = `${context}/${version}/*`;
-            const accessToken = accessTokenProvider();
+            const accessToken = accessTokenProviderRef.current();
             if (accessToken) {
                 req.headers[authorizationHeader] = accessToken;
             }


### PR DESCRIPTION
### Purpose
<!-- Short description of the feature you are going to add with this PR. -->
Ensure that the latest internal API key is correctly applied in the Tryout section of the Publisher portal. 


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/api-manager/issues/3104

### Approach
Used useRef hook to ensure that the latest `accessToken` is fetched and applied in the `requestInterceptor`.

Note: According to the swagger-ui-react documentation, this behavior should happen by default. It was also observed in earlier versions (v3, v4) that the interceptor worked as expected, but it no longer works in v5 (couldn't find out why). The useRef approach ensures the latest token is always applied, fixing the issue. 
