### PR TITLE
Disable the certificate save button when business plan is empty

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/UploadCertificate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/UploadCertificate.jsx
@@ -500,6 +500,7 @@ export default function UploadCertificate(props) {
                             || isSaving
                             || isAliasIncluded()
                             || isRejected
+                            || policy === ''
                     }
                 >
                     <FormattedMessage


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/3123