### PR TITLE
Fix Application Throttle Policy Reset button visibility bug

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Overview.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Overview.jsx
@@ -334,76 +334,77 @@ function Overview(props) {
                                 {application.description}
                             </TableCell>
                         </TableRow>
-                        {tierDescription
-                            && (
-                                <TableRow>
-                                    <TableCell component='th' scope='row' className={classes.leftCol}>
-                                        <div className={classes.iconAligner}>
-                                            <Icon className={classes.iconOdd}>settings_input_component</Icon>
-                                            <span className={classes.iconTextWrapper}>
-                                                <Typography variant='caption' gutterBottom align='left'>
+                        <TableRow>
+                            <TableCell component='th' scope='row' className={classes.leftCol}>
+                                <div className={classes.iconAligner}>
+                                    <Icon className={classes.iconOdd}>settings_input_component</Icon>
+                                    <span className={classes.iconTextWrapper}>
+                                        <Typography variant='caption' gutterBottom align='left'>
+                                            <FormattedMessage
+                                                id='Applications.Details.InfoBar.business.plan'
+                                                defaultMessage='Business Plan'
+                                            />
+                                        </Typography>
+                                    </span>
+                                </div>
+                            </TableCell>
+                            {application
+                                && (
+                                    <TableCell className={classes.iconAligner}>
+                                        {application.throttlingPolicy}
+                                        {tierDescription && tierDescription.trim() && (
+                                            <span className={tierDisabled ? classes.disabledTier : ''}>
+                                                &nbsp;
+                                                {`(${tierDescription.trim()})`}
+                                            </span>
+                                        )}
+
+                                        <VerticalDivider height={40} />
+                                        <Grid item xs={1} m={1}>
+                                            <Button
+                                                id='reset-application-policy'
+                                                style={{ padding: '1px' }}
+                                                onClick={handleResetConfirmation}
+                                                color='grey'
+                                                aria-label={(
                                                     <FormattedMessage
-                                                        id='Applications.Details.InfoBar.business.plan'
-                                                        defaultMessage='Business Plan'
+                                                        id='Applications.Details.Overview.application.reset'
+                                                        defaultMessage='Reset'
+                                                    />
+                                                )}
+                                            >
+                                                <Icon>replay</Icon>
+                                                <Typography variant='caption'>
+                                                    <FormattedMessage
+                                                        id='Applications.Details.Overview.application.reset.text'
+                                                        defaultMessage='RESET'
                                                     />
                                                 </Typography>
-                                            </span>
-                                        </div>
-                                    </TableCell>
-                                    {application
-                                        && (
-                                            <TableCell className={classes.iconAligner}>
-                                                {application.throttlingPolicy}
-                                                {' '}
-                                                <span className={tierDisabled ? classes.disabledTier : ''}>{`(${tierDescription})`}</span>
-
-                                                <VerticalDivider height={40} />
-                                                <Grid item xs={1} m={1}>
-                                                    <Button
-                                                        id='reset-application-policy'
-                                                        style={{ padding: '1px' }}
-                                                        onClick={handleResetConfirmation}
-                                                        color='grey'
-                                                        aria-label={(
-                                                            <FormattedMessage
-                                                                id='Applications.Details.Overview.application.reset'
-                                                                defaultMessage='Reset'
-                                                            />
-                                                        )}
-                                                    >
-                                                        <Icon>replay</Icon>
-                                                        <Typography variant='caption'>
-                                                            <FormattedMessage
-                                                                id='Applications.Details.Overview.application.reset.text'
-                                                                defaultMessage='RESET'
-                                                            />
-                                                        </Typography>
-                                                    </Button>
-                                                    <Tooltip
-                                                        interactive
-                                                        title={(
-                                                            <FormattedMessage
-                                                                id='Applications.Details.Overview.application.reset.tooltip'
-                                                                defaultMessage='Reset the Application Throttle Policy for a Specific User'
-                                                            />
-                                                        )}
-                                                        placement='right'
-                                                        classeName={classes.infoToolTip}
-                                                    >
-                                                        <IconButton className={classes.infoButton} aria-label='arch'>
-                                                            <InfoIcon />
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                    <ResetThrottlePolicyDialog
-                                                        handleResetThrottlePolicy={handleReset}
-                                                        isResetOpen={isResetOpen}
-                                                        toggleResetConfirmation={toggleResetConfirmation}
+                                            </Button>
+                                            <Tooltip
+                                                interactive
+                                                title={(
+                                                    <FormattedMessage
+                                                        id='Applications.Details.Overview.application.reset.tooltip'
+                                                        defaultMessage='Reset the Application Throttle Policy for a Specific User'
                                                     />
-                                                </Grid>
-                                            </TableCell>
-                                        )}
-                                </TableRow>
-                            )}
+                                                )}
+                                                placement='right'
+                                                classeName={classes.infoToolTip}
+                                            >
+                                                <IconButton className={classes.infoButton} aria-label='arch'>
+                                                    <InfoIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <ResetThrottlePolicyDialog
+                                                handleResetThrottlePolicy={handleReset}
+                                                isResetOpen={isResetOpen}
+                                                toggleResetConfirmation={toggleResetConfirmation}
+                                            />
+                                        </Grid>
+                                    </TableCell>
+                                )}
+                        </TableRow>
                         <TableRow>
                             <TableCell component='th' scope='row' className={classes.leftCol}>
                                 <div className={classes.iconAligner}>


### PR DESCRIPTION
### Purpose
<!-- Short description of the feature you are going to add with this PR. -->
The business plan row in the DevPortal Application Overview wasn’t showing up when the policy description was empty because of the rendering conditions. The reset button was also not showing. The purpose of the PR is to fix that bug.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/api-manager/issues/3163

### Approach
Updated the rendering conditions. 

### Screenshots
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/1b117f10-c0a3-421b-80e4-4cca75a27b12">
