### PR TITLE
Ignore empty auth headers in DevPortal Tryout in third party APIs

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
@@ -28,15 +28,15 @@ const SwaggerUI = (props) => {
     } = props;
 
     const securitySchemeRef = useRef(props.securitySchemeType);
-    const authorizationHeaderRef = useRef(props.authorizationHeader);
+    const authorizationHeaderRef = useRef(authorizationHeader);
 
     useEffect(() => {
         securitySchemeRef.current = props.securitySchemeType;
     }, [props.securitySchemeType]);
 
     useEffect(() => {
-        authorizationHeaderRef.current = props.authorizationHeader;
-    }, [props.authorizationHeader]);
+        authorizationHeaderRef.current = authorizationHeader;
+    }, [authorizationHeader]);
 
     const componentProps = {
         spec,
@@ -55,8 +55,10 @@ const SwaggerUI = (props) => {
                 req.headers[currentAuthHeader] = 'Basic ' + accessTokenProvider();
             } else if (currentSecuritySchemeType === 'TEST') {
                 req.headers[currentAuthHeader] = accessTokenProvider();
-            } else if (api.advertiseInfo && api.advertiseInfo.advertised && authorizationHeader !== '') {
-                req.headers[currentAuthHeader] = accessTokenProvider();
+            } else if (api.advertiseInfo && api.advertiseInfo.advertised) {
+                if (currentAuthHeader) {
+                    req.headers[currentAuthHeader] = accessTokenProvider();
+                }
             } else {
                 req.headers[currentAuthHeader] = 'Bearer ' + accessTokenProvider();
             }


### PR DESCRIPTION
# Purpose
Ignore empty auth headers in DevPortal Tryout in third party APIs. 

# Issues
Fixes https://github.com/wso2/api-manager/issues/3181

# Screenshots
<img width="884" alt="image" src="https://github.com/user-attachments/assets/78168a6a-9f63-44b7-8f20-99108aae9453">

<img width="721" alt="image" src="https://github.com/user-attachments/assets/f1045272-9001-4475-a2fe-3f9605888dbf">

