### PR TITLE
Fix alignment issues in ChipInput components

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
@@ -310,7 +310,7 @@ const AppConfiguration = (props) => {
                                             handleAppRequestChange(e);
                                         }}
                                         style={{
-                                            margin: '0 8px 12px 0',
+                                            marginRight: '8px',
                                             float: 'left',
                                         }}
                                     />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/AccessControl.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/AccessControl.jsx
@@ -279,7 +279,7 @@ export default function AccessControl(props) {
                         InputProps={{
                             endAdornment: (!roleValidity || !userRoleValidity) && (
                                 <InputAdornment position='end'>
-                                    <Error color='error' style={{ paddingBottom: 8 }} />
+                                    <Error color='error' />
                                 </InputAdornment>
                             ),
                         }}
@@ -297,7 +297,7 @@ export default function AccessControl(props) {
                                 }}
                                 style={{
                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                    margin: '0 8px 12px 0',
+                                    marginRight: '8px',
                                     float: 'left',
                                 }}
                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/StoreVisibility.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/StoreVisibility.jsx
@@ -270,7 +270,7 @@ export default function StoreVisibility(props) {
                         InputProps={{
                             endAdornment: !roleValidity && (
                                 <InputAdornment position='end'>
-                                    <Error color='error' style={{ paddingBottom: 8 }} />
+                                    <Error color='error' />
                                 </InputAdornment>
                             ),
                         }}
@@ -299,7 +299,7 @@ export default function StoreVisibility(props) {
                                 }}
                                 style={{
                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                    margin: '0 8px 12px 0',
+                                    marginRight: '8px',
                                     float: 'left',
                                 }}
                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Scopes/CreateScope.jsx
@@ -642,7 +642,7 @@ class CreateScope extends React.Component {
                                                 }}
                                                 style={{
                                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                                    margin: '8px 8px 8px 0',
+                                                    marginRight: '8px',
                                                     float: 'left',
                                                 }}
                                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Scopes/EditScope.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Scopes/EditScope.jsx
@@ -456,7 +456,7 @@ class EditScope extends React.Component {
                                                 }}
                                                 style={{
                                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                                    margin: '8px 8px 8px 0',
+                                                    marginRight: '8px',
                                                     float: 'left',
                                                 }}
                                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Scopes/Create/CreateScope.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Scopes/Create/CreateScope.jsx
@@ -655,7 +655,7 @@ class CreateScope extends React.Component {
                                                 }}
                                                 style={{
                                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                                    margin: '8px 8px 8px 0',
+                                                    marginRight: '8px',
                                                     float: 'left',
                                                 }}
                                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Scopes/EditScope.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Scopes/EditScope.jsx
@@ -558,7 +558,7 @@ class EditScope extends React.Component {
                                                 }}
                                                 style={{
                                                     backgroundColor: invalidRoles.includes(value) ? red[300] : null,
-                                                    margin: '8px 8px 8px 0',
+                                                    marginRight: '8px',
                                                     float: 'left',
                                                 }}
                                             />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/ChipInput.js
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/ChipInput.js
@@ -96,7 +96,7 @@ const StyledFormControl = styled(FormControl)(({ theme }) => {
     },
     [`& .${classes.labeled}`]: {},
     [`& .${classes.label}`]: {
-      top: 4,
+      top: 0,
       padding: '0 8px',
       backgroundColor: theme.palette.background.paper,
       '&$outlined&:not($labelShrink)': {
@@ -758,6 +758,7 @@ export const defaultChipRenderer = ({ value, text, isFocused, isDisabled, isRead
     style={{
       pointerEvents: isDisabled || isReadOnly ? 'none' : undefined,
       backgroundColor: isFocused ? blue[300] : undefined,
+      marginRight: '8px',
     }}
     onClick={handleClick}
     onDelete={handleDelete}


### PR DESCRIPTION
# Purpose
To fix the alignment issues in ChipInput components

# Issues
Fixes https://github.com/wso2/api-manager/issues/3224

# Screenshots
<img width="75%" alt="image" src="https://github.com/user-attachments/assets/ba8ff49c-f7a3-4c1a-b380-4db41d3a92e0">

**Note:**
I noticed that we are using the [mui-chips-input](https://viclafouch.github.io/mui-chips-input/) library in the admin portal, but a custom component in the other two portals. Maybe we can replace the components in the publisher and dev portals with the same library used in the admin portal (if there's no specific reason for using the custom component).
