### PR TITLE
Remove Unnecessary NPM Dependencies

### DIFF
--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -58,7 +58,6 @@
         "graphiql": "^3.1.1",
         "graphiql-subscriptions-fetcher": "0.0.2",
         "graphql": "^16.8.0",
-        "graphql-to-postman": "0.1.1",
         "graphql-ws": "^5.14.0",
         "html-react-parser": "^4.2.2",
         "js-file-download": "^0.4.12",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -96,7 +96,6 @@
         "stream-browserify": "^3.0.0",
         "swagger-client": "^3.18.5",
         "swagger-ui-react": "^5.17.14",
-        "swagger2-postman2-converter": "0.0.3",
         "url": "^0.11.3",
         "xml-formatter": "^3.6.2"
     },

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -30,7 +30,6 @@ import postmanIcon from '@iconify/icons-simple-icons/postman';
 import { Icon as Icons } from '@iconify/react';
 import fileDownload from 'js-file-download';
 import openapiToPostman from 'openapi-to-postmanv2';
-import swaggerToPostman from 'swagger2-postman2-converter';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import Tooltip from '@mui/material/Tooltip';
 import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
@@ -390,15 +389,7 @@ class ApiConsole extends React.Component {
         openapiToPostman.convert({ type: 'string', data: fr },
             {}, (err, conversionResult) => {
                 if (!conversionResult.result) {
-                    const collection = swaggerToPostman.convert(fr);
-                    if (!collection) {
-                        console.log('Could not convert');
-                    } else {
-                        fileDownload(
-                            JSON.stringify(collection),
-                            'postman collection',
-                        );
-                    }
+                    console.log('Could not convert');
                 } else {
                     fileDownload(
                         JSON.stringify(conversionResult.output[0].data),

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GraphQLConsole/GraphQLConsole.jsx
@@ -25,8 +25,6 @@ import Typography from '@mui/material/Typography';
 import { FormattedMessage } from 'react-intl';
 import AuthManager from 'AppData/AuthManager';
 import Icon from '@mui/material/Icon';
-import fileDownload from 'js-file-download';
-import converter from 'graphql-to-postman';
 import Box from '@mui/material/Box';
 import GraphQLUI from './GraphQLUI';
 import TryOutController from '../../../Shared/ApiTryOut/TryOutController';
@@ -215,27 +213,6 @@ export default function GraphQLConsole() {
         }
     }
 
-    function grapgQLToPostman(graphQL, URL) {
-        converter.convert({
-            type: 'string',
-            data: graphQL,
-        }, {}, (error, result) => {
-            if (error) {
-                console.log(error);
-            } else {
-                const urlValue = URL.https;
-                const results = result;
-                results.output[0].data.variable[0].value = urlValue;
-                const outputData = results.output[0].data;
-                fileDownload(
-                    JSON.stringify(outputData),
-                    'postman collection',
-                );
-                console.log('Conversion success');
-            }
-        });
-    }
-
     if (api == null) {
         return <Progress />;
     }
@@ -301,7 +278,6 @@ export default function GraphQLConsole() {
                         username={username}
                         password={password}
                         setSelectedKeyType={setSelectedKeyType}
-                        convertToPostman={grapgQLToPostman}
                         selectedKeyType={selectedKeyType}
                         setKeys={setKeys}
                         setURLs={setURLs}


### PR DESCRIPTION
The following dependencies and their related code segments have been removed:

1. **graphql-to-postman:** This package was removed as it is no longer used in the codebase.
2. **swagger2-postman2-converter:** This package was removed because the same conversion functionality can now be achieved using the latest version of openapi-to-postmanv2.