### PR TITLE
Fix the default value of backend throughput options

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/MaxBackendTps.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/MaxBackendTps.jsx
@@ -120,7 +120,7 @@ export default function MaxBackendTps(props) {
                             </FormLabel>
                             <RadioGroup
                                 aria-label='change-max-TPS'
-                                value={api.maxTps === null ? 'unlimited' : 'specify'}
+                                value={api.maxTps === undefined || api.maxTps === null ? 'unlimited' : 'specify'}
                                 onChange={(event) => {
                                     configDispatcher({
                                         action: 'maxTps',
@@ -165,7 +165,7 @@ export default function MaxBackendTps(props) {
                                 />
                             </RadioGroup>
                         </FormControl>
-                        <Collapse in={api.maxTps !== null}>
+                        <Collapse in={api.maxTps !== undefined && api.maxTps !== null}>
                             <Grid item xs={12} style={{ marginBottom: 10, position: 'relative' }}>
                                 <TextField
                                     label={intl.formatMessage({


### PR DESCRIPTION
# Purpose
Display the backend throughput config as unlimited when maxTps value is undefined

# Issues
Fixes https://github.com/wso2/api-manager/issues/3198

# Screenshots
<img width="515" alt="image" src="https://github.com/user-attachments/assets/66d69efc-f535-46ad-8c59-962988d7b210">


