### PR TITLE
Make all navigation bar links visible to all users

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/SampleAPI/SampleAPIProduct.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/SampleAPI/SampleAPIProduct.jsx
@@ -23,7 +23,7 @@ import Grid from '@mui/material/Grid';
 import OnboardingMenuCard from 'AppComponents/Shared/Onboarding/OnboardingMenuCard';
 import Onboarding from 'AppComponents/Shared/Onboarding/Onboarding';
 import { PropTypes } from 'prop-types';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage, injectIntl, useIntl } from 'react-intl';
 import AuthManager from 'AppData/AuthManager';
 import Alert from 'AppComponents/Shared/MuiAlert';
 
@@ -36,6 +36,7 @@ import Alert from 'AppComponents/Shared/MuiAlert';
  */
 function SampleAPI() {
     const theme = useTheme();
+    const intl = useIntl();
     const { apiproductAddIcon } = theme.custom.landingPage.icons;
     return (
         <Onboarding
@@ -70,12 +71,10 @@ function SampleAPI() {
                 disabled={AuthManager.isNotPublisher()}
                 id='itest-id-create-api-product'
                 to='/api-products/create'
-                name={(
-                    <FormattedMessage
-                        id='Apis.Listing.SampleAPIProduct.onboarding.menu.card.name'
-                        defaultMessage='API Product'
-                    />
-                )}
+                name={intl.formatMessage({
+                    id: 'Apis.Listing.SampleAPIProduct.onboarding.menu.card.name',
+                    defaultMessage: 'API Product',
+                })}
                 iconName={apiproductAddIcon}
             />
         </Onboarding>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
@@ -21,7 +21,7 @@ import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import LaunchIcon from '@mui/icons-material/Launch';
 import { FormattedMessage, useIntl } from 'react-intl';
-import AuthManager, { isRestricted } from 'AppData/AuthManager';
+import { isRestricted } from 'AppData/AuthManager';
 import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import Divider from '@mui/material/Divider';
 
@@ -58,9 +58,6 @@ const StyledBox = styled(Box)((
  * @returns
  */
 function GlobalNavLinks(props) {
-    const publisherUser = !AuthManager.isNotPublisher();
-    const readOnlyUser = AuthManager.isReadOnlyUser();
-    const adminUser = AuthManager.isAdminUser();
 
     const { selected } = props;
     const theme = useTheme();
@@ -119,41 +116,35 @@ function GlobalNavLinks(props) {
                                 defaultMessage='Services'
                             />
                         </GlobalNavLink>
-                        { (readOnlyUser || publisherUser)
-                            && (
-                                <GlobalNavLink
-                                    to='/api-products'
-                                    type='api-product'
-                                    title={intl.formatMessage({
-                                        id: 'Base.Header.navbar.GlobalNavBar.title.api.products',
-                                        defaultMessage: 'API Products',
-                                    })}
-                                    active={selected === 'api-products'}
-                                >
-                                    <FormattedMessage
-                                        id='Base.Header.navbar.GlobalNavBar.api.products'
-                                        defaultMessage='API Products'
-                                    />
-                                </GlobalNavLink>
-                            )}
-                        {(adminUser)
-                            && (
-                                <GlobalNavLink
-                                    id='scope'
-                                    to='/scopes'
-                                    type='scopes'
-                                    title={intl.formatMessage({
-                                        id: 'Base.Header.navbar.GlobalNavBar.title.scopes',
-                                        defaultMessage: 'Scopes',
-                                    })}
-                                    active={selected === 'scopes'}
-                                >
-                                    <FormattedMessage
-                                        id='Base.Header.navbar.GlobalNavBar.scopes'
-                                        defaultMessage='Scopes'
-                                    />
-                                </GlobalNavLink>
-                            )}
+                        <GlobalNavLink
+                            to='/api-products'
+                            type='api-product'
+                            title={intl.formatMessage({
+                                id: 'Base.Header.navbar.GlobalNavBar.title.api.products',
+                                defaultMessage: 'API Products',
+                            })}
+                            active={selected === 'api-products'}
+                        >
+                            <FormattedMessage
+                                id='Base.Header.navbar.GlobalNavBar.api.products'
+                                defaultMessage='API Products'
+                            />
+                        </GlobalNavLink>
+                        <GlobalNavLink
+                            id='scope'
+                            to='/scopes'
+                            type='scopes'
+                            title={intl.formatMessage({
+                                id: 'Base.Header.navbar.GlobalNavBar.title.scopes',
+                                defaultMessage: 'Scopes',
+                            })}
+                            active={selected === 'scopes'}
+                        >
+                            <FormattedMessage
+                                id='Base.Header.navbar.GlobalNavBar.scopes'
+                                defaultMessage='Scopes'
+                            />
+                        </GlobalNavLink>
                         <GlobalNavLink
                             id='policies'
                             to='/policies'


### PR DESCRIPTION
## Purpose
> Make all navigation bar links visible to all users, as anyone who can log in to the publisher portal can view every page.
> Fix `FormattedMessage` usage for correct string passing.
> Related Issue: https://github.com/wso2/api-manager/issues/3118

## Approach
> Remove user role checks from navigation bar. 
> Replaced the direct usage of `FormattedMessage` with `intl.formatMessage`.