### PR TITLE
Fix logic for disabling the save button in the Design Configurations

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -625,8 +625,9 @@ export default function DesignConfigurations() {
                                     )}
                                     <Box pt={2}>
                                         <Button
-                                            disabled={errorInAccessRoles ||
-                                                errorInRoleVisibility ||
+                                            disabled={
+                                                (apiConfig.accessControl === 'RESTRICTED' && errorInAccessRoles) ||
+                                                (apiConfig.visibility === 'RESTRICTED' && errorInRoleVisibility) ||
                                                 restricted ||
                                                 errorInTags ||
                                                 errorInExternalEndpoints}


### PR DESCRIPTION
# Purpose
Fixing the save button issue

# Issues
Fixes https://github.com/wso2/api-manager/issues/3225

# Approach
Added logic to ensure that access role errors and visibility roles are considered for disabling the save button only if the respective options are selected.


