### PR TITLE
Reset isPolicyEmpty flag when certificate upload window is closed.

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/UploadCertificate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/UploadCertificate.jsx
@@ -160,6 +160,7 @@ export default function UploadCertificate(props) {
         setKeyType(API_SECURITY_KEY_TYPE_PRODUCTION);
         setEndpoint('');
         setPolicy('');
+        setPoliciesEmpty(true);
     };
 
     const isAliasIncluded = () => {


### PR DESCRIPTION
## Description
Fixes https://github.com/wso2/api-manager/issues/3123

From the publisher portal's API configurations we can add a certificate for Mutual SSL in Transport Level Security. Users should not be allowed to add certificates if a business plan is not selected. But if a user first selects a business plan, closes the certificate upload window and add a certificate again without a business plan, the save button is enabled.

## Approach
The`isPoliciesEmpty` state is reset to `true` when the certificate upload window is closed.

## Testing
The certificate upload flows of endpoint security and mutual SSL have been tested.