### PR TITLE
Fix alignment of read only label in top menu

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/APIDetailsTopMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/APIDetailsTopMenu.jsx
@@ -60,6 +60,7 @@ const classes = {
     topRevisionStyle: `${PREFIX}-topRevisionStyle`,
     readOnlyStyle: `${PREFIX}-readOnlyStyle`,
     active: `${PREFIX}-active`,
+    alertMargin: `${PREFIX}-alertMargin`,
 };
 
 const Root = styled('div')(({ theme }) => ({
@@ -139,6 +140,9 @@ const Root = styled('div')(({ theme }) => ({
         height: 8,
         borderRadius: '50%',
         alignItems: 'center',
+    },
+    [`.${classes.alertMargin}`]: {
+        marginLeft: theme.spacing(1),
     },
 }));
 
@@ -294,6 +298,7 @@ const APIDetailsTopMenu = (props) => {
                         variant='outlined'
                         severity='warning'
                         icon={false}
+                        className={classes.alertMargin}
                     >
                         <FormattedMessage
                             id='Apis.Details.components.APIDetailsTopMenu.read.only.label'
@@ -301,13 +306,13 @@ const APIDetailsTopMenu = (props) => {
                         />
                     </MUIAlert>
                 )}
-                <div className={classes.dateWrapper} />
                 {(api.subtypeConfiguration?.subtype === 'AIAPI') && (
                     <MUIAlert
                         data-testid='itest-ai-api-label'
                         variant='outlined'
                         severity='info'
                         icon={false}
+                        className={classes.alertMargin}
                     >
                         <FormattedMessage
                             id='Apis.Details.components.APIDetailsTopMenu.ai.api.label'
@@ -321,6 +326,7 @@ const APIDetailsTopMenu = (props) => {
                         variant='outlined'
                         severity='warning'
                         icon={false}
+                        className={classes.alertMargin}
                     >
                         <FormattedMessage
                             id='Apis.Details.components.APIDetailsTopMenu.advertise.only.label'


### PR DESCRIPTION
# Purpose
Fixing the alignment of "Read Only" button in the top menu.

# Issues
Fixes https://github.com/wso2/api-manager/issues/3299

# Screenshots

<img width="498" alt="Screenshot 2024-10-31 at 21 05 11" src="https://github.com/user-attachments/assets/ae81f7a7-d2b5-4e41-a635-121ea0e3406b">
<img width="498" alt="Screenshot 2024-10-31 at 21 18 01" src="https://github.com/user-attachments/assets/ee958a25-ea22-4843-9e41-df3182888934">


