### PR TITLE
Add support for org-wide application update

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -107,8 +107,6 @@ class ApplicationFormHandler extends React.Component {
      * retrieve Settings from the context and check the org-wide application update enabled
      */
     isOrgWideAppUpdateEnabled = () => {
-        // const settingsContext = this.context;
-        // const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
         const { settings: { orgWideAppUpdateEnabled } } = this.context;
         this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -78,6 +79,7 @@ class ApplicationFormHandler extends React.Component {
             allAppAttributes: null,
             isApplicationSharingEnabled: true,
             applicationOwner: '',
+            isOrgWideAppUpdateEnabled: false,
         };
         this.handleAddChip = this.handleAddChip.bind(this);
         this.handleDeleteChip = this.handleDeleteChip.bind(this);
@@ -99,6 +101,16 @@ class ApplicationFormHandler extends React.Component {
             this.initApplicationCreateState();
         }
         this.isApplicationGroupSharingEnabled();
+        this.isOrgWideAppUpdateEnabled();
+    }
+
+    /**
+     * retrieve Settings from the context and check the org-wide application update enabled
+     */
+    isOrgWideAppUpdateEnabled = () => {
+        const settingsContext = this.context;
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 
     /**
@@ -415,7 +427,7 @@ class ApplicationFormHandler extends React.Component {
     render() {
         const {
             throttlingPolicyList, applicationRequest, isNameValid, allAppAttributes, isApplicationSharingEnabled,
-            isEdit, applicationOwner,
+            isEdit, applicationOwner, isOrgWideAppUpdateEnabled,
         } = this.state;
         const { match: { params } } = this.props;
 
@@ -501,7 +513,8 @@ class ApplicationFormHandler extends React.Component {
                                             onClick={isEdit ? this.saveEdit : this.saveApplication}
                                             disabled={
                                                 isEdit
-                                                && AuthManager.getUser().name.toLowerCase() !== applicationOwner.toLowerCase()
+                                                && (!isOrgWideAppUpdateEnabled
+                                                && AuthManager.getUser().name.toLowerCase() !== applicationOwner.toLowerCase())
                                             }
                                             className={classes.button}
                                         >

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -108,8 +107,9 @@ class ApplicationFormHandler extends React.Component {
      * retrieve Settings from the context and check the org-wide application update enabled
      */
     isOrgWideAppUpdateEnabled = () => {
-        const settingsContext = this.context;
-        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        // const settingsContext = this.context;
+        // const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        const { settings: { orgWideAppUpdateEnabled } } = this.context;
         this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
@@ -58,11 +58,6 @@ class InfoBar extends React.Component {
         this.toggleDeleteConfirmation = this.toggleDeleteConfirmation.bind(this);
     }
 
-    /**
-     *
-     * Get all tags
-     * @memberof CommonListing
-     */
     componentDidMount() {
         this.isOrgWideAppUpdateEnabled();
     }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -31,6 +32,7 @@ import Application from 'AppData/Application';
 import Alert from 'AppComponents/Shared/Alert';
 import AuthManager from 'AppData/AuthManager';
 import Box from '@mui/material/Box';
+import Settings from 'AppComponents/Shared/SettingsContext';
 import DeleteConfirmation from '../Listing/DeleteConfirmation';
 
 /**
@@ -49,11 +51,30 @@ class InfoBar extends React.Component {
             notFound: false,
             showOverview: true,
             isDeleteOpen: false,
+            isOrgWideAppUpdateEnabled: false,
         };
         this.toggleOverview = this.toggleOverview.bind(this);
         this.handleAppDelete = this.handleAppDelete.bind(this);
         this.handleDeleteConfimation = this.handleDeleteConfimation.bind(this);
         this.toggleDeleteConfirmation = this.toggleDeleteConfirmation.bind(this);
+    }
+
+    /**
+     *
+     * Get all tags
+     * @memberof CommonListing
+     */
+    componentDidMount() {
+        this.isOrgWideAppUpdateEnabled();
+    }
+
+    /**
+     * retrieve Settings from the context and check the org-wide application update enabled
+     */
+    isOrgWideAppUpdateEnabled = () => {
+        const settingsContext = this.context;
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 
     toggleDeleteConfirmation = () => {
@@ -125,7 +146,7 @@ class InfoBar extends React.Component {
         } = this.props;
         const applicationOwner = this.props.application.owner;
         const {
-            notFound, isDeleteOpen,
+            notFound, isDeleteOpen, isOrgWideAppUpdateEnabled,
         } = this.state;
 
         if (notFound) {
@@ -180,7 +201,7 @@ class InfoBar extends React.Component {
                             </Typography>
                         </Box>
                     </Grid>
-                    {isUserOwner && (
+                    {(isOrgWideAppUpdateEnabled || isUserOwner) && (
                         <Grid container justifyContent='flex-end'>
                             <VerticalDivider height={70} />
                             <Grid
@@ -252,7 +273,7 @@ class InfoBar extends React.Component {
                                     id='delete-application'
                                     onClick={this.handleDeleteConfimation}
                                     style={{ padding: '4px', display: 'flex', flexDirection: 'column' }}
-                                    disabled={AuthManager.getUser().name !== applicationOwner
+                                    disabled={(!isOrgWideAppUpdateEnabled && AuthManager.getUser().name !== applicationOwner)
                                         || this.props.application.status === 'DELETE_PENDING'}
                                     color='grey'
                                     classes={{
@@ -291,6 +312,9 @@ class InfoBar extends React.Component {
         );
     }
 }
+
+InfoBar.contextType = Settings;
+
 InfoBar.propTypes = {
     classes: PropTypes.shape({}).isRequired,
     theme: PropTypes.shape({}).isRequired,

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/InfoBar.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -72,8 +71,7 @@ class InfoBar extends React.Component {
      * retrieve Settings from the context and check the org-wide application update enabled
      */
     isOrgWideAppUpdateEnabled = () => {
-        const settingsContext = this.context;
-        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        const { settings: { orgWideAppUpdateEnabled } } = this.context;
         this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -115,8 +114,7 @@ class AppsTableContent extends Component {
      * retrieve Settings from the context and check the org-wide application update enabled
      */
     isOrgWideAppUpdateEnabled = () => {
-        const settingsContext = this.context;
-        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        const { settings: { orgWideAppUpdateEnabled } } = this.context;
         this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
@@ -285,9 +285,9 @@ class AppsTableContent extends Component {
                                                 <span>
                                                     <Link
                                                         to={`/applications/${app.applicationId}/edit/`}
-                                                        className={(!isOrgWideAppUpdateEnabled &&!isAppOwner) && classes.appOwner}
+                                                        className={(!isOrgWideAppUpdateEnabled && !isAppOwner) && classes.appOwner}
                                                     >
-                                                        <IconButton 
+                                                        <IconButton
                                                             disabled={!isOrgWideAppUpdateEnabled && !isAppOwner}
                                                             aria-label={'Edit' + app.name}
                                                             size='large'

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
@@ -101,11 +101,6 @@ class AppsTableContent extends Component {
         };
     }
 
-    /**
-     *
-     * Get all tags
-     * @memberof CommonListing
-     */
     componentDidMount() {
         this.isOrgWideAppUpdateEnabled();
     }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Listing/AppsTableContent.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-destructuring */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -32,6 +33,7 @@ import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import { ScopeValidation, resourceMethods, resourcePaths } from 'AppComponents/Shared/ScopeValidation';
 import PropTypes from 'prop-types';
 import AuthManager from 'AppData/AuthManager';
+import Settings from 'AppComponents/Shared/SettingsContext';
 
 const PREFIX = 'AppsTableContent';
 
@@ -90,6 +92,7 @@ class AppsTableContent extends Component {
         super(props);
         this.state = {
             notFound: false,
+            isOrgWideAppUpdateEnabled: false,
         };
         this.APPLICATION_STATES = {
             CREATED: 'CREATED',
@@ -100,6 +103,24 @@ class AppsTableContent extends Component {
     }
 
     /**
+     *
+     * Get all tags
+     * @memberof CommonListing
+     */
+    componentDidMount() {
+        this.isOrgWideAppUpdateEnabled();
+    }
+
+    /**
+     * retrieve Settings from the context and check the org-wide application update enabled
+     */
+    isOrgWideAppUpdateEnabled = () => {
+        const settingsContext = this.context;
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
+    }
+
+    /**
      * @inheritdoc
      * @memberof AppsTableContent
      */
@@ -107,7 +128,7 @@ class AppsTableContent extends Component {
         const {
             apps, toggleDeleteConfirmation,
         } = this.props;
-        const { notFound } = this.state;
+        const { notFound, isOrgWideAppUpdateEnabled } = this.state;
         let appsTableData = [];
 
         if (apps) {
@@ -248,7 +269,7 @@ class AppsTableContent extends Component {
                                     >
                                         {(app.status === this.APPLICATION_STATES.APPROVED
                                         || app.status === this.APPLICATION_STATES.DELETE_PENDING) && (
-                                            <Tooltip title={isAppOwner
+                                            <Tooltip title={isOrgWideAppUpdateEnabled || isAppOwner
                                                 ? (
                                                     <FormattedMessage
                                                         id='Applications.Listing.AppsTableContent.edit.tooltip'
@@ -264,9 +285,13 @@ class AppsTableContent extends Component {
                                                 <span>
                                                     <Link
                                                         to={`/applications/${app.applicationId}/edit/`}
-                                                        className={!isAppOwner && classes.appOwner}
+                                                        className={(!isOrgWideAppUpdateEnabled &&!isAppOwner) && classes.appOwner}
                                                     >
-                                                        <IconButton disabled={!isAppOwner} aria-label={'Edit' + app.name} size='large'>
+                                                        <IconButton 
+                                                            disabled={!isOrgWideAppUpdateEnabled && !isAppOwner}
+                                                            aria-label={'Edit' + app.name}
+                                                            size='large'
+                                                        >
                                                             <Icon>
                                                                 edit
                                                             </Icon>
@@ -280,7 +305,7 @@ class AppsTableContent extends Component {
                                         resourcePath={resourcePaths.SINGLE_APPLICATION}
                                         resourceMethod={resourceMethods.DELETE}
                                     >
-                                        <Tooltip title={isAppOwner ? (
+                                        <Tooltip title={isOrgWideAppUpdateEnabled || isAppOwner ? (
                                             <FormattedMessage
                                                 id='Applications.Listing.AppsTableContent.delete.tooltip'
                                                 defaultMessage='Delete'
@@ -295,7 +320,7 @@ class AppsTableContent extends Component {
                                             <span>
                                                 <IconButton
                                                     className='itest-application-delete-button'
-                                                    disabled={app.deleting || !isAppOwner
+                                                    disabled={app.deleting || (!isOrgWideAppUpdateEnabled && !isAppOwner)
                                                         || app.status === this.APPLICATION_STATES.DELETE_PENDING}
                                                     data-appid={app.applicationId}
                                                     onClick={toggleDeleteConfirmation}
@@ -318,6 +343,9 @@ class AppsTableContent extends Component {
         );
     }
 }
+
+AppsTableContent.contextType = Settings;
+
 AppsTableContent.propTypes = {
     toggleDeleteConfirmation: PropTypes.func.isRequired,
     apps: PropTypes.instanceOf(Map).isRequired,

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
@@ -240,7 +240,7 @@ const AppConfiguration = (props) => {
                                 margin='dense'
                                 variant='outlined'
                                 size='small'
-                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                             >
                                 {config.values.map(key => (
                                     <MenuItem key={key} value={key}>
@@ -345,7 +345,7 @@ const AppConfiguration = (props) => {
                                 margin='dense'
                                 size='small'
                                 variant='outlined'
-                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                             />
                         ) : (config.type === 'checkbox') ? (
                             <Checkbox
@@ -365,7 +365,7 @@ const AppConfiguration = (props) => {
                                 }
                                 margin='dense'
                                 variant='outlined'
-                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                             />
                         ) : (
                             <TextField
@@ -385,7 +385,7 @@ const AppConfiguration = (props) => {
                                 }
                                 margin='dense'
                                 variant='outlined'
-                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                             />
                         )}
                     </Box>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { styled } from '@mui/material/styles';
 import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
@@ -34,6 +34,7 @@ import Select from '@mui/material/Select';
 import Input from '@mui/material/Input';
 import Box from '@mui/material/Box';
 import ChipInput from 'AppComponents/Shared/ChipInput';
+import Settings from 'AppComponents/Shared/SettingsContext';
 
 
 const PREFIX = 'AppConfiguration';
@@ -107,6 +108,8 @@ const AppConfiguration = (props) => {
     } = props;
 
     const [selectedValue, setSelectedValue] = useState(previousValue);
+    const [isOrgWideAppUpdateEnabled, setIsOrgWideAppUpdateEnabled] = useState(false);
+    const settingsContext = useContext(Settings);
 
     /**
      * This method is used to handle the updating of key generation
@@ -199,7 +202,9 @@ const AppConfiguration = (props) => {
      */
     useEffect(() => {
         setSelectedValue(previousValue);
-    }, [previousValue])
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        setIsOrgWideAppUpdateEnabled(orgWideAppUpdateEnabled);
+    }, [previousValue, settingsContext]);
 
     const setCheckboxValue = () => {
         return ( typeof selectedValue === 'string' && selectedValue === 'true' )
@@ -235,7 +240,7 @@ const AppConfiguration = (props) => {
                                 margin='dense'
                                 variant='outlined'
                                 size='small'
-                                disabled={!isUserOwner}
+                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
                             >
                                 {config.values.map(key => (
                                     <MenuItem key={key} value={key}>
@@ -340,7 +345,7 @@ const AppConfiguration = (props) => {
                                 margin='dense'
                                 size='small'
                                 variant='outlined'
-                                disabled={!isUserOwner}
+                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
                             />
                         ) : (config.type === 'checkbox') ? (
                             <Checkbox
@@ -360,7 +365,7 @@ const AppConfiguration = (props) => {
                                 }
                                 margin='dense'
                                 variant='outlined'
-                                disabled={!isUserOwner}
+                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
                             />
                         ) : (
                             <TextField
@@ -380,7 +385,7 @@ const AppConfiguration = (props) => {
                                 }
                                 margin='dense'
                                 variant='outlined'
-                                disabled={!isUserOwner}
+                                disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)}
                             />
                         )}
                     </Box>
@@ -389,6 +394,8 @@ const AppConfiguration = (props) => {
         </Root>
     );
 };
+
+AppConfiguration.contextType = Settings;
 
 AppConfiguration.defaultProps = {
     notFound: false,

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -30,6 +30,7 @@ import FormHelperText from '@mui/material/FormHelperText';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
+import Settings from 'AppComponents/Shared/SettingsContext';
 
 function ImportExternalApp(props) {
     const {
@@ -46,6 +47,18 @@ function ImportExternalApp(props) {
     const handleClose = () => {
         setOpen(false);
     };
+
+    const [isOrgWideAppUpdateEnabled, setIsOrgWideAppUpdateEnabled] = useState(false);
+    const settingsContext = useContext(Settings);
+
+    /**
+     * Update the state when new props are available
+     */
+    useEffect(() => {
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        setIsOrgWideAppUpdateEnabled(orgWideAppUpdateEnabled);
+    }, [settingsContext]);
+
     /**
      * Handle onChange of provided consumer key and secret
      *
@@ -90,7 +103,7 @@ function ImportExternalApp(props) {
                                 onChange={e => handleChange(e)}
                                 margin='normal'
                                 fullWidth
-                                disabled={!isUserOwner}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                                 variant='outlined'
                             />
                             <FormControl variant="standard">
@@ -114,7 +127,7 @@ function ImportExternalApp(props) {
                                 onChange={e => handleChange(e)}
                                 margin='normal'
                                 fullWidth
-                                disabled={!isUserOwner}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                                 variant='outlined'
                             />
                             <FormControl variant="standard">
@@ -140,13 +153,13 @@ function ImportExternalApp(props) {
                         resourcePath={resourcePaths.APPLICATION_GENERATE_KEYS}
                         resourceMethod={resourceMethods.POST}
                     >
-                        {!isUserOwner ? (
+                        {!isOrgWideAppUpdateEnabled && !isUserOwner ? (
                             <>
                                 <Button
                                     variant='contained'
                                     color='primary'
                                     onClick={() => provideOAuthKeySecret()}
-                                    disabled={!isUserOwner}
+                                    disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                                 >
                                     {
                                         key

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ImportExternalApp.jsx
@@ -52,7 +52,7 @@ function ImportExternalApp(props) {
     const settingsContext = useContext(Settings);
 
     /**
-     * Update the state when new props are available
+     * Updates isOrgWideAppUpdateEnabled whenever settingsContext changes
      */
     useEffect(() => {
         const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import cloneDeep from 'lodash.clonedeep';
@@ -36,6 +36,7 @@ import PropTypes from 'prop-types';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import Validation from 'AppData/Validation';
 import AppConfiguration from './AppConfiguration';
+import ContextSettings from 'AppComponents/Shared/SettingsContext';
 
 const PREFIX = 'KeyConfiguration';
 
@@ -154,6 +155,8 @@ const KeyConfiguration = (props) => {
         enableMapOAuthConsumerApps, enableOAuthAppCreation, enableTokenEncryption, enableTokenGeneration,
         id, name, revokeEndpoint, tokenEndpoint, type, userInfoEndpoint,
     } = keyManagerConfig;
+    const [isOrgWideAppUpdateEnabled, setIsOrgWideAppUpdateEnabled] = useState(false);
+    const settingsContext = useContext(ContextSettings);
 
     /**
      * Get the display names for the supported grant types
@@ -267,6 +270,14 @@ const KeyConfiguration = (props) => {
         availableGrantTypes,
         Settings.grantTypes,
     );
+
+    /**
+     * Update the state when new props are available
+     */
+    useEffect(() => {
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        setIsOrgWideAppUpdateEnabled(orgWideAppUpdateEnabled);
+    }, [settingsContext]);
 
     // Check for additional properties for token endpoint and revoke endpoints.
     return (
@@ -406,7 +417,7 @@ const KeyConfiguration = (props) => {
                                                                 && selectedGrantTypes.includes(key))}
                                                         onChange={(e) => handleChange('grantType', e)}
                                                         value={value}
-                                                        disabled={!isUserOwner}
+                                                        disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                                                         color='grey'
                                                         data-testid={key}
                                                     />
@@ -460,7 +471,7 @@ const KeyConfiguration = (props) => {
                                             />
                                         )}
                                         variant='outlined'
-                                        disabled={!isUserOwner
+                                        disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner)
                                             || (selectedGrantTypes && !selectedGrantTypes.includes('authorization_code')
                                                 && !selectedGrantTypes.includes('implicit'))}
                                         error={callbackError}

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
@@ -159,7 +159,7 @@ const KeyConfiguration = (props) => {
     const settingsContext = useContext(ContextSettings);
 
     /**
-     * Update the state when new props are available
+     * Updates isOrgWideAppUpdateEnabled whenever settingsContext changes
      */
     useEffect(() => {
         const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
@@ -159,6 +159,14 @@ const KeyConfiguration = (props) => {
     const settingsContext = useContext(ContextSettings);
 
     /**
+     * Update the state when new props are available
+     */
+    useEffect(() => {
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        setIsOrgWideAppUpdateEnabled(orgWideAppUpdateEnabled);
+    }, [settingsContext]);
+
+    /**
      * Get the display names for the supported grant types
      * @param grantTypes
      * @param grantTypeDisplayNameMap
@@ -270,14 +278,6 @@ const KeyConfiguration = (props) => {
         availableGrantTypes,
         Settings.grantTypes,
     );
-
-    /**
-     * Update the state when new props are available
-     */
-    useEffect(() => {
-        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
-        setIsOrgWideAppUpdateEnabled(orgWideAppUpdateEnabled);
-    }, [settingsContext]);
 
     // Check for additional properties for token endpoint and revoke endpoints.
     return (

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -57,6 +57,7 @@ import TokenMangerSummary from './TokenManagerSummary';
 import Progress from '../Progress';
 import RemoveKeys from './RemoveKeys';
 import CleanKeys from './CleanKeys';
+import Settings from 'AppComponents/Shared/SettingsContext';
 
 const PREFIX = 'TokenManager';
 
@@ -236,6 +237,7 @@ class TokenManager extends React.Component {
             importDisabled: false,
             mode: null,
             tokenType: 'DIRECT',
+            isOrgWideAppUpdateEnabled: false,
         };
         this.keyStates = {
             COMPLETED: 'COMPLETED',
@@ -262,6 +264,7 @@ class TokenManager extends React.Component {
      */
     componentDidMount() {
         this.loadApplication();
+        this.isOrgWideAppUpdateEnabled();
     }
 
     componentDidUpdate(nextProps) {
@@ -270,6 +273,15 @@ class TokenManager extends React.Component {
         if (nextKeyType !== prevKeyType) {
             this.loadApplication();
         }
+    }
+
+    /**
+     * retrieve Settings from the context and check the org-wide application update enabled
+     */
+    isOrgWideAppUpdateEnabled = () => {
+        const settingsContext = this.context;
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 
     /**
@@ -728,7 +740,7 @@ class TokenManager extends React.Component {
         const {
             keys, keyRequest, isLoading, isKeyJWT, providedConsumerKey,
             providedConsumerSecret, selectedTab, keyManagers, validating, hasError, initialToken,
-            initialValidityTime, initialScopes, importDisabled, mode, tokenType,
+            initialValidityTime, initialScopes, importDisabled, mode, tokenType, isOrgWideAppUpdateEnabled,
         } = this.state;
 
         if (keyManagers && keyManagers.length === 0) {
@@ -982,7 +994,7 @@ class TokenManager extends React.Component {
                                                 resourcePath={resourcePaths.APPLICATION_GENERATE_KEYS}
                                                 resourceMethod={resourceMethods.POST}
                                             >
-                                                {!isUserOwner ? (
+                                                {!isOrgWideAppUpdateEnabled && !isUserOwner ? (
                                                     <>
                                                         <Button
                                                             id='generate-keys'
@@ -992,7 +1004,7 @@ class TokenManager extends React.Component {
                                                             onClick={
                                                                 key ? this.updateKeys : this.generateKeys
                                                             }
-                                                            disabled={!isUserOwner || isLoading || !keymanager.enableOAuthAppCreation
+                                                            disabled={(!isOrgWideAppUpdateEnabled && !isUserOwner) || isLoading || !keymanager.enableOAuthAppCreation
                                                                 || (isKeyManagerAllowed
                                                                     && !isKeyManagerAllowed(keymanager.name)
                                                                     && ((keymanager.name !== 'Resident Key Manager')
@@ -1226,7 +1238,7 @@ class TokenManager extends React.Component {
                                                             resourcePath={resourcePaths.APPLICATION_GENERATE_KEYS}
                                                             resourceMethod={resourceMethods.POST}
                                                         >
-                                                            {!isUserOwner ? (
+                                                            {!isOrgWideAppUpdateEnabled && !isUserOwner ? (
                                                                 <>
                                                                     <Button
                                                                         id='generate-keys'
@@ -1367,6 +1379,8 @@ class TokenManager extends React.Component {
         );
     }
 }
+
+TokenManager.contextType = Settings;
 
 TokenManager.defaultProps = {
     updateSubscriptionData: () => { },

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ViewKeys.jsx
@@ -45,6 +45,7 @@ import Tokens from './Tokens';
 import ViewToken from './ViewToken';
 import ViewSecret from './ViewSecret';
 import ViewCurl from './ViewCurl';
+import Settings from 'AppComponents/Shared/SettingsContext';
 
 const PREFIX = 'ViewKeys';
 
@@ -125,6 +126,7 @@ class ViewKeys extends React.Component {
             },
             subscriptionScopes: [],
             isUpdating: false,
+            isOrgWideAppUpdateEnabled: false,
         };
     }
 
@@ -133,6 +135,16 @@ class ViewKeys extends React.Component {
      */
     componentDidMount() {
         this.getGeneratedKeys();
+        this.isOrgWideAppUpdateEnabled();
+    }
+
+    /**
+     * retrieve Settings from the context and check the org-wide application update enabled
+     */
+    isOrgWideAppUpdateEnabled = () => {
+        const settingsContext = this.context;
+        const orgWideAppUpdateEnabled = settingsContext.settings.orgWideAppUpdateEnabled;
+        this.setState({ isOrgWideAppUpdateEnabled: orgWideAppUpdateEnabled });
     }
 
     /**
@@ -358,7 +370,7 @@ class ViewKeys extends React.Component {
             });
     };
 
-    viewKeyAndSecret = (consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner) => {
+    viewKeyAndSecret = (consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner, isOrgWideAppUpdateEnabled) => {
         const {
             intl, selectedApp: { hashEnabled }, keyType,
         } = this.props;
@@ -492,7 +504,7 @@ class ViewKeys extends React.Component {
                                 color='primary'
                                 sx={{ mt: 1 }}
                                 onClick={() => this.handleSecretRegenerate(consumerKey, keyType, keyMappingId, selectedTab)}
-                                disabled={!isUserOwner}
+                                disabled={!isOrgWideAppUpdateEnabled && !isUserOwner}
                             >
                                 <FormattedMessage
                                     defaultMessage='Regenerate Consumer Secret'
@@ -523,7 +535,7 @@ class ViewKeys extends React.Component {
         const {
             notFound, showToken, showCurl, showSecretGen, tokenCopied, open,
             token, tokenScopes, tokenValidityTime, accessTokenRequest, subscriptionScopes,
-            isKeyJWT, tokenResponse, secretGenResponse, isUpdating,
+            isKeyJWT, tokenResponse, secretGenResponse, isUpdating, isOrgWideAppUpdateEnabled,
         } = this.state;
         const {
             intl, keyType, fullScreen, keys, selectedApp: { tokenType }, selectedGrantTypes, isUserOwner, summary,
@@ -585,7 +597,7 @@ class ViewKeys extends React.Component {
         if (summary) {
             return (
                 <Grid container spacing={3}>
-                    {this.viewKeyAndSecret(consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner)}
+                    {this.viewKeyAndSecret(consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner, isOrgWideAppUpdateEnabled)}
                 </Grid>
             );
         }
@@ -595,7 +607,7 @@ class ViewKeys extends React.Component {
         return consumerKey && (
             <Root className={classes.inputWrapper}>
                 <Grid container spacing={3}>
-                    {this.viewKeyAndSecret(consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner)}
+                    {this.viewKeyAndSecret(consumerKey, consumerSecret, keyMappingId, selectedTab, isUserOwner, isOrgWideAppUpdateEnabled)}
                     <Grid item xs={12}>
                         <Dialog
                             fullScreen={fullScreen}
@@ -724,6 +736,9 @@ class ViewKeys extends React.Component {
         );
     }
 }
+
+ViewKeys.contextType = Settings;
+
 ViewKeys.defaultProps = {
     fullScreen: false,
     summary: false,

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyForm/UploadPolicyDropzone.tsx
@@ -117,7 +117,7 @@ const UploadPolicyDropzone: FC<UploadPolicyDropzoneProps> = ({
             defaultMessage: 'Incompatible file type',
         }));
     };
-    const intl = useIntl();
+    
     const renderPolicyFileDropzone = () => {
         return (
             <Dropzone


### PR DESCRIPTION
### Purpose
This UI fix introduces a capability that could represent a valid business requirement for certain customers. Consequently, the API-M product will include a system property that enables update access for users within the application-sharing group. This feature will be disabled by default to ensure the current behavior remains unchanged.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/3446

### Approach
Introduced `orgWideAppUpdateEnabled` system property to enable this capability.

Ex.: `sh api-manager.sh -DorgWideAppUpdateEnabled=true`

Related PR: https://github.com/wso2/carbon-apimgt/pull/12731
