### PR TITLE
Fix property value overflow in publisher portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Properties/EditableRow.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Properties/EditableRow.jsx
@@ -34,6 +34,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import Tooltip from '@mui/material/Tooltip';
 
 const PREFIX = 'EditableRow';
 
@@ -41,10 +42,11 @@ const classes = {
     link: `${PREFIX}-link`,
     checkBoxStyles: `${PREFIX}-checkBoxStyles`,
     colorPrimary: `${PREFIX}-colorPrimary`,
-    cancelButton: `${PREFIX}-cancelButton`
+    cancelButton: `${PREFIX}-cancelButton`,
+    tableCellStyles: `${PREFIX}-tableCellStyles`
 };
 
-const StyledTableRow = styled(TableRow)(() => ({
+const StyledTableRow = styled(TableRow)(({theme}) => ({
     [`& .${classes.link}`]: {
         cursor: 'pointer',
     },
@@ -62,6 +64,17 @@ const StyledTableRow = styled(TableRow)(() => ({
 
     [`& .${classes.cancelButton}`]: {
         marginLeft: 4,
+    },
+    [`& .${classes.tableCellStyles}`]: {
+        display: 'inline-block',
+        minWidth: '150px',
+        maxWidth: '600px',
+        whiteSpace: 'normal',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        [theme.breakpoints.up('xl')]: {
+            maxWidth: '1000px',
+        },
     }
 }));
 
@@ -195,9 +208,15 @@ function EditableRow(props) {
             ) : (
                 <>
                     <TableCell>
-                        <Box display='inline-block' minWidth={150}>
-                            {oldValue}
-                        </Box>
+                        <Tooltip
+                            placement='top'
+                            interactive
+                            title={oldValue}
+                        > 
+                            <Box className={classes.tableCellStyles}>
+                                {oldValue}
+                            </Box>
+                        </Tooltip>
                     </TableCell>
                     <TableCell>
                         {isVisibleInStore && (


### PR DESCRIPTION
## Purpose
> In the publisher portal, the Edit and Delete buttons of API properties becomes invisible if the property value is too long without containing white spaces, as it overflows.  The UI overflow needs to be fixed and a tooltip should be added to show the whole content.

## Approach
> Adjust the styling of the `Box` containing the `Property Value` so that the `overflow` is `hidden`, and `textOverflow` is set to `ellipsis`. Add a `Tooltip` to display the full content of the `Property Value`.

## Related to
https://github.com/wso2/api-manager/issues/3426
