### PR TITLE
Add graphql api creation by SDL url and introspection

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -160,6 +160,7 @@ export default function DefaultAPIForm(props) {
     const {
         onChange, onValidate, api, isAPIProduct, multiGateway,
         isWebSocket, children, appendChildrenBeforeEndpoint, hideEndpoint,
+        readOnlyAPIEndpoint,
     } = props;
 
     const [validity, setValidity] = useState({});
@@ -594,6 +595,7 @@ export default function DefaultAPIForm(props) {
                     <TextField
                         fullWidth
                         id='itest-id-apiendpoint-input'
+                        disabled={readOnlyAPIEndpoint !== null}
                         label={(
                             <FormattedMessage
                                 id='Apis.Create.Components.DefaultAPIForm.api.endpoint'
@@ -756,6 +758,7 @@ DefaultAPIForm.defaultProps = {
     onValidate: () => { },
     api: {}, // Uncontrolled component
     isWebSocket: false,
+    readOnlyAPIEndpoint: null,
 };
 DefaultAPIForm.propTypes = {
     api: PropTypes.shape({}),
@@ -764,4 +767,5 @@ DefaultAPIForm.propTypes = {
     isWebSocket: PropTypes.shape({}),
     onChange: PropTypes.func.isRequired,
     onValidate: PropTypes.func,
+    readOnlyAPIEndpoint: PropTypes.string,
 };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
@@ -236,7 +236,7 @@ export default function ApiCreateGraphQL(props) {
                         <FormattedMessage
                             id='Apis.Create.GraphQL.ApiCreateGraphQL.sub.heading'
                             defaultMessage={'Create a GraphQL API by importing a SDL definition'
-                                + ' from a file or URL, or by using introspection.'}
+                                + ' from a file or URL, or by using endpoint.'}
                         />
                     </Typography>
                 </>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
@@ -81,11 +81,14 @@ export default function ApiCreateGraphQL(props) {
             case 'version':
             case 'gatewayType':
             case 'endpoint':
+                return { ...currentState, [action]: value };
             case 'context':
             case 'isFormValid':
                 return { ...currentState, [action]: value };
             case 'inputType':
-                return { ...currentState, [action]: value, inputValue: value === 'url' ? '' : null };
+                return { ...currentState, [action]: value,
+                    inputValue: value === 'url' || value === 'endpoint' ? '' : null
+                };
             case 'graphQLInfo':
                 return { ...currentState, [action]: value };
             case 'preSetAPI':
@@ -145,6 +148,7 @@ export default function ApiCreateGraphQL(props) {
             endpoint,
             gatewayType,
             implementationType,
+            inputType,
             inputValue,
             graphQLInfo: { operations },
         } = apiInputs;
@@ -166,7 +170,6 @@ export default function ApiCreateGraphQL(props) {
             policies,
             operations,
         };
-        const uploadMethod = 'file';
         if (endpoint) {
             additionalProperties.endpointConfig = {
                 endpoint_type: 'http',
@@ -182,9 +185,13 @@ export default function ApiCreateGraphQL(props) {
         const apiData = {
             additionalProperties: JSON.stringify(additionalProperties),
             implementationType,
-            [uploadMethod]: uploadMethod,
-            file: inputValue,
         };
+
+        if (inputType === 'file') {
+            apiData.file = inputValue;
+        } else if (inputType === 'url' || inputType === 'endpoint') {
+            apiData.schema = apiInputs.graphQLInfo.graphQLSchema.schemaDefinition;
+        }
 
         newApi
             .importGraphQL(apiData)
@@ -222,13 +229,14 @@ export default function ApiCreateGraphQL(props) {
                     <Typography variant='h5'>
                         <FormattedMessage
                             id='Apis.Create.GraphQL.ApiCreateGraphQL.heading'
-                            defaultMessage='Create an API using a GraphQL SDL definition'
+                            defaultMessage='Create a GraphQL API'
                         />
                     </Typography>
                     <Typography variant='caption'>
                         <FormattedMessage
                             id='Apis.Create.GraphQL.ApiCreateGraphQL.sub.heading'
-                            defaultMessage='Create an API by importing an existing GraphQL SDL definition.'
+                            defaultMessage={'Create a GraphQL API by importing a SDL definition'
+                                + ' from a file or URL, or by using introspection.'}
                         />
                     </Typography>
                 </>
@@ -272,6 +280,7 @@ export default function ApiCreateGraphQL(props) {
                             multiGateway={multiGateway}
                             api={apiInputs}
                             isAPIProduct={false}
+                            readOnlyAPIEndpoint={apiInputs.inputType==='endpoint' ? apiInputs.endpoint : null}
                         />
                     )}
                 </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
@@ -81,7 +81,6 @@ export default function ApiCreateGraphQL(props) {
             case 'version':
             case 'gatewayType':
             case 'endpoint':
-                return { ...currentState, [action]: value };
             case 'context':
             case 'isFormValid':
                 return { ...currentState, [action]: value };
@@ -236,7 +235,8 @@ export default function ApiCreateGraphQL(props) {
                         <FormattedMessage
                             id='Apis.Create.GraphQL.ApiCreateGraphQL.sub.heading'
                             defaultMessage={'Create a GraphQL API by importing a SDL definition'
-                                + ' from a file or URL, or by using endpoint.'}
+                                + ' using a file, SDL hosted URL, or by using a GraphQL endpoint.'
+                            }
                         />
                     </Typography>
                 </>
@@ -280,7 +280,7 @@ export default function ApiCreateGraphQL(props) {
                             multiGateway={multiGateway}
                             api={apiInputs}
                             isAPIProduct={false}
-                            readOnlyAPIEndpoint={apiInputs.inputType==='endpoint' ? apiInputs.endpoint : null}
+                            readOnlyAPIEndpoint={apiInputs.inputType === 'endpoint' ? apiInputs.endpoint : null}
                         />
                     )}
                 </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/Steps/ProvideGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/Steps/ProvideGraphQL.jsx
@@ -155,7 +155,16 @@ export default function ProvideGraphQL(props) {
                     inputsDispatcher({ action: 'graphQLInfo', value: graphQLInfo });
                     setValidity({ isValidURL, file: null });
                 } else {
-                    setValidity({ isValidURL, file: { message: 'GraphQL content validation failed!' } });
+                    let errorMessage;
+                    if (inputType === ProvideGraphQL.INPUT_TYPES.ENDPOINT) {
+                        errorMessage = 'Error occurred while generating GraphQL schema from endpoint';
+                    } else if (inputType === ProvideGraphQL.INPUT_TYPES.URL) {
+                        errorMessage = 'Error occurred while retrieving GraphQL schema from url';
+                    }
+                    setValidity({
+                        isValidURL,
+                        file: { message: errorMessage }
+                    });
                 }
                 onValidate(isValidURL);
                 setIsValidating(false);
@@ -169,8 +178,8 @@ export default function ProvideGraphQL(props) {
             }
             
             const validationFunction = inputType === ProvideGraphQL.INPUT_TYPES.URL
-                ? () => API.validateGraphQLByUrl(newURL)
-                : () => API.validateGraphQLByEndpoint(newURL, { useIntrospection: true });
+                ? () => API.validateGraphQL(newURL)
+                : () => API.validateGraphQL(newURL, { useIntrospection: true });
 
             validationFunction()
                 .then(handleResponse)
@@ -296,8 +305,10 @@ export default function ProvideGraphQL(props) {
                                             </Avatar>
                                         </ListItemAvatar>
                                         <ListItemText
-                                            primary={`${apiInputs.inputValue.path} - 
-                                    ${humanFileSize(apiInputs.inputValue.size)}`}
+                                            primary={`
+                                                ${apiInputs.inputValue.path} - 
+                                                ${humanFileSize(apiInputs.inputValue.size)}`
+                                            }
                                             data-testid={'file-input-' + apiInputs.inputValue.path}
                                         />
                                         <ListItemSecondaryAction>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/Steps/ProvideGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/Steps/ProvideGraphQL.jsx
@@ -15,13 +15,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import Grid from '@mui/material/Grid';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import CircularProgress from '@mui/material/CircularProgress';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';
@@ -36,6 +36,10 @@ import ListItemText from '@mui/material/ListItemText';
 import API from 'AppData/api';
 import DropZoneLocal, { humanFileSize } from 'AppComponents/Shared/DropZoneLocal';
 import Banner from 'AppComponents/Shared/Banner';
+import { debounce, FormControlLabel, InputAdornment, Radio, RadioGroup, TextField } from '@mui/material';
+import APIValidation from 'AppData/APIValidation';
+import CheckIcon from '@mui/icons-material/Check';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 
 const PREFIX = 'ProvideGraphQL';
 
@@ -56,15 +60,18 @@ const Root = styled('div')((
 
 /**
  * Sub component of API Create using GraphQL UI, This is handling the taking input of GraphQL file or URL from the user
- * In the create API using OpenAPI wizard first step out of 2 steps
+ * In the create API using GraphQL wizard first step out of 2 steps
  * @export
  * @param {*} props
  * @returns {React.Component} @inheritdoc
  */
 export default function ProvideGraphQL(props) {
     const { apiInputs, inputsDispatcher, onValidate } = props;
-    const { inputValue } = apiInputs;
-
+    const { inputType, inputValue } = apiInputs;
+    const isURLInput = inputType === ProvideGraphQL.INPUT_TYPES.URL || inputType === '';
+    const isFileInput = inputType === ProvideGraphQL.INPUT_TYPES.FILE;
+    const isEndpointInput = inputType === ProvideGraphQL.INPUT_TYPES.ENDPOINT;
+    const intl = useIntl();
     // If valid value is `null`,that means valid, else an error object will be there
     const [isValid, setValidity] = useState({ file: null });
     const [isValidating, setIsValidating] = useState(false);
@@ -106,31 +113,161 @@ export default function ProvideGraphQL(props) {
             });
     }
 
+    function reset() {
+        inputsDispatcher({ action: 'importingContent', value: null });
+        inputsDispatcher({ action: 'inputValue', value: null });
+        inputsDispatcher({ action: 'isFormValid', value: false });
+        inputsDispatcher({ action: 'endpoint', value: '' });
+    }
+
+    const isInvalidURL = Boolean(isValid.url);
+    let urlStateEndAdornment = null;
+    if (isValidating) {
+        urlStateEndAdornment = (
+            <InputAdornment position='end'>
+                <CircularProgress />
+            </InputAdornment>
+        );
+    } else if (isValid.url !== undefined) {
+        if (isInvalidURL) {
+            urlStateEndAdornment = (
+                <InputAdornment position='end'>
+                    <ErrorOutlineIcon fontSize='large' color='error' />
+                </InputAdornment>
+            );
+        } else {
+            urlStateEndAdornment = (
+                <InputAdornment position='end' id='url-validated'>
+                    <CheckIcon fontSize='large' color='primary' />
+                </InputAdornment>
+            );
+        }
+    }
+
+    const debouncedValidateURLOrEndpoint = useCallback(
+        debounce((newURL) => {
+            const handleResponse = (response) => {
+                const {
+                    body: { graphQLInfo },
+                } = response;
+                const isValidURL = response.body.isValid;
+                if (isValidURL) {
+                    inputsDispatcher({ action: 'graphQLInfo', value: graphQLInfo });
+                    setValidity({ isValidURL, file: null });
+                } else {
+                    setValidity({ isValidURL, file: { message: 'GraphQL content validation failed!' } });
+                }
+                onValidate(isValidURL);
+                setIsValidating(false);
+            };
+
+            const handleError = (error) => {
+                setValidity({ url: { message: error.message } });
+                onValidate(false);
+                setIsValidating(false);
+                console.error(error);
+            }
+            
+            const validationFunction = inputType === ProvideGraphQL.INPUT_TYPES.URL
+                ? () => API.validateGraphQLByUrl(newURL)
+                : () => API.validateGraphQLByEndpoint(newURL, { useIntrospection: true });
+
+            validationFunction()
+                .then(handleResponse)
+                .catch(handleError);
+
+            if(inputType === ProvideGraphQL.INPUT_TYPES.ENDPOINT){
+                inputsDispatcher({ action: 'endpoint', value: newURL });
+            }
+        }, 750),
+        [inputType],
+    );
+
+    function validateURL(value) {
+        const state = APIValidation.url.required().validate(value).error;
+        if (state === null) {
+            setIsValidating(true);
+            debouncedValidateURLOrEndpoint(apiInputs.inputValue);
+        } else {
+            setValidity({ ...isValid, url: state });
+            onValidate(false);
+        }
+    }
+
     useEffect(() => {
         if (inputValue) {
-            onDrop([inputValue]);
+            if (inputType === ProvideGraphQL.INPUT_TYPES.FILE) {
+                onDrop([inputValue]);
+            } else if (inputType === ProvideGraphQL.INPUT_TYPES.URL ||
+                inputType === ProvideGraphQL.INPUT_TYPES.ENDPOINT) {
+                validateURL(inputValue);
+            }
         }
-    }, [inputValue]);
+    }, [inputType, inputValue]);
+
+    useEffect(() => {
+        reset();
+    }, [inputType]);
+
     const accept = '.graphql,text/plain';
     return (
         <Root>
             <Grid container>
-                {!apiInputs.inputValue && (
-                    <Grid item md={12} sx={{ mb: 2 }}>
-                        <FormControl component='fieldset'>
-                            <FormLabel component='legend'>
-                                <>
-                                    <sup className={classes.mandatoryStar}>*</sup>
-                                    {' '}
-                                    <FormattedMessage
-                                        id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.type'
-                                        defaultMessage='Provide GraphQL File'
-                                    />
-                                </>
-                            </FormLabel>
-                        </FormControl>
-                    </Grid>
-                )}
+                <Grid item xs={12} sx={{ mb: 2 }}>
+                    <FormControl component='fieldset'>
+                        <FormLabel component='legend'>
+                            <>
+                                <sup className={classes.mandatoryStar}>*</sup>
+                                {' '}
+                                <FormattedMessage
+                                    id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.type'
+                                    defaultMessage='Input Type'
+                                />
+                            </>
+                        </FormLabel>
+                        <RadioGroup
+                            aria-label='Input Source'
+                            value={apiInputs.inputType === '' ? 'url' : apiInputs.inputType}
+                            onChange={(event) => inputsDispatcher({
+                                action: 'inputType',
+                                value: event.target.value
+                            })}
+                        >
+                            <FormControlLabel
+                                disabled={isValidating}
+                                value={ProvideGraphQL.INPUT_TYPES.FILE}
+                                control={<Radio color='primary' />}
+                                label={intl.formatMessage({
+                                    id: 'Apis.Create.GraphQL.create.api.form.file.label',
+                                    defaultMessage: 'GraphQL File/Archive',
+                                })}
+                                aria-label='GraphQL File/Archive'
+                                id='graphql-file-select-radio'
+                            />
+                            <FormControlLabel
+                                disabled={isValidating}
+                                value={ProvideGraphQL.INPUT_TYPES.URL}
+                                control={<Radio color='primary' />}
+                                label={intl.formatMessage({
+                                    id: 'Apis.Create.GraphQL.create.api.form.url.label',
+                                    defaultMessage: 'GraphQL SDL URL',
+                                })}
+                                id='graphql-url-select-radio'
+                            />
+                            <FormControlLabel
+                                disabled={isValidating}
+                                value={ProvideGraphQL.INPUT_TYPES.ENDPOINT}
+                                control={<Radio color='primary' />}
+                                label={intl.formatMessage({
+                                    id: 'Apis.Create.GraphQL.create.api.form.endpoint.label',
+                                    defaultMessage: 'GraphQL Endpoint',
+                                })}
+                                aria-label='GraphQL Endpoint'
+                                id='graphql-endpoint-select-radio'
+                            />
+                        </RadioGroup>
+                    </FormControl>
+                </Grid>
                 {isValid.file
                     && (
                         <Grid item md={12}>
@@ -145,64 +282,146 @@ export default function ProvideGraphQL(props) {
                         </Grid>
                     )}
                 <Grid item md={12}>
-                    {apiInputs.inputValue ? (
-                        <List data-testid='uploaded-list-graphql'>
-                            <ListItem key={apiInputs.inputValue.path} data-testid='uploaded-list-content-graphql' >
-                                <ListItemAvatar>
-                                    <Avatar>
-                                        <InsertDriveFile />
-                                    </Avatar>
-                                </ListItemAvatar>
-                                <ListItemText
-                                    primary={`${apiInputs.inputValue.path} - 
-                                    ${humanFileSize(apiInputs.inputValue.size)}`}
-                                    data-testid={'file-input-'+apiInputs.inputValue.path}
-                                />
-                                <ListItemSecondaryAction>
-                                    <IconButton
-                                        edge='end'
-                                        aria-label='delete'
-                                        onClick={() => {
-                                            inputsDispatcher({ action: 'inputValue', value: null });
-                                            inputsDispatcher({ action: 'isFormValid', value: false });
-                                        }}
-                                        data-testid='btn-delete-imported-file'
-                                        size='large'>
-                                        <DeleteIcon />
-                                    </IconButton>
-                                </ListItemSecondaryAction>
-                            </ListItem>
-                        </List>
-                    ) : (
-                        <DropZoneLocal
-                            error={isValid.file}
-                            onDrop={onDrop}
-                            files={apiInputs.inputValue}
-                            accept={accept}
-                            ariaLabel='GraphQL file upload'
-                        >
-                            {isValidating ? (<CircularProgress />)
-                                : ([
-                                    <FormattedMessage
-                                        id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.file.dropzone'
-                                        defaultMessage={'Drag & Drop files here {break} or {break} '
-                                        + 'Browse files{break}({accept})'}
-                                        values={{ break: <br />, accept }}
-                                    />,
-                                    <Button
-                                        color='primary'
-                                        variant='contained'
-                                        data-testid='browse-to-upload-btn'
-                                        sx={{ mt: 1 }}
+                    {isFileInput && (
+                        <>
+                            {apiInputs.inputValue ? (
+                                <List data-testid='uploaded-list-graphql'>
+                                    <ListItem
+                                        key={apiInputs.inputValue.path}
+                                        data-testid='uploaded-list-content-graphql'
                                     >
-                                        <FormattedMessage
-                                            id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.file.upload'
-                                            defaultMessage='Browse File to Upload'
+                                        <ListItemAvatar>
+                                            <Avatar>
+                                                <InsertDriveFile />
+                                            </Avatar>
+                                        </ListItemAvatar>
+                                        <ListItemText
+                                            primary={`${apiInputs.inputValue.path} - 
+                                    ${humanFileSize(apiInputs.inputValue.size)}`}
+                                            data-testid={'file-input-' + apiInputs.inputValue.path}
                                         />
-                                    </Button>,
-                                ]
+                                        <ListItemSecondaryAction>
+                                            <IconButton
+                                                edge='end'
+                                                aria-label='delete'
+                                                onClick={() => {
+                                                    inputsDispatcher({ action: 'inputValue', value: null });
+                                                    inputsDispatcher({ action: 'isFormValid', value: false });
+                                                }}
+                                                data-testid='btn-delete-imported-file'
+                                                size='large'>
+                                                <DeleteIcon />
+                                            </IconButton>
+                                        </ListItemSecondaryAction>
+                                    </ListItem>
+                                </List>
+                            ) : (
+                                <DropZoneLocal
+                                    error={isValid.file}
+                                    onDrop={onDrop}
+                                    files={apiInputs.inputValue}
+                                    accept={accept}
+                                    ariaLabel='GraphQL file upload'
+                                >
+                                    {isValidating ? (<CircularProgress />)
+                                        : ([
+                                            <FormattedMessage
+                                                id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.file.dropzone'
+                                                defaultMessage={'Drag & Drop files here {break} or {break} '
+                                                    + 'Browse files{break}({accept})'}
+                                                values={{ break: <br />, accept }}
+                                            />,
+                                            <Button
+                                                color='primary'
+                                                variant='contained'
+                                                data-testid='browse-to-upload-btn'
+                                                sx={{ mt: 1 }}
+                                            >
+                                                <FormattedMessage
+                                                    id='Apis.Create.GraphQL.Steps.ProvideGraphQL.Input.file.upload'
+                                                    defaultMessage='Browse File to Upload'
+                                                />
+                                            </Button>,
+                                        ]
+                                        )}
+                                </DropZoneLocal>
+                            )}
+                        </>
+                    )}
+                    {isURLInput && (
+                        <TextField
+                            autoFocus
+                            id='outlined-full-width-url'
+                            label={intl.formatMessage({
+                                id: 'Apis.Create.GraphQL.create.api.url.label',
+                                defaultMessage: 'GraphQL SDL URL',
+                            })}
+                            placeholder={intl.formatMessage({
+                                id: 'Apis.Create.GraphQL.create.api.url.placeholder',
+                                defaultMessage: 'Enter GraphQL SDL URL',
+                            })}
+                            fullWidth
+                            margin='normal'
+                            variant='outlined'
+                            onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
+                            value={apiInputs.inputValue}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            InputProps={{
+                                onBlur: ({ target: { value } }) => {
+                                    validateURL(value);
+                                },
+                                endAdornment: urlStateEndAdornment,
+                            }}
+                            // 'Give the URL of GraphQL endpoint'
+                            helperText={(isValid.url && isValid.url.message)
+                                || (
+                                    <FormattedMessage
+                                        id='Apis.Create.GraphQL.create.api.url.helper.text'
+                                        defaultMessage='Click away to validate the URL'
+                                    />
                                 )}
-                        </DropZoneLocal>
+                            error={isInvalidURL}
+                            data-testid='graphql-add-form-url'
+                        />
+                    )}
+                    {isEndpointInput && (
+                        <TextField
+                            autoFocus
+                            id='outlined-full-width-endpoint'
+                            label={intl.formatMessage({
+                                id: 'Apis.Create.GraphQL.create.api.endpoint.label',
+                                defaultMessage: 'GraphQL Endpoint',
+                            })}
+                            placeholder={intl.formatMessage({
+                                id: 'Apis.Create.GraphQL.create.api.endpoint.placeholder',
+                                defaultMessage: 'Enter GraphQL Endpoint',
+                            })}
+                            fullWidth
+                            margin='normal'
+                            variant='outlined'
+                            onChange={({ target: { value } }) => inputsDispatcher({ action: 'inputValue', value })}
+                            value={apiInputs.inputValue}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            InputProps={{
+                                onBlur: ({ target: { value } }) => {
+                                    validateURL(value);
+                                },
+                                endAdornment: urlStateEndAdornment,
+                            }}
+                            helperText={(isValid.url && isValid.url.message)
+                                || (
+                                    <FormattedMessage
+                                        id='Apis.Create.GraphQL.create.api.url.helper.text'
+                                        defaultMessage='Click away to validate the URL'
+                                    />
+                                )}
+                            error={isInvalidURL}
+                            data-testid='graphql-add-form-endpoint'
+                        />
                     )}
                 </Grid>
             </Grid>
@@ -213,10 +432,18 @@ export default function ProvideGraphQL(props) {
 ProvideGraphQL.defaultProps = {
     onValidate: () => {},
 };
+
+ProvideGraphQL.INPUT_TYPES = {
+    URL: 'url',
+    ENDPOINT: 'endpoint',
+    FILE: 'file',
+};
+
 ProvideGraphQL.propTypes = {
     apiInputs: PropTypes.shape({
         type: PropTypes.string,
         inputType: PropTypes.string,
+        inputValue: PropTypes.string
     }).isRequired,
     inputsDispatcher: PropTypes.func.isRequired,
     onValidate: PropTypes.func,

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/ImportDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/ImportDefinition.jsx
@@ -456,18 +456,19 @@ export default function ImportDefinition(props) {
                             defaultMessage='Cancel'
                         />
                     </Button>
-                    {!isGraphQL && <Button
-                        onClick={handleAPIDefinitionEditAndImport}
-                        id='import-before-edit-btn'
-                        variant='contained'
-                        color='primary'
-                        disabled={apiInputs.importingContent == null}
-                    >
-                        <FormattedMessage
-                            id='Apis.Details.APIDefinition.APIDefinition.import.definition.edit'
-                            defaultMessage='Edit and Import'
-                        />
-                    </Button>
+                    {!isGraphQL && 
+                        <Button
+                            onClick={handleAPIDefinitionEditAndImport}
+                            id='import-before-edit-btn'
+                            variant='contained'
+                            color='primary'
+                            disabled={apiInputs.importingContent == null}
+                        >
+                            <FormattedMessage
+                                id='Apis.Details.APIDefinition.APIDefinition.import.definition.edit'
+                                defaultMessage='Edit and Import'
+                            />
+                        </Button>
                     }
                     <Button
                         onClick={importDefinition}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/ImportDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/ImportDefinition.jsx
@@ -253,10 +253,20 @@ export default function ImportDefinition(props) {
     function updateGraphQLSchema() {
         const {
             inputValue,
+            inputType,
         } = apiInputs;
 
-        const promisedValidation = API.validateGraphQLFile(inputValue);
-        promisedValidation
+        let validationPromise;
+
+        if (inputType === ProvideGraphQL.INPUT_TYPES.FILE) {
+            validationPromise = API.validateGraphQLFile(inputValue);
+        } else if (inputType === ProvideGraphQL.INPUT_TYPES.URL) {
+            validationPromise = API.validateGraphQLByUrl(inputValue);
+        } else if (inputType === ProvideGraphQL.INPUT_TYPES.ENDPOINT) {
+            validationPromise = API.validateGraphQLByEndpoint(inputValue, { useIntrospection: true });
+        }
+
+        validationPromise
             .then((response) => {
                 const { isValid, graphQLInfo } = response.obj;
                 if (isValid === true) {
@@ -446,18 +456,19 @@ export default function ImportDefinition(props) {
                             defaultMessage='Cancel'
                         />
                     </Button>
-                    <Button 
+                    {!isGraphQL && <Button
                         onClick={handleAPIDefinitionEditAndImport}
                         id='import-before-edit-btn'
                         variant='contained'
                         color='primary'
-                        disabled={apiInputs.importingContent==null}
+                        disabled={apiInputs.importingContent == null}
                     >
                         <FormattedMessage
                             id='Apis.Details.APIDefinition.APIDefinition.import.definition.edit'
                             defaultMessage='Edit and Import'
                         />
                     </Button>
+                    }
                     <Button
                         onClick={importDefinition}
                         variant='contained'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
@@ -46,13 +46,13 @@ const GraphqlAPIMenu = (props) => {
                 helperText={(
                     <FormattedMessage
                         id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.content'
-                        defaultMessage='Use an existing definition'
+                        defaultMessage='Use an existing schema or introspection'
                     />
                 )}
             >
                 <FormattedMessage
                     id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.title'
-                    defaultMessage='Import GraphQL SDL'
+                    defaultMessage='Create GraphQL API'
                 />
             </LandingMenuItem>
         </Component>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/GraphqlAPIMenu.jsx
@@ -46,7 +46,7 @@ const GraphqlAPIMenu = (props) => {
                 helperText={(
                     <FormattedMessage
                         id='Apis.Listing.SampleAPI.SampleAPI.graphql.import.sdl.content'
-                        defaultMessage='Use an existing schema or introspection'
+                        defaultMessage='Use an existing schema or endpoint'
                     />
                 )}
             >

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -1545,7 +1545,9 @@ class API extends Resource {
             requestBody: {
                 type: 'GraphQL',
                 additionalProperties: api_data.additionalProperties,
-                file: api_data.file,
+                ...(api_data.file !== undefined
+                    ? { file: api_data.file }
+                    : { schema: api_data.schema }),
             }
         };
 
@@ -1584,6 +1586,49 @@ class API extends Resource {
             );
         });
         return promised_validationResponse;
+    }
+
+    static validateGraphQLByUrl(url) {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+        const promised_validationResponse = apiClient.then(client => {
+            return client.apis['Validation'].validateGraphQLSchema(
+                {
+                    type: 'GraphQL',
+                    'Content-Type': 'multipart/form-data',
+                },
+                {
+                    requestBody: {
+                        url,
+                    }
+                },
+                this._requestMetaData({
+                    'Content-Type': 'multipart/form-data',
+                }),
+            );
+        });
+        return promised_validationResponse
+    }
+
+    static validateGraphQLByEndpoint(endpoint, params = { useIntrospection: true }){
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+        const promised_validationResponse = apiClient.then(client => {
+            return client.apis['Validation'].validateGraphQLSchema(
+                {
+                    type: 'GraphQL',
+                    'Content-Type': 'multipart/form-data',
+                    ...params
+                },
+                {
+                    requestBody: {
+                        url: endpoint,
+                    }
+                },
+                this._requestMetaData({
+                    'Content-Type': 'multipart/form-data',
+                }),
+            );
+        });
+        return promised_validationResponse
     }
 
     /**

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -1588,13 +1588,14 @@ class API extends Resource {
         return promised_validationResponse;
     }
 
-    static validateGraphQLByUrl(url) {
+    static validateGraphQL(url, params = { useIntrospection: false }) {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         const promised_validationResponse = apiClient.then(client => {
             return client.apis['Validation'].validateGraphQLSchema(
                 {
                     type: 'GraphQL',
                     'Content-Type': 'multipart/form-data',
+                    ...params
                 },
                 {
                     requestBody: {
@@ -1606,29 +1607,7 @@ class API extends Resource {
                 }),
             );
         });
-        return promised_validationResponse
-    }
-
-    static validateGraphQLByEndpoint(endpoint, params = { useIntrospection: true }){
-        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-        const promised_validationResponse = apiClient.then(client => {
-            return client.apis['Validation'].validateGraphQLSchema(
-                {
-                    type: 'GraphQL',
-                    'Content-Type': 'multipart/form-data',
-                    ...params
-                },
-                {
-                    requestBody: {
-                        url: endpoint,
-                    }
-                },
-                this._requestMetaData({
-                    'Content-Type': 'multipart/form-data',
-                }),
-            );
-        });
-        return promised_validationResponse
+        return promised_validationResponse;
     }
 
     /**


### PR DESCRIPTION
# Purpose

This feature enhances the GraphQL API creation capabilities by adding support for additional methods: creating APIs using an SDL URL and using the introspection method by providing an endpoint.

# Implementation

- Added new radio buttons for GraphQL API creation using SDL URL and endpoint (for introspection).
- Made the endpoint input in the API creation UI readonly when creating a GraphQL API using an endpoint.
- Added new API call functions for validateGraphQLSchema using SDL URL and endpoint.
- Updated existing UI texts to reflect the new functionality.

Related to issue: https://github.com/wso2/api-manager/issues/3444
