### PR TITLE
Fix improper error notification thrown when monetizing APIs

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Monetization/BusinessPlans.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Monetization/BusinessPlans.jsx
@@ -249,6 +249,7 @@ class BusinessPlans extends Component {
 BusinessPlans.propTypes = {
     api: PropTypes.instanceOf(API).isRequired,
     classes: PropTypes.shape({}).isRequired,
+    ref: PropTypes.shape({}).isRequired,
 };
 
-export default injectIntl(BusinessPlans);
+export default injectIntl(BusinessPlans,{ forwardRef: true });

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Monetization/BusinessPlans.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Monetization/BusinessPlans.jsx
@@ -249,7 +249,6 @@ class BusinessPlans extends Component {
 BusinessPlans.propTypes = {
     api: PropTypes.instanceOf(API).isRequired,
     classes: PropTypes.shape({}).isRequired,
-    ref: PropTypes.shape({}).isRequired,
 };
 
 export default injectIntl(BusinessPlans,{ forwardRef: true });


### PR DESCRIPTION
### Issue
The error message "Something went wrong while configuring monetization" was improperly thrown when disabling/enabling monetization for an API due to the businessPlans object being undefined.

### Fix
Prevented the businessPlans ref from being overridden using `forwardRef: true`.

Fixes [wso2/api-manager#3497](https://github.com/wso2/api-manager/issues/3497)