### PR TITLE
Fix UI bug related to enable/disable key manager in admin portal

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/ListKeyManagers.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/ListKeyManagers.jsx
@@ -22,7 +22,8 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import Typography from '@mui/material/Typography';
 import Delete from 'AppComponents/KeyManagers/DeleteKeyManager';
 import { Link as RouterLink, useHistory } from 'react-router-dom';
-import Alert from '@mui/material/Alert';
+import AlertMui from '@mui/material/Alert';
+import Alert from 'AppComponents/Shared/Alert';
 import Switch from '@mui/material/Switch';
 import Button from '@mui/material/Button';
 import {
@@ -683,7 +684,7 @@ export default function ListKeyManagers() {
     if (error) {
         return (
             <ContentBase {...pageProps}>
-                <Alert severity='error'>{error}</Alert>
+                <AlertMui severity='error'>{error}</AlertMui>
             </ContentBase>
         );
     }


### PR DESCRIPTION
## Purpose

- This fix resolves the issue of an unexpected behaviour when enabling/disabling key managers in admin portal where it needs multiple clicks and a page refresh to successfully enable/disable a key manager.
- In the UI implementation, the Alert component from material UI had being incorrectly used. It does not have a success function which gives an error.

## Implementation

- Replaced the MUI Alert component with the Alert in the shared components.

Fixes https://github.com/wso2/api-manager/issues/3308
