### PR TITLE
Fix: "Generate Keys" Button Disables Incorrectly for Third-Party Key Managers (#1854)

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -372,6 +372,7 @@ class TokenManager extends React.Component {
                     additionalProperties: this.getDefaultAdditionalProperties(selectedKM),
                 },
                 selectedTab: newSelectedTab,
+                mode: null,
                 importDisabled: false,
             });
         }


### PR DESCRIPTION
**Purpose**

- This pull request fixes the issue where the "Generate Keys" button of other key managers gets disabled when keys are provided for a third-party key manager. 
- Resolves: https://github.com/wso2/api-manager/issues/1854

**Approach**

The value of the mode variable is updated on every tab change. Based on the current value of the mode variable, the "Generate Keys" button is enabled or disabled accordingly.

