### PR TITLE
Fix UI bug related to disabling Deploy button for observers

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
@@ -527,6 +527,7 @@ export default function DeploymentOnboarding(props) {
                                             }
                                             color='primary'
                                             disabled={selectedEnvironment.length === 0
+                                                || isRestricted(['apim:api_create', 'apim:api_publish'], api)
                                                 || (advertiseInfo && advertiseInfo.advertised)
                                                 || isDeployButtonDisabled}
                                         >


### PR DESCRIPTION
### Purpose:

This fix disables the Deploy button in the deployments tab for a read only user (observer role), when the API is not initially deployed.

### Implementation:

Restricted the initial Deploy button only for the roles creater and publisher.

Fixes https://github.com/wso2/api-manager/issues/2362