### PR TITLE
Fix: "Reload" Button in Admin Scopes Not Functioning Correctly (#1329)

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/ListAddOns.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/Commons/ListAddOns.jsx
@@ -35,7 +35,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
  */
 function ListAddOns(props) {
     const {
-        searchActive, filterData, onRefresh, searchPlaceholder, children,
+        searchActive, filterData, onRefresh, searchPlaceholder, children, searchValue,
     } = props;
 
     return (
@@ -60,6 +60,7 @@ function ListAddOns(props) {
                                     disableUnderline: true,
                                     style: { fontSize: '12px' },
                                 }}
+                                value={searchValue}
                                 onChange={filterData}
                             />
                         )}

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
@@ -158,9 +158,11 @@ export default function ListRoles() {
     const [hasListPermission, setHasListPermission] = useState(true);
     const intl = useIntl();
     const [errorMessage, setError] = useState(null);
+    const [searchText, setSearchText] = useState('');
 
-    useEffect(() => {
+    const fetchData = useCallback(() => {
         PermissionAPI.getRoleAliases();
+        setSearchText('');
         Promise.all([PermissionAPI.getRoleAliases(), PermissionAPI.systemScopes()]).then(
             ([roleAliasesRes, systemScopesRes]) => {
                 setSystemScopes(systemScopesRes.body);
@@ -179,7 +181,11 @@ export default function ListRoles() {
                 console.error(error);
             }
         });
-    }, []);
+    }, [intl]);
+
+    useEffect(() => {
+        fetchData();
+    }, [fetchData]);
 
     useEffect(() => {
         if (systemScopes && roleAliases) {
@@ -200,6 +206,7 @@ export default function ListRoles() {
 
     const onSearch = (searchKey) => {
         const keys = Object.keys(permissionMappings);
+        setSearchText(searchKey.target.value);
         const filteredKeys = keys.filter((key) => key.toLowerCase().includes(searchKey.target.value.toLowerCase()));
         const newPermissionMappings = {};
         for (let i = 0; i < filteredKeys.length; i++) {
@@ -300,6 +307,8 @@ export default function ListRoles() {
                 searchActive={searchProps.active}
                 searchPlaceholder={searchProps.searchPlaceholder}
                 filterData={onSearch}
+                onRefresh={fetchData}
+                searchValue={searchText}
             >
                 <Grid item>
                     <Button

--- a/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/RolePermissions/ListRoles.jsx
@@ -181,7 +181,7 @@ export default function ListRoles() {
                 console.error(error);
             }
         });
-    }, [intl]);
+    }, []);
 
     useEffect(() => {
         fetchData();


### PR DESCRIPTION
### Purpose
* This pull request addresses the issue where the "Reload" button in the Admin Portal Scope Assignments page does not function as expected, failing to reset the data and search input to their original states.
* Resolves: https://github.com/wso2/api-manager/issues/1329

### Goal
* To ensure that the "Reload" button in the Admin scopes page restores the original data and clears the search input when clicked.

### Approach

- Introduced a new state variable `searchText` to keep track of the search input value.
- Created a `fetchData` function to centralize data fetching logic and reset the search input.
- Updated the `useEffect` hook to use the `fetchData` function.
- Modified the `onSearch` function to update the `searchText` state.
- Updated the `ListAddOns` component to accept a `searchValue` prop and set it as the value of the search input field.
