### PR TITLE
[Gateway Federation][Feature][4.5.0] Add Publisher UI Restrictions for Federated Gateway Types Using a Templated JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.9</version>
+    <version>9.2.10-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.9</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.8-SNAPSHOT</version>
+    <version>9.2.8</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.8</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.9-SNAPSHOT</version>
+    <version>9.2.9</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.9</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.6-SNAPSHOT</version>
+    <version>9.2.6</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.6</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.7-SNAPSHOT</version>
+    <version>9.2.7</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.7</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.6</version>
+    <version>9.2.7-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.7</version>
+    <version>9.2.8-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.8</version>
+    <version>9.2.9-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.8</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6</version>
+        <version>9.2.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8</version>
+        <version>9.2.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7-SNAPSHOT</version>
+        <version>9.2.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8-SNAPSHOT</version>
+        <version>9.2.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9</version>
+        <version>9.2.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7</version>
+        <version>9.2.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6-SNAPSHOT</version>
+        <version>9.2.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9-SNAPSHOT</version>
+        <version>9.2.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/src/main/webapp/source/src/app/components/Throttling/Subscription/List.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/Throttling/Subscription/List.jsx
@@ -300,6 +300,7 @@ export default function ListSubscriptionThrottlingPolicies() {
                 color='primary'
                 endIcon={<ArrowDropDownIcon />}
                 onClick={handleClick}
+                data-testid='throttling-subscription-add-button'
             >
                 <FormattedMessage
                     id='Throttling.Subscription.Policy.List.addButtonProps.title'
@@ -316,6 +317,7 @@ export default function ListSubscriptionThrottlingPolicies() {
                     onClick={() => handleMenuItemClick(false)}
                     component={RouterLink}
                     to={{ pathname: '/throttling/subscription/add', state: { isAI: false } }}
+                    data-testid='throttling-subscription-add-policy-menu-item'
                 >
                     Add Policy
                 </MenuItem>
@@ -323,6 +325,7 @@ export default function ListSubscriptionThrottlingPolicies() {
                     onClick={() => handleMenuItemClick(true)}
                     component={RouterLink}
                     to={{ pathname: '/throttling/subscription/add', state: { isAI: true } }}
+                    data-testid='throttling-subscription-add-ai-policy-menu-item'
                 >
                     Add AI Policy
                 </MenuItem>

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6</version>
+        <version>9.2.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8</version>
+        <version>9.2.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7-SNAPSHOT</version>
+        <version>9.2.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8-SNAPSHOT</version>
+        <version>9.2.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9</version>
+        <version>9.2.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7</version>
+        <version>9.2.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6-SNAPSHOT</version>
+        <version>9.2.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9-SNAPSHOT</version>
+        <version>9.2.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/CustomPadLock.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/CustomPadLock.jsx
@@ -17,13 +17,32 @@
  */
 
 import React, { useMemo } from 'react';
+import { styled } from '@mui/material/styles';
 import 'swagger-ui-react/swagger-ui.css';
 import LockIcon from '@mui/icons-material/Lock';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
-import Grid from '@mui/material/Grid';
+import {
+    IconButton, Tooltip, Grid, Table, TableBody, TableCell, TableRow,
+} from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
+
+const StyledTableCell = styled(TableCell)(() => ({
+    color: 'white',
+    paddingBottom: '0',
+    paddingLeft: '0',
+    paddingTop: '0',
+    textAlign: 'left',
+}));
+
+const StyledScopeCell = styled(TableCell)(() => ({
+    color: 'white',
+    padding: '0',
+    textAlign: 'left',
+    borderBottom: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+}));
 
 /**
  *
@@ -40,6 +59,27 @@ function isSecurityEnabled(spec, resourcePath) {
 
 /**
  *
+ *
+ * @export
+ * @param {*} spec
+ * @param {*} resourcePath
+ * @returns
+ */
+function getScopesForOperation(spec, resourcePath) {
+    const operation = resourcePath.reduce((a, v) => a[v], spec);
+    const security = operation.security || [];
+    const scopes = [];
+
+    security.forEach((auth) => {
+        Object.values(auth).forEach((scopeList) => {
+            scopes.push(...scopeList);
+        });
+    });
+    return scopes;
+}
+
+/**
+ *
  * Handles the resource level lock icon
  * @export
  * @param {*} BaseLayout
@@ -52,6 +92,7 @@ function CustomPadLock(props) {
         BaseLayout, oldProps, spec,
     } = props;
     const securityEnabled = useMemo(() => isSecurityEnabled(spec, oldProps.specPath), []);
+    const scopes = useMemo(() => getScopesForOperation(spec, oldProps.specPath), []);
 
     return (
         <div>
@@ -61,22 +102,58 @@ function CustomPadLock(props) {
                 </Grid>
                 <Grid item justifyContent='flex-end' alignItems='right'>
                     <Tooltip
-                        title={
-                            (securityEnabled)
-                                ? (
-                                    <FormattedMessage
-                                        id={'Apis.Details.Resources.components.Operation.disable.security'
-                                            + '.when.used.in.api.products'}
-                                        defaultMessage='Security enabled'
-                                    />
-                                )
-                                : (
-                                    <FormattedMessage
-                                        id='Apis.Details.Resources.components.enabled.security'
-                                        defaultMessage='No security'
-                                    />
-                                )
-                        }
+                        title={(
+                            <Table size='small'>
+                                <TableBody>
+                                    <TableRow>
+                                        <StyledTableCell>
+                                            <FormattedMessage
+                                                id='Apis.Details.Resources.components.Operation.security'
+                                                defaultMessage='Security'
+                                            />
+                                        </StyledTableCell>
+                                        <StyledTableCell>
+                                            {securityEnabled
+                                                ? (
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Resources.components.Operation.security.enabled'
+                                                        defaultMessage='Enabled'
+                                                    />
+                                                )
+                                                : (
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Resources.components.Operation.security.disabled'
+                                                        defaultMessage='Disabled'
+                                                    />
+                                                )}
+                                        </StyledTableCell>
+                                    </TableRow>
+                                    {securityEnabled && (
+                                        <TableRow>
+                                            <StyledTableCell>
+                                                <FormattedMessage
+                                                    id='Apis.Details.Resources.components.Operation.scopes'
+                                                    defaultMessage='Scopes'
+                                                />
+                                            </StyledTableCell>
+                                            <StyledTableCell style={{ maxWidth: 100, paddingRight: 0 }}>
+                                                {scopes.length > 0 && (
+                                                    scopes.map((scope, index) => (
+                                                    // eslint-disable-next-line react/no-array-index-key
+                                                        <TableRow key={index}>
+                                                            <StyledScopeCell style={{ maxWidth: 100 }}>
+                                                                {scope}
+                                                            </StyledScopeCell>
+                                                        </TableRow>
+                                                    ))
+                                                )}
+                                            </StyledTableCell>
+                                        </TableRow>
+                                    )}
+
+                                </TableBody>
+                            </Table>
+                        )}
                         aria-label={(
                             <FormattedMessage
                                 id='Apis.Details.Resources.components.Operation.security.operation'

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7</version>
+        <version>9.2.8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.7</version>
+    <version>9.2.8-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9-SNAPSHOT</version>
+        <version>9.2.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.9-SNAPSHOT</version>
+    <version>9.2.9</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9</version>
+        <version>9.2.10-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.9</version>
+    <version>9.2.10-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6</version>
+        <version>9.2.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.6</version>
+    <version>9.2.7-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7-SNAPSHOT</version>
+        <version>9.2.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.7-SNAPSHOT</version>
+    <version>9.2.7</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8</version>
+        <version>9.2.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.8</version>
+    <version>9.2.9-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8-SNAPSHOT</version>
+        <version>9.2.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.8-SNAPSHOT</version>
+    <version>9.2.8</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6-SNAPSHOT</version>
+        <version>9.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.6-SNAPSHOT</version>
+    <version>9.2.6</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6</version>
+        <version>9.2.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8</version>
+        <version>9.2.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7-SNAPSHOT</version>
+        <version>9.2.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.8-SNAPSHOT</version>
+        <version>9.2.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9</version>
+        <version>9.2.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.7</version>
+        <version>9.2.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.6-SNAPSHOT</version>
+        <version>9.2.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.9-SNAPSHOT</version>
+        <version>9.2.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy} from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import Progress from 'AppComponents/Shared/Progress';
 import AuthManager from 'AppData/AuthManager';
@@ -73,7 +73,7 @@ const Apis = () => {
                     }
                 }}
             />
-            <Route path='/apis/:apiUUID/' render={(props) => <DeferredDetails {...props} isAPIProduct={false} />} />
+            <Route path='/apis/:apiUUID/' render={(props) =><DeferredDetails {...props} isAPIProduct={false} />} />
             <Route
                 path='/api-products/:apiProdUUID/'
                 render={(props) => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -15,11 +15,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { Route, Switch } from 'react-router-dom';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
 import APICreateDefault from './Default/APICreateDefault';
 import APIProductCreateWrapper from './APIProduct/APIProductCreateWrapper';
 import ApiCreateSwagger from './OpenAPI/ApiCreateOpenAPI';
@@ -42,6 +43,27 @@ const Root = styled('div')({
     },
 });
 
+const gatewayDetsils = {
+    'wso2/synapse': { 
+        value: 'wso2/synapse',
+        name: 'Regular Gateway', 
+        description: 'API gateway embedded in APIM runtime. Connect directly APIManager.', 
+        isNew: false 
+    },
+    'wso2/apk': { 
+        value: 'wso2/apk',
+        name: 'APK Gateway', 
+        description: 'Fast API gateway running on kubernetes designed to manage and secure APIs.', 
+        isNew: true 
+    },
+    'AWS': { 
+        value: 'AWS',
+        name: 'AWS Gateway', 
+        description: 'A secure and scalable API gateway from AWS.', 
+        isNew: true 
+    }
+};
+
 // Wrapper component to pass additional props
 const WithSomeValue = (Component, additionalProps) => (routeProps) => (
     <Component {...routeProps} {...additionalProps} />
@@ -54,41 +76,48 @@ const WithSomeValue = (Component, additionalProps) => (routeProps) => (
  * @returns @inheritdoc
  */
 function APICreateRoutes() {
-    const { data: settings } = usePublisherSettings();
-    const [gateway, setGatewayType] = useState(false);
-    
-    const getGatewayType = () => {
-        if (settings != null) {
-            if (settings.gatewayTypes && settings.gatewayTypes.length === 2 ) {
-                setGatewayType(true);
-            } else {
-                setGatewayType(false);
-            }
-        }
-    };
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
+    const [apiTypes, setApiTypes] = useState(null);
 
     useEffect(() => {
-        getGatewayType();
-    }, [settings]);
+        if (!isLoading) {
+            setApiTypes(JSON.parse(publisherSettings.gatewayFeatureCatalog).apiTypes);
+        }
+    }, [isLoading]);
+
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     
     return (
         <Root className={classes.content}>
             <Switch>
-                <Route path='/apis/create/rest' component={WithSomeValue(APICreateDefault, { multiGateway: gateway })}/>
+                <Route path='/apis/create/rest' component={WithSomeValue(APICreateDefault, 
+                    { multiGateway: apiTypes?.rest.map(type => gatewayDetsils[type]) })}
+                />
                 <Route path='/api-products/create' component={APIProductCreateWrapper} />
                 <Route path='/apis/create/graphQL' component={WithSomeValue(ApiCreateGraphQL,
-                    { multiGateway: gateway })}
+                    { multiGateway: apiTypes?.graphql.map(type => gatewayDetsils[type]) })}
                 />
                 <Route path='/apis/create/openapi' component={WithSomeValue(ApiCreateSwagger,
-                    { multiGateway: gateway })}
+                    { multiGateway: apiTypes?.rest.map(type => gatewayDetsils[type]) })}
                 />
-                <Route path='/apis/create/wsdl' component={ApiCreateWSDL} />
+                <Route path='/apis/create/wsdl' component={WithSomeValue(ApiCreateWSDL,
+                    { multiGateway: apiTypes?.soap.map(type => gatewayDetsils[type]) })}
+                />
                 {/* TODO: Remove ApiCreateWebSocket components and associated routes */}
-                <Route path='/apis/create/ws' component={ApiCreateWebSocket} />
-                <Route path='/apis/create/streamingapi/:apiType' component={APICreateStreamingAPI} />
-                <Route path='/apis/create/asyncapi' component={APICreateAsyncAPI} />
+                <Route path='/apis/create/ws' component={WithSomeValue(ApiCreateWebSocket,
+                    { multiGateway: apiTypes?.ws.map(type => gatewayDetsils[type]) })}
+                />
+                <Route path='/apis/create/streamingapi/:apiType' component={WithSomeValue(APICreateStreamingAPI,
+                    { multiGateway: apiTypes?.ws.map(type => gatewayDetsils[type]) })}
+                />
+                <Route path='/apis/create/asyncapi' component={WithSomeValue(APICreateAsyncAPI,
+                    { multiGateway: apiTypes?.ws.map(type => gatewayDetsils[type]) })}
+                />
                 <Route path='/apis/create/ai-api' component={WithSomeValue(ApiCreateAIAPI,
-                    { multiGateway: gateway })}/>
+                    { multiGateway: apiTypes?.ai.map(type => gatewayDetsils[type]) })}
+                />
                 <Route component={ResourceNotFound} />
             </Switch>
         </Root>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AsyncAPI/ApiCreateAsyncAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AsyncAPI/ApiCreateAsyncAPI.jsx
@@ -81,7 +81,7 @@ const StyledAPICreateBase = styled(APICreateBase)((
  */
 export default function ApiCreateAsyncAPI(props) {
     const [wizardStep, setWizardStep] = useState(0);
-    const { history } = props;
+    const { history, multiGateway } = props;
     // eslint-disable-next-line no-use-before-define
 
     const [hideEndpoint, setHideEndpoint] = useState(true);
@@ -355,6 +355,7 @@ export default function ApiCreateAsyncAPI(props) {
                             hideEndpoint={hideEndpoint}
                             endpointPlaceholderText='Streaming Provider'
                             appendChildrenBeforeEndpoint
+                            multiGateway={multiGateway}
                         >
                             <Grid container spacing={2}>
                                 {apiInputs.gatewayVendor === 'solace'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -20,7 +20,7 @@ import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
-import { InputAdornment, IconButton, Icon } from '@mui/material';
+import { InputAdornment, IconButton, Icon, Select, MenuItem } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
@@ -29,9 +29,6 @@ import APIValidation from 'AppData/APIValidation';
 import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormLabel from '@mui/material/FormLabel';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import API from 'AppData/api';
 import { green } from '@mui/material/colors';
 
@@ -169,12 +166,6 @@ export default function DefaultAPIForm(props) {
     const [isUpdating, setUpdating] = useState(false);
     const [isErrorCode, setIsErrorCode] = useState(false);
     const iff = (condition, then, otherwise) => (condition ? then : otherwise);
-
-    const getBorderColor = (gatewayType) => {
-        return api.gatewayType === gatewayType
-            ? '2px solid #1976D2'
-            : '2px solid gray';
-    };
 
     // Check the provided API validity on mount, TODO: Better to use Joi schema here ~tmkb
     useEffect(() => {
@@ -655,87 +646,54 @@ export default function DefaultAPIForm(props) {
                         }}
                     />
                 )}
-                {multiGateway  &&
+                {multiGateway && 
                     <Grid container spacing={2}>
-                        <FormControl component='fieldset'>
+                        <FormControl component='fieldset' fullWidth>
                             <FormLabel sx={{ marginLeft: '15px', marginTop: '20px' }}>
                                 <FormattedMessage
                                     id='Apis.Create.Components.DefaultAPIForm.select.gateway.type'
                                     defaultMessage='Select Gateway type'
                                 />
+                                <sup className={classes.mandatoryStar}>*</sup>
                             </FormLabel>
-                            <RadioGroup
-                                row
-                                aria-label='gateway-type'
-                                name='gatewayType'
+                            <Select
+                                id='gateway-type-select'
                                 value={api.gatewayType}
                                 onChange={onChange}
+                                fullWidth
+                                sx={{ marginLeft: '15px', marginTop: '10px', minWidth: 200 }}
+                                inputProps={{ name: 'gatewayType', id: 'gateway-type-select' }}
                             >
-                                <Grid item xs={6}>
-                                    <FormControlLabel
-                                        value='wso2/synapse'
-                                        className={classes.radioOutline}
-                                        control={<Radio />}
-                                        label={(
-                                            <div>
-                                                <span>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'regular.gateway.type'}
-                                                        defaultMessage='Regular Gateway'
-                                                    />
-                                                </span>
-                                                <Typography variant='body2' color='textSecondary'>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'regular.gateway.type.text'}
-                                                        defaultMessage={'API gateway embedded in APIM '
-                                                            + 'runtime. Connect directly APIManager.'}
-                                                    />
-                                                </Typography>
-                                            </div>
-                                        )}
-                                        sx={{ border: getBorderColor('wso2/synapse') }}
+                                <MenuItem disabled value=''>
+                                    <FormattedMessage
+                                        id='Apis.Create.Components.DefaultAPIForm.select.gateway.type.placeholder'
+                                        defaultMessage='Please select a gateway type'
                                     />
-                                </Grid>
-                                <Grid item xs={6}>
-                                    <FormControlLabel
-                                        value='wso2/apk'
-                                        className={classes.radioOutline}
-                                        control={<Radio />}
-                                        label={(
-                                            <div>
-                                                <span>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'apk.gateway.type'}
-                                                        defaultMessage='APK Gateway'
-                                                    />
-                                                </span>
+                                </MenuItem>
+                                {multiGateway.map((gateway) => 
+                                    <MenuItem key={gateway.value} value={gateway.value}>
+                                        <div>
+                                            {gateway.name}
+                                            {gateway.isNew && 
                                                 <span className={`${classes.label} ${classes.newLabel}`}>New</span>
-                                                <Typography variant='body2' color='textSecondary'>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'apk.gateway.type.text'}
-                                                        defaultMessage={'Fast API gateway running on kubernetes'
-                                                            + ' designed to manage and secure APIs.'}
-                                                    />
-                                                </Typography>
-                                            </div>
-                                        )}
-                                        sx={{ border: getBorderColor('wso2/apk') }}
-                                    />
-                                </Grid>
-                            </RadioGroup>
-                            <FormHelperText sx={{ marginLeft: '15px' }}><FormattedMessage
-                                id={'Apis.Create.Components.DefaultAPIForm.'
-                                    + 'select.gateway.type.helper.text'}
-                                defaultMessage='Select the gateway type where your API will run.'
-                            />
+                                            }
+                                            <Typography variant='body2' color='textSecondary'>
+                                                {gateway.description}
+                                            </Typography>
+                                        </div>
+                                    </MenuItem>
+                                )}
+                            </Select>
+                            <FormHelperText sx={{ marginLeft: '15px' }}>
+                                <FormattedMessage
+                                    id={'Apis.Create.Components.DefaultAPIForm.'
+                                        + 'select.gateway.type.helper.text'}
+                                    defaultMessage='Select the gateway type where your API will run.'
+                                />
                             </FormHelperText>
                         </FormControl>
                     </Grid>
-                }   
+                }
                 {!appendChildrenBeforeEndpoint && !!children && children}
             </form>
             <Grid container direction='row' justifyContent='flex-end' alignItems='center'>
@@ -762,7 +720,7 @@ DefaultAPIForm.defaultProps = {
 };
 DefaultAPIForm.propTypes = {
     api: PropTypes.shape({}),
-    multiGateway: PropTypes.string.isRequired,
+    multiGateway: PropTypes.isRequired,
     isAPIProduct: PropTypes.shape({}).isRequired,
     isWebSocket: PropTypes.shape({}),
     onChange: PropTypes.func.isRequired,

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -54,7 +54,7 @@ const StyledAPICreateBase = styled(APICreateBase)((
 
 const APICreateStreamingAPI = (props) => {
     // const theme = useTheme();
-    const { history } = props;
+    const { history, multiGateway } = props;
     const intl = useIntl();
     const { data: settings, isLoading, error: settingsError } = usePublisherSettings();
     const [pageError, setPageError] = useState(null);
@@ -437,6 +437,7 @@ const APICreateStreamingAPI = (props) => {
                         endpointPlaceholderText='Streaming Provider'
                         appendChildrenBeforeEndpoint
                         hideEndpoint={hideEndpoint}
+                        multiGateway={multiGateway}
                         isWebSocket={(apiType && apiType === protocolKeys.WebSocket)
                             || apiInputs.protocol === protocolKeys.WebSocket}
                     >

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
@@ -47,7 +47,7 @@ import ProvideWSDL from './Steps/ProvideWSDL';
 export default function ApiCreateWSDL(props) {
     const intl = useIntl();
     const [wizardStep, setWizardStep] = useState(0);
-    const { history } = props;
+    const { history, multiGateway } = props;
     const [policies, setPolicies] = useState([]);
 
     useEffect(() => {
@@ -255,6 +255,7 @@ export default function ApiCreateWSDL(props) {
                             onChange={handleOnChange}
                             api={apiInputs}
                             isAPIProduct={false}
+                            multiGateway={multiGateway}
                         />
                     )}
                 </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WebSocket/ApiCreateWebSocket.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WebSocket/ApiCreateWebSocket.jsx
@@ -16,7 +16,9 @@
 import React from 'react';
 import APICreateDefault from 'AppComponents/Apis/Create/Default/APICreateDefault';
 
-const ApiCreateWebSocket = () => {
-    return (<APICreateDefault isWebSocket />);
+const ApiCreateWebSocket = (props) => {
+    const {multiGateway} = props;
+
+    return (<APICreateDefault multiGateway={multiGateway} isWebSocket />);
 };
 export default ApiCreateWebSocket;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -608,7 +608,9 @@ export default function DesignConfigurations() {
                                         />
                                     </Box>
                                     <Box py={1}>
-                                        {api.apiType !== API.CONSTS.APIProduct && (
+                                        {api.apiType !== API.CONSTS.APIProduct &&
+                                            settings && JSON.parse(settings.gatewayFeatureCatalog)
+                                            .gatewayFeatures[api.gatewayType].basic.includes("advertised") && (
                                             <AdvertiseInfo
                                                 oldApi={api}
                                                 api={apiConfig}
@@ -618,11 +620,14 @@ export default function DesignConfigurations() {
                                             />
                                         )}
                                     </Box>
-                                    { settings && !settings.portalConfigurationOnlyModeEnabled && (
-                                        <Box py={1}>
-                                            <DefaultVersion api={apiConfig} configDispatcher={configDispatcher} />
-                                        </Box>
-                                    )}
+                                    { settings && !settings.portalConfigurationOnlyModeEnabled &&
+                                        JSON.parse(settings.gatewayFeatureCatalog).gatewayFeatures[api.gatewayType]
+                                            .basic.includes("defaultVersion") &&
+                                            <Box py={1}>
+                                                <DefaultVersion api={apiConfig} 
+                                                    configDispatcher={configDispatcher} />
+                                            </Box>
+                                    }
                                     <Box pt={2}>
                                         <Button
                                             disabled={

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -32,8 +32,9 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Api from 'AppData/api';
 import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
-import { useAppContext } from 'AppComponents/Shared/AppContext';
+import { useAppContext, usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import { isRestricted } from 'AppData/AuthManager';
+import { Progress } from 'AppComponents/Shared';
 import CustomSplitButton from 'AppComponents/Shared/CustomSplitButton';
 import ResponseCaching from './components/ResponseCaching';
 import CORSConfiguration from './components/CORSConfiguration';
@@ -423,6 +424,7 @@ export default function RuntimeConfiguration() {
         }
     }
     const { api, updateAPI } = useContext(APIContext);
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const history = useHistory();
     const isAsyncAPI = api.type === 'WS' || api.type === 'WEBSUB' || api.type === 'SSE' || api.type === 'ASYNC';
     const isNonWebSubAsyncAPI = api.type === 'WS' || api.type === 'SSE' || api.type === 'ASYNC';
@@ -430,6 +432,8 @@ export default function RuntimeConfiguration() {
     const [isUpdating, setIsUpdating] = useState(false);
     const [updateComplexityList, setUpdateComplexityList] = useState(null);
     const [apiConfig, configDispatcher] = useReducer(configReducer, copyAPIConfig(api));
+    const [componentValidator, setComponentValidator] = useState([]);
+    const [endpointSecurity, setEndpointSecurity] = useState([]);
 
     const intl = useIntl();
     useEffect(() => {
@@ -450,6 +454,15 @@ export default function RuntimeConfiguration() {
                 });
         }
     }, []);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(JSON.parse(publisherSettings.gatewayFeatureCatalog)
+                .gatewayFeatures[api.gatewayType].runtime);
+            setEndpointSecurity(JSON.parse(publisherSettings.gatewayFeatureCatalog)
+                .gatewayFeatures[api.gatewayType].endpoints);
+        }
+    }, [isLoading]);
 
     /**
      * Update the GraphQL Query Complexity Values
@@ -552,6 +565,10 @@ export default function RuntimeConfiguration() {
             }));
     }
 
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
+
     return (
         <Root>
             <Box pb={3}>
@@ -565,7 +582,8 @@ export default function RuntimeConfiguration() {
             <div className={classes.contentWrapper}>
                 {(apiConfig.advertiseInfo && apiConfig.advertiseInfo.advertised) ? (
                     <Paper className={classes.paper} elevation={0}>
-                        <APISecurity api={apiConfig} configDispatcher={configDispatcher} />
+                        <APISecurity api={apiConfig} configDispatcher={configDispatcher} 
+                            componentValidator={componentValidator} />
                     </Paper>
                 ) : (
                     <Grid container direction='row' justifyContent='space-around' alignItems='stretch' 
@@ -589,16 +607,18 @@ export default function RuntimeConfiguration() {
                                 <Grid item xs={12} sx={{ mb: 3, position: 'relative' }}>
                                     <Paper elevation={0} 
                                         sx={{ p: 3, boxSizing: 'border-box' }}>
-                                        <APISecurity api={apiConfig} configDispatcher={configDispatcher} />
-                                        { api.type !== 'WS' && (
+                                        <APISecurity api={apiConfig} configDispatcher={configDispatcher} 
+                                            componentValidator={componentValidator} />
+                                        { api.type !== 'WS' && componentValidator.includes("cors") && (
                                             <CORSConfiguration api={apiConfig} 
                                                 configDispatcher={configDispatcher} />
                                         )}
 
-                                        {((api.type !== 'GRAPHQL' || !isAsyncAPI) && api.gatewayType !== 'wso2/apk')
+                                        {((api.type !== 'GRAPHQL' || !isAsyncAPI) && 
+                                            componentValidator.includes("schemaValidation"))
                                             && <SchemaValidation api={apiConfig} 
                                                 configDispatcher={configDispatcher} />}
-                                        {api.type === 'GRAPHQL' && api.gatewayType !== 'wso2/apk' && (
+                                        {api.type === 'GRAPHQL' && componentValidator.includes("queryAnalysis") && (
                                             <Box mt={3}>
                                                 <QueryAnalysis
                                                     api={apiConfig}
@@ -612,7 +632,7 @@ export default function RuntimeConfiguration() {
                                         <ArrowForwardIcon className={classes.arrowForwardIcon} />
                                     )}
                                 </Grid>
-                                { api.gatewayType !== 'wso2/apk' && !isNonWebSubAsyncAPI && (
+                                { componentValidator.includes("responseCaching") && !isNonWebSubAsyncAPI && (
                                     <>
                                         <Typography className={classes.heading} variant='h6' component='h3'>
                                             {!isWebSub ? (
@@ -680,7 +700,7 @@ export default function RuntimeConfiguration() {
                                         )}
                                         {api.subtypeConfiguration?.subtype !== 'AIAPI' && !api.isAPIProduct() && (
                                             <>
-                                                {(!isAsyncAPI && api.gatewayType !== 'wso2/apk') && (
+                                                {(!isAsyncAPI && componentValidator.includes("backendThroughput")) && (
                                                     <MaxBackendTps
                                                         api={apiConfig}
                                                         configDispatcher={configDispatcher}
@@ -691,7 +711,7 @@ export default function RuntimeConfiguration() {
                                         {!api.isAPIProduct() && (
                                             <>
                                                 { !isWebSub && (
-                                                    <Endpoints api={api} />
+                                                    <Endpoints api={api} endpointSecurity={endpointSecurity} />
                                                 )}
                                             </>
                                         )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/Topics.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/Topics.jsx
@@ -54,6 +54,7 @@ export default function Topics(props) {
     const {
         disableUpdate,
         disableAddOperation,
+        componentValidator,
     } = props;
 
     const [api, updateAPI] = useAPI();
@@ -541,6 +542,7 @@ export default function Topics(props) {
                                                         && markedOperations[target].subscribe)}
                                                 onMarkAsDelete={onMarkAsDelete}
                                                 disableDelete={api.gatewayVendor === 'solace'}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}
@@ -559,6 +561,7 @@ export default function Topics(props) {
                                                         && markedOperations[target].publish)}
                                                 onMarkAsDelete={onMarkAsDelete}
                                                 disableDelete={api.gatewayVendor === 'solace'}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
@@ -67,6 +67,7 @@ export default function APISecurity(props) {
         api: { securityScheme, id },
         configDispatcher,
         api,
+        componentValidator,
     } = props;
     const apiContext = useContext(ApiContext);
     const isAPIProduct = apiContext.api.apiType === API.CONSTS.APIProduct;
@@ -133,24 +134,32 @@ export default function APISecurity(props) {
                 {(isAPIProduct || (!isEndpointAvailable || (isEndpointAvailable && !isPrototyped)))
                 && (
                     <>
-                        <Grid item xs={12}>
-                            <TransportLevel
-                                haveMultiLevelSecurity={haveMultiLevelSecurity}
-                                securityScheme={securityScheme}
-                                configDispatcher={configDispatcher}
-                                api={api}
-                                id={id}
-                            />
-                        </Grid>
-                        <Grid item xs={12}>
-                            <ApplicationLevel
-                                haveMultiLevelSecurity={haveMultiLevelSecurity}
-                                securityScheme={securityScheme}
-                                api={api}
-                                configDispatcher={configDispatcher}
-                                id={id}
-                            />
-                        </Grid>
+                        {["transportsHTTP", "transportsHTTPS", "transportsMutualSSL"].some(transport =>
+                            componentValidator?.includes(transport)) &&
+                            <Grid item xs={12}>
+                                <TransportLevel
+                                    haveMultiLevelSecurity={haveMultiLevelSecurity}
+                                    securityScheme={securityScheme}
+                                    configDispatcher={configDispatcher}
+                                    api={api}
+                                    id={id}
+                                    componentValidator={componentValidator}
+                                />
+                            </Grid>
+                        }
+                        {["oauth2", "apikey", "basicAuth", "keyManagerConfig"].some(authType =>
+                            componentValidator?.includes(authType)) &&
+                            <Grid item xs={12}>
+                                <ApplicationLevel
+                                    haveMultiLevelSecurity={haveMultiLevelSecurity}
+                                    securityScheme={securityScheme}
+                                    api={api}
+                                    configDispatcher={configDispatcher}
+                                    id={id}
+                                    componentValidator={componentValidator}
+                                />
+                            </Grid>
+                        }
                         <Grid item xs={12}>
                             <span className={classes.error}>
                                 <Validate />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
@@ -102,7 +102,7 @@ const Root = styled('div')((
  */
 export default function ApplicationLevel(props) {
     const {
-        haveMultiLevelSecurity, securityScheme, configDispatcher, api,
+        haveMultiLevelSecurity, securityScheme, configDispatcher, api, componentValidator
     } = props;
     const [apiFromContext] = useAPI();
     const [oauth2Enabled, setOauth2Enabled] = useState(securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2));
@@ -191,29 +191,31 @@ export default function ApplicationLevel(props) {
                     </AccordionSummary>
                     <AccordionDetails className={classes.expansionPanelDetails}>
                         <FormGroup style={{ display: 'flow-root' }}>
-                            <FormControlLabel
-                                control={(
-                                    <Checkbox
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                        checked={securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2)}
-                                        onChange={({ target: { checked, value } }) => {
-                                            setOauth2Enabled(checked);
-                                            configDispatcher({
-                                                action: 'securityScheme',
-                                                event: { checked, value },
-                                            });
-                                        }}
-                                        value={DEFAULT_API_SECURITY_OAUTH2}
-                                        color='primary'
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
-                                        + 'ApplicationLevel.security.scheme.oauth2',
-                                    defaultMessage: 'OAuth2',
-                                })}
-                            />
-                            {(apiFromContext.gatewayType === 'wso2/synapse' ||
+                            {componentValidator.includes('oauth2') && 
+                                <FormControlLabel
+                                    control={(
+                                        <Checkbox
+                                            disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            checked={securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2)}
+                                            onChange={({ target: { checked, value } }) => {
+                                                setOauth2Enabled(checked);
+                                                configDispatcher({
+                                                    action: 'securityScheme',
+                                                    event: { checked, value },
+                                                });
+                                            }}
+                                            value={DEFAULT_API_SECURITY_OAUTH2}
+                                            color='primary'
+                                        />
+                                    )}
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
+                                            + 'ApplicationLevel.security.scheme.oauth2',
+                                        defaultMessage: 'OAuth2',
+                                    })}
+                                />
+                            }
+                            {(componentValidator.includes('basicAuth') ||
                                 apiFromContext.apiType === API.CONSTS.APIProduct) && (
                                 <FormControlLabel
                                     control={(
@@ -236,28 +238,31 @@ export default function ApplicationLevel(props) {
                                     })}
                                 />
                             )}
-                            <FormControlLabel
-                                control={(
-                                    <Checkbox
-                                        checked={securityScheme.includes(API_SECURITY_API_KEY)}
-                                        disabled={
-                                            isRestricted(['apim:api_create'], apiFromContext) || isSubValidationDisabled
-                                        }
-                                        onChange={({ target: { checked, value } }) => configDispatcher({
-                                            action: 'securityScheme',
-                                            event: { checked, value },
-                                        })}
-                                        value={API_SECURITY_API_KEY}
-                                        color='primary'
-                                        id='api-security-api-key-checkbox'
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
-                                        + 'ApplicationLevel.security.scheme.api.key',
-                                    defaultMessage: 'Api Key',
-                                })}
-                            />
+                            {componentValidator.includes('apikey') &&
+                                <FormControlLabel
+                                    control={(
+                                        <Checkbox
+                                            checked={securityScheme.includes(API_SECURITY_API_KEY)}
+                                            disabled={
+                                                isRestricted(['apim:api_create'], apiFromContext) 
+                                                || isSubValidationDisabled
+                                            }
+                                            onChange={({ target: { checked, value } }) => configDispatcher({
+                                                action: 'securityScheme',
+                                                event: { checked, value },
+                                            })}
+                                            value={API_SECURITY_API_KEY}
+                                            color='primary'
+                                            id='api-security-api-key-checkbox'
+                                        />
+                                    )}
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
+                                            + 'ApplicationLevel.security.scheme.api.key',
+                                        defaultMessage: 'Api Key',
+                                    })}
+                                />
+                            }
                         </FormGroup>
                         <FormControl className={classes.bottomSpace} component='fieldset'>
                             <RadioGroup
@@ -313,20 +318,24 @@ export default function ApplicationLevel(props) {
                                 />
                             </FormHelperText>
                         </FormControl>
-                        {oauth2Enabled && (
+                        {oauth2Enabled && componentValidator.includes("audienceValidation") && (
                             <Audience
                                 api={api}
                                 configDispatcher={configDispatcher}
                             />
                         )}
-                        {(apiFromContext.apiType === API.CONSTS.API) && oauth2Enabled && (
+                        {(apiFromContext.apiType === API.CONSTS.API) && oauth2Enabled &&
+                            componentValidator.includes("keyManagerConfig") && (
                             <KeyManager
                                 api={api}
                                 configDispatcher={configDispatcher}
                             />
                         )}
-                        <AuthorizationHeader api={api} configDispatcher={configDispatcher} />
-                        <ApiKeyHeader api={api} configDispatcher={configDispatcher} />
+                        {componentValidator.includes('oauth2') &&
+                            <AuthorizationHeader api={api} configDispatcher={configDispatcher} />
+                        } {componentValidator.includes('apikey') &&
+                            <ApiKeyHeader api={api} configDispatcher={configDispatcher} />
+                        }   
                         <FormControl>
                             {!hasResourceWithSecurity
                             && (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -94,7 +94,7 @@ const Root = styled('div')((
  */
 function TransportLevel(props) {
     const {
-        haveMultiLevelSecurity, securityScheme, configDispatcher, intl, id, api,
+        haveMultiLevelSecurity, securityScheme, configDispatcher, intl, id, api, componentValidator,
     } = props;
     const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
     const [apiFromContext] = useAPI();
@@ -273,20 +273,23 @@ function TransportLevel(props) {
                         </Typography>
                     </AccordionSummary>
                     <AccordionDetails className={classes.expansionPanelDetails}>
-                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme} />
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    checked={isMutualSSLEnabled}
-                                    onChange={handleMutualSSLChange}
-                                    color='primary'
-                                    id='mutual-ssl-checkbox'
-                                />
-                            )}
-                            label='Mutual SSL'
-                        />
-                        {isMutualSSLEnabled && (
+                        <Transports api={api} configDispatcher={configDispatcher} 
+                            securityScheme={securityScheme} componentValidator={componentValidator} />
+                        {componentValidator.includes('transportsMutualSSL') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                        checked={isMutualSSLEnabled}
+                                        onChange={handleMutualSSLChange}
+                                        color='primary'
+                                        id='mutual-ssl-checkbox'
+                                    />
+                                )}
+                                label='Mutual SSL'
+                            />
+                        }
+                        {(isMutualSSLEnabled && componentValidator.includes('transportsMutualSSL')) && (
                             <FormControl component='fieldset'>
                                 <RadioGroup
                                     aria-label='HTTP security SSL mandatory selection'
@@ -343,7 +346,8 @@ function TransportLevel(props) {
                                 </FormHelperText>
                             </FormControl>
                         )}
-                        {(isMutualSSLEnabled && (!api.advertiseInfo || !api.advertiseInfo.advertised)) && (
+                        {(isMutualSSLEnabled && (!api.advertiseInfo || !api.advertiseInfo.advertised)) &&
+                            componentValidator.includes('transportsMutualSSL') && (
                             // TODO:
                             // This is half baked!!!
                             // Refactor the Certificate component to share its capabilities in here and

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
@@ -97,7 +97,7 @@ const showEndpoint = function (api, type) {
  * @returns
  */
 function Endpoints(props) {
-    const { api } = props;
+    const { api, endpointSecurity } = props;
 
     const isPrototypedAvailable = api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped' && api.lifeCycleStatus === 'PROTOTYPED';
@@ -143,51 +143,53 @@ function Endpoints(props) {
                         )
                         : (
                             <>
-                                <Box pb={2}>
-                                    {/* Production Endpoint (TODO) fix the endpoint
-                                                    info when it's available with the api object */}
+                                {endpointSecurity.includes('typePRODUCTION') &&
+                                    <Box pb={2}>
+                                        {/* Production Endpoint (TODO) fix the endpoint
+                                                        info when it's available with the api object */}
 
-                                    { !isPrototypedAvailable ? (
-                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                            <FormattedMessage
-                                                id='Apis.Details.Configuration.components.Endpoints.production'
-                                                defaultMessage='Production'
-                                            />
-                                        </Typography>
-                                    ) : (
-                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                            <FormattedMessage
-                                                id='Apis.Details.Configuration.components.Endpoints.prototype'
-                                                defaultMessage='Prototype'
-                                            />
-                                        </Typography>
-                                    )}
-                                    {showEndpoint(api, 'prod')
-                                && (
-                                    <Tooltip
-                                        title={showEndpoint(api, 'prod')}
-                                        interactive
-                                    >
-                                        <Typography component='p' variant='body1' className={classes.textTrim}>
-                                            <>
-                                                {showEndpoint(api, 'prod')}
-                                            </>
-                                        </Typography>
-                                    </Tooltip>
-                                )}
-                                    <Typography component='p' variant='body1' className={classes.notConfigured}>
-                                        {!showEndpoint(api, 'prod') && (
-                                            <>
+                                        { !isPrototypedAvailable ? (
+                                            <Typography component='p' variant='subtitle2' className={classes.subtitle}>
                                                 <FormattedMessage
-                                                    id={'Apis.Details.Configuration.'
-                                                    + 'components.Endpoints.not.set'}
-                                                    defaultMessage='-'
+                                                    id='Apis.Details.Configuration.components.Endpoints.production'
+                                                    defaultMessage='Production'
                                                 />
-                                            </>
+                                            </Typography>
+                                        ) : (
+                                            <Typography component='p' variant='subtitle2' className={classes.subtitle}>
+                                                <FormattedMessage
+                                                    id='Apis.Details.Configuration.components.Endpoints.prototype'
+                                                    defaultMessage='Prototype'
+                                                />
+                                            </Typography>
                                         )}
-                                    </Typography>
-                                </Box>
-                                {!isPrototypedAvailable && (
+                                        {showEndpoint(api, 'prod')
+                                    && (
+                                        <Tooltip
+                                            title={showEndpoint(api, 'prod')}
+                                            interactive
+                                        >
+                                            <Typography component='p' variant='body1' className={classes.textTrim}>
+                                                <>
+                                                    {showEndpoint(api, 'prod')}
+                                                </>
+                                            </Typography>
+                                        </Tooltip>
+                                    )}
+                                        <Typography component='p' variant='body1' className={classes.notConfigured}>
+                                            {!showEndpoint(api, 'prod') && (
+                                                <>
+                                                    <FormattedMessage
+                                                        id={'Apis.Details.Configuration.'
+                                                        + 'components.Endpoints.not.set'}
+                                                        defaultMessage='-'
+                                                    />
+                                                </>
+                                            )}
+                                        </Typography>
+                                    </Box>
+                                }   
+                                {!isPrototypedAvailable && endpointSecurity.includes('typeSANDBOX') && (
                                     <Box pb={2}>
                                         {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -57,7 +57,7 @@ const StyledGrid = styled(Grid)((
  * @returns
  */
 export default function Transports(props) {
-    const { api, configDispatcher, securityScheme } = props;
+    const { api, configDispatcher, securityScheme, componentValidator } = props;
     const [apiFromContext] = useAPI();
 
     const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
@@ -92,39 +92,44 @@ export default function Transports(props) {
                         />
                     </FormLabel>
                     <FormGroup style={{ display: 'flow-root' }}>
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext) || isMutualSSLEnabled}
-                                    checked={api.transport
-                                        ? api.transport.includes('http') && !isMutualSSLEnabled : null}
-                                    onChange={({ target: { checked } }) => configDispatcher({
-                                        action: 'transport',
-                                        event: { checked, value: 'http' },
-                                    })}
-                                    value='http'
-                                    color='primary'
-                                    id='http-transport'
-                                />
-                            )}
-                            label='HTTP'
-                        />
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    checked={api.transport
-                                        ? api.transport.includes('https') : null}
-                                    onChange={({ target: { checked } }) => configDispatcher({
-                                        action: 'transport',
-                                        event: { checked, value: 'https' },
-                                    })}
-                                    value='https'
-                                    color='primary'
-                                />
-                            )}
-                            label='HTTPS'
-                        />
+                        {componentValidator.includes('transportsHTTP') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext) || 
+                                            isMutualSSLEnabled}
+                                        checked={api.transport
+                                            ? api.transport.includes('http') && !isMutualSSLEnabled : null}
+                                        onChange={({ target: { checked } }) => configDispatcher({
+                                            action: 'transport',
+                                            event: { checked, value: 'http' },
+                                        })}
+                                        value='http'
+                                        color='primary'
+                                        id='http-transport'
+                                    />
+                                )}
+                                label='HTTP'
+                            />
+                        }
+                        {componentValidator.includes('transportsHTTPS') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                        checked={api.transport
+                                            ? api.transport.includes('https') : null}
+                                        onChange={({ target: { checked } }) => configDispatcher({
+                                            action: 'transport',
+                                            event: { checked, value: 'https' },
+                                        })}
+                                        value='https'
+                                        color='primary'
+                                    />
+                                )}
+                                label='HTTPS'
+                            />
+                        }
                     </FormGroup>
                 </FormControl>
             </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -460,14 +460,14 @@ class CreateEditForm extends React.Component {
             nameNotDuplicate &&
             !nameMaxLengthExceeds &&
             !invalidDocName &&
-            ((!invalidUrl && sourceUrl !== '') || sourceType !== 'URL')
+            ((!invalidUrl && sourceUrl) || sourceType !== 'URL')
         ) {
             setSaveDisabled(false);
         } else {
             setSaveDisabled(true);
         }
 
-        if (type === 'OTHER' && otherTypeName === '') {
+        if (type === 'OTHER' && !otherTypeName) {
             setSaveDisabled(true);
         }
         return (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointListing.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointListing.jsx
@@ -116,6 +116,7 @@ function EndpointListing(props) {
         setAdvancedConfigOpen,
         setESConfigOpen,
         apiId,
+        componentValidator,
     } = props;
     const [endpointType, setEndpointType] = useState(epType);
     const [endpoints, setEndpoints] = useState([{ url: 'http://myservice/endpoint' }]);
@@ -172,6 +173,7 @@ function EndpointListing(props) {
                                         setAdvancedConfigOpen={setAdvancedConfigOpen}
                                         setESConfigOpen={setESConfigOpen}
                                         apiId={apiId}
+                                        componentValidator={componentValidator}
                                     />
                                 );
                             }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -194,6 +194,8 @@ function EndpointOverview(props) {
         isCustomBackendSelected,
         setIsCustomBackendSelected,
         apiKeyParamConfig,
+        componentValidator,
+        endpointSecurityTypes,
     } = props;
     const { endpointConfig } = api;
     const [endpointType, setEndpointType] = useState(endpointTypes[0]);
@@ -282,7 +284,7 @@ function EndpointOverview(props) {
      * @param {Object} apiObject  The representative type of the endpoint.
      * @return {string} The supported endpoint types.
      * */
-    const getSupportedType = (apiObject) => {
+    const getSupportedType = (apiObject, componentValidator) => {
         const { type, subtypeConfiguration } = apiObject;
         let supportedEndpointTypes = [];
         if (type === 'GRAPHQL' && apiObject.gatewayType !== 'wso2/apk') {
@@ -322,7 +324,7 @@ function EndpointOverview(props) {
         if(subtypeConfiguration?.subtype !== 'AIAPI' && apiObject.gatewayType !== 'wso2/apk' && type === 'HTTP' ) {
             supportedEndpointTypes.push({ key: 'sequence_backend', value: 'Sequence Backend' });
         }
-        return supportedEndpointTypes;
+        return supportedEndpointTypes.filter(type => componentValidator.includes(type.key));
     };
 
     /**
@@ -349,7 +351,7 @@ function EndpointOverview(props) {
     }
 
     useEffect(() => {
-        const supportedTypeLists = getSupportedType(api);
+        const supportedTypeLists = getSupportedType(api, componentValidator);
         const epType = getEndpointType(api);
         if (epType.key === 'service') {
             getServices();
@@ -816,104 +818,108 @@ function EndpointOverview(props) {
                                 {endpointType.key === 'service'
                                     ? (
                                         <>
-                                            <FormControlLabel
-                                                control={(
-                                                    <Checkbox
-                                                        disabled={isRestricted(
-                                                            ['apim:api_create'], api)}
-                                                        checked={endpointCategory.prod}
-                                                        value='prod'
-                                                        color='primary'
-                                                        onChange={epCategoryOnChangeHandler}
-                                                    />
-                                                )}
-                                                label={(
-                                                    <Typography>
-                                                        <FormattedMessage
-                                                            id={'Apis.Details.'
-                                                                + 'Endpoints.EndpointOverview'
-                                                                + '.production.endpoint'
-                                                                + '.production.label'}
-                                                            defaultMessage='Production Endpoint'
+                                            {componentValidator.includes("typePRODUCTION") && 
+                                            <>
+                                                <FormControlLabel
+                                                    control={(
+                                                        <Checkbox
+                                                            disabled={isRestricted(
+                                                                ['apim:api_create'], api)}
+                                                            checked={endpointCategory.prod}
+                                                            value='prod'
+                                                            color='primary'
+                                                            onChange={epCategoryOnChangeHandler}
                                                         />
-                                                    </Typography>
-                                                )}
-                                            />
-                                            <Collapse in={endpointCategory.prod}>
-                                                <ServiceEndpoint
-                                                    classes={classes}
-                                                    api={api}
-                                                    services={servicesList}
-                                                    category='production_endpoints'
-                                                    type=''
-                                                    setAdvancedConfigOpen={toggleAdvanceConfig}
-                                                    esCategory='production'
-                                                    setESConfigOpen={toggleEndpointSecurityConfig}
-                                                    name={<FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.production'
-                                                            + '.endpoint.production.header'}
-                                                        defaultMessage='Production Endpoint'
-                                                    />}
-                                                    editEndpoint={editEndpoint}
-                                                    endpointURL={getEndpoints
-                                                    (
-                                                        'production_endpoints'
                                                     )}
-                                                    existingService={getService}
-                                                    editService={editService}
-                                                    index={0} />
-                                            </Collapse>
-                                            <FormControlLabel
-                                                control={(
-                                                    <Checkbox
-                                                        disabled={isRestricted(
-                                                            ['apim:api_create'], api)}
-                                                        checked={endpointCategory.sandbox}
-                                                        value='sandbox'
-                                                        color='primary'
-                                                        onChange={() => (
-                                                            handleOnChangeEndpointCategoryChange
-                                                            (
-                                                                'sandbox',
-                                                            ))}
-                                                    />
-                                                )}
-                                                label={(
-                                                    <FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.sandbox'
-                                                            + '.endpoint'}
-                                                        defaultMessage='Sandbox Endpoint'
-                                                    />
-                                                )}
-                                            />
-                                            <Collapse in={endpointCategory.sandbox}>
-                                                <ServiceEndpoint
-                                                    classes={classes}
-                                                    api={api}
-                                                    services={servicesList}
-                                                    category='sandbox_endpoints'
-                                                    type=''
-                                                    setAdvancedConfigOpen={toggleAdvanceConfig}
-                                                    esCategory='sandbox'
-                                                    setESConfigOpen={toggleEndpointSecurityConfig}
-                                                    name={ <FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.sandbox'
-                                                            + '.endpoint'}
-                                                        defaultMessage='Sandbox Endpoint'
-                                                    />}
-                                                    editEndpoint={editEndpoint}
-                                                    endpointURL={getEndpoints
-                                                    (
-                                                        'sandbox_endpoints'
+                                                    label={(
+                                                        <Typography>
+                                                            <FormattedMessage
+                                                                id={'Apis.Details.'
+                                                                    + 'Endpoints.EndpointOverview'
+                                                                    + '.production.endpoint'
+                                                                    + '.production.label'}
+                                                                defaultMessage='Production Endpoint'
+                                                            />
+                                                        </Typography>
                                                     )}
-                                                    index={0} />
-                                            </Collapse>
-
+                                                />
+                                                <Collapse in={endpointCategory.prod}>
+                                                    <ServiceEndpoint
+                                                        classes={classes}
+                                                        api={api}
+                                                        services={servicesList}
+                                                        category='production_endpoints'
+                                                        type=''
+                                                        setAdvancedConfigOpen={toggleAdvanceConfig}
+                                                        esCategory='production'
+                                                        setESConfigOpen={toggleEndpointSecurityConfig}
+                                                        name={<FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.production'
+                                                                + '.endpoint.production.header'}
+                                                            defaultMessage='Production Endpoint'
+                                                        />}
+                                                        editEndpoint={editEndpoint}
+                                                        endpointURL={getEndpoints
+                                                        (
+                                                            'production_endpoints'
+                                                        )}
+                                                        existingService={getService}
+                                                        editService={editService}
+                                                        index={0} />
+                                                </Collapse>
+                                            </>}
+                                            {componentValidator.includes("typeSANDBOX") &&
+                                            <>
+                                                <FormControlLabel
+                                                    control={(
+                                                        <Checkbox
+                                                            disabled={isRestricted(
+                                                                ['apim:api_create'], api)}
+                                                            checked={endpointCategory.sandbox}
+                                                            value='sandbox'
+                                                            color='primary'
+                                                            onChange={() => (
+                                                                handleOnChangeEndpointCategoryChange
+                                                                (
+                                                                    'sandbox',
+                                                                ))}
+                                                        />
+                                                    )}
+                                                    label={(
+                                                        <FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.sandbox'
+                                                                + '.endpoint'}
+                                                            defaultMessage='Sandbox Endpoint'
+                                                        />
+                                                    )}
+                                                />
+                                                <Collapse in={endpointCategory.sandbox}>
+                                                    <ServiceEndpoint
+                                                        classes={classes}
+                                                        api={api}
+                                                        services={servicesList}
+                                                        category='sandbox_endpoints'
+                                                        type=''
+                                                        setAdvancedConfigOpen={toggleAdvanceConfig}
+                                                        esCategory='sandbox'
+                                                        setESConfigOpen={toggleEndpointSecurityConfig}
+                                                        name={ <FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.sandbox'
+                                                                + '.endpoint'}
+                                                            defaultMessage='Sandbox Endpoint'
+                                                        />}
+                                                        editEndpoint={editEndpoint}
+                                                        endpointURL={getEndpoints
+                                                        (
+                                                            'sandbox_endpoints'
+                                                        )}
+                                                        index={0} />
+                                                </Collapse>
+                                            </>}
                                         </>
-
                                     )
                                     : (
                                         <>
@@ -957,32 +963,35 @@ function EndpointOverview(props) {
                                                                         />
                                                                     </Typography>
                                                                 )
-                                                                : (
-                                                                    <FormControlLabel
-                                                                        control={(
-                                                                            <Checkbox
-                                                                                id='production-endpoint-checkbox'
-                                                                                disabled={isRestricted(
-                                                                                    ['apim:api_create'], api)}
-                                                                                checked={endpointCategory.prod}
-                                                                                value='prod'
-                                                                                color='primary'
-                                                                                onChange={epCategoryOnChangeHandler}
-                                                                            />
-                                                                        )}
-                                                                        label={(
-                                                                            <Typography>
-                                                                                <FormattedMessage
-                                                                                    id={'Apis.Details.'
-                                                                                        + 'Endpoints.EndpointOverview'
-                                                                                        + '.production.endpoint'
-                                                                                        + '.production.label'}
-                                                                                    defaultMessage='Production Endpoint'
+                                                                : 
+                                                                    componentValidator.includes("typePRODUCTION") && 
+                                                                    <>
+                                                                        <FormControlLabel
+                                                                            control={(
+                                                                                <Checkbox
+                                                                                    id='production-endpoint-checkbox'
+                                                                                    disabled={isRestricted(
+                                                                                        ['apim:api_create'], api)}
+                                                                                    checked={endpointCategory.prod}
+                                                                                    value='prod'
+                                                                                    color='primary'
+                                                                                    onChange={epCategoryOnChangeHandler}
                                                                                 />
-                                                                            </Typography>
-                                                                        )}
-                                                                    />
-                                                                )}
+                                                                            )}
+                                                                            label={(
+                                                                                <Typography>
+                                                                                    <FormattedMessage
+                                                                                        id={'Apis.Details.'
+                                                                                            + 'Endpoints.EndpointOverview'
+                                                                                            + '.production.endpoint'
+                                                                                            + '.production.label'}
+                                                                                        defaultMessage='Production Endpoint'
+                                                                                    />
+                                                                                </Typography>
+                                                                            )}
+                                                                        />
+                                                                    </>
+                                                                }
                                                             <Collapse in={endpointCategory.prod}>
                                                                 {endpointType.key === 'default'
                                                                     ? (
@@ -1043,35 +1052,37 @@ function EndpointOverview(props) {
                                                                                     />
                                                                                 </Typography>
                                                                             </Button>
-                                                                            <Button
-                                                                                className={classes.button}
-                                                                                aria-label='Settings'
-                                                                                onClick={() => toggleEndpointSecurityConfig(
-                                                                                    '', 'production',
-                                                                                )}
-                                                                                disabled={
-                                                                                    (isRestricted(
-                                                                                        ['apim:api_create'], api,
-                                                                                    )
-                                                                                    )
-                                                                                }
-                                                                                variant='outlined'
-                                                                            >
-                                                                                <Icon
-                                                                                    className={classes.buttonIcon}
+                                                                            {endpointSecurityTypes.length > 0 &&
+                                                                                <Button
+                                                                                    className={classes.button}
+                                                                                    aria-label='Settings'
+                                                                                    onClick={() => toggleEndpointSecurityConfig(
+                                                                                        '', 'production',
+                                                                                    )}
+                                                                                    disabled={
+                                                                                        (isRestricted(
+                                                                                            ['apim:api_create'], api,
+                                                                                        )
+                                                                                        )
+                                                                                    }
+                                                                                    variant='outlined'
                                                                                 >
-                                                                                    security
-                                                                                </Icon>
-                                                                                <Typography>
-                                                                                    <FormattedMessage
-                                                                                        id={'Apis.Details.Endpoints'
-                                                                                            + '.EndpointOverview.endpoint'
-                                                                                            + '.security.configuration'}
-                                                                                        defaultMessage={'Endpoint '
-                                                                                            + 'Security Configurations'}
-                                                                                    />
-                                                                                </Typography>
-                                                                            </Button>
+                                                                                    <Icon
+                                                                                        className={classes.buttonIcon}
+                                                                                    >
+                                                                                        security
+                                                                                    </Icon>
+                                                                                    <Typography>
+                                                                                        <FormattedMessage
+                                                                                            id={'Apis.Details.Endpoints'
+                                                                                                + '.EndpointOverview.endpoint'
+                                                                                                + '.security.configuration'}
+                                                                                            defaultMessage={'Endpoint '
+                                                                                                + 'Security Configurations'}
+                                                                                        />
+                                                                                    </Typography>
+                                                                                </Button>
+                                                                            }
                                                                         </InlineMessage>
                                                                     )
                                                                     : (
@@ -1108,6 +1119,7 @@ function EndpointOverview(props) {
                                                                             setESConfigOpen={toggleEndpointSecurityConfig}
                                                                             ap
                                                                             iId={api.id}
+                                                                            componentValidator={componentValidator}
                                                                         />
                                                                         {api.subtypeConfiguration?.subtype === 'AIAPI' && // eslint-disable-line
                                                                             (apiKeyParamConfig.authHeader || apiKeyParamConfig.authQueryParameter) && // eslint-disable-line
@@ -1122,159 +1134,163 @@ function EndpointOverview(props) {
                                                             {endpointType.key === 'prototyped' ? <div />
                                                                 : (
                                                                     <div>
-                                                                        <FormControlLabel
-                                                                            control={(
-                                                                                <Checkbox
-                                                                                    id='sandbox-endpoint-checkbox'
-                                                                                    disabled={isRestricted(
-                                                                                        ['apim:api_create'], api)}
-                                                                                    checked={endpointCategory.sandbox}
-                                                                                    value='sandbox'
-                                                                                    color='primary'
-                                                                                    onChange={() => (
-                                                                                        handleOnChangeEndpointCategoryChange
-                                                                                        (
-                                                                                            'sandbox',
-                                                                                        ))}
-                                                                                />
-                                                                            )}
-                                                                            label={(
-                                                                                <FormattedMessage
-                                                                                    id={'Apis.Details.Endpoints.'
-                                                                                        + 'EndpointOverview.sandbox'
-                                                                                        + '.endpoint'}
-                                                                                    defaultMessage='Sandbox Endpoint'
-                                                                                />
-                                                                            )}
-                                                                        />
-                                                                        <Collapse in={endpointCategory.sandbox}>
-                                                                            {endpointType.key === 'default'
-                                                                                ? (
-                                                                                    <InlineMessage>
-                                                                                        <div className={classes.
-                                                                                            contentWrapper}>
-                                                                                            <Typography
-                                                                                                component='p'
-                                                                                                className={classes.content}
-                                                                                            >
-                                                                                                <FormattedMessage
-                                                                                                    id={'Apis.Details'
-                                                                                                        + '.Endpoints'
-                                                                                                        + '.Endpoint'
-                                                                                                        + 'Overview'
-                                                                                                        + '.upload'
-                                                                                                        + '.mediation'
-                                                                                                        + '.message'}
-                                                                                                    defaultMessage={
-                                                                                                        'Please upload '
-                                                                                                        + ' a mediation'
-                                                                                                        + ' sequence '
-                                                                                                        + 'file to'
-                                                                                                        + ' Message '
-                                                                                                        + '  Mediation'
-                                                                                                        + ' Policies,'
-                                                                                                        + ' which sets the'
-                                                                                                        + ' endpoints.'
-                                                                                                    }
-                                                                                                />
-                                                                                                <IconButton
-                                                                                                    onClick={
-                                                                                                        saveAndRedirect
-                                                                                                    }
-                                                                                                    size='large'>
-                                                                                                    <LaunchIcon
-                                                                                                        style={{
-                                                                                                            marginLeft:
-                                                                                                                '2px'
-                                                                                                        }}
-                                                                                                        fontSize='small'
-                                                                                                        color='primary'
+                                                                        {componentValidator.includes("typeSANDBOX") && 
+                                                                        <>
+                                                                            <FormControlLabel
+                                                                                control={(
+                                                                                    <Checkbox
+                                                                                        id='sandbox-endpoint-checkbox'
+                                                                                        disabled={isRestricted(
+                                                                                            ['apim:api_create'], api)}
+                                                                                        checked={endpointCategory.sandbox}
+                                                                                        value='sandbox'
+                                                                                        color='primary'
+                                                                                        onChange={() => (
+                                                                                            handleOnChangeEndpointCategoryChange
+                                                                                            (
+                                                                                                'sandbox',
+                                                                                            ))}
+                                                                                    />
+                                                                                )}
+                                                                                label={(
+                                                                                    <FormattedMessage
+                                                                                        id={'Apis.Details.Endpoints.'
+                                                                                            + 'EndpointOverview.sandbox'
+                                                                                            + '.endpoint'}
+                                                                                        defaultMessage='Sandbox Endpoint'
+                                                                                    />
+                                                                                )}
+                                                                            />
+                                                                            <Collapse in={endpointCategory.sandbox}>
+                                                                                {endpointType.key === 'default'
+                                                                                    ? (
+                                                                                        <InlineMessage>
+                                                                                            <div className={classes.
+                                                                                                contentWrapper}>
+                                                                                                <Typography
+                                                                                                    component='p'
+                                                                                                    className={classes.content}
+                                                                                                >
+                                                                                                    <FormattedMessage
+                                                                                                        id={'Apis.Details'
+                                                                                                            + '.Endpoints'
+                                                                                                            + '.Endpoint'
+                                                                                                            + 'Overview'
+                                                                                                            + '.upload'
+                                                                                                            + '.mediation'
+                                                                                                            + '.message'}
+                                                                                                        defaultMessage={
+                                                                                                            'Please upload '
+                                                                                                            + ' a mediation'
+                                                                                                            + ' sequence '
+                                                                                                            + 'file to'
+                                                                                                            + ' Message '
+                                                                                                            + '  Mediation'
+                                                                                                            + ' Policies,'
+                                                                                                            + ' which sets the'
+                                                                                                            + ' endpoints.'
+                                                                                                        }
                                                                                                     />
-                                                                                                </IconButton>
-                                                                                            </Typography>
-                                                                                        </div>
-                                                                                        <Button
-                                                                                            className={classes.button}
-                                                                                            aria-label='Settings'
-                                                                                            onClick={() =>
-                                                                                                toggleAdvanceConfig(
-                                                                                                    0, '',
-                                                                                                    'sandbox_endpoints',
-                                                                                                )}
-                                                                                            disabled={
-                                                                                                (isRestricted(
-                                                                                                    ['apim:api_create'],
-                                                                                                    api,
-                                                                                                )
-                                                                                                )
-                                                                                            }
-                                                                                            variant='outlined'
-                                                                                        >
-                                                                                            <Icon
-                                                                                                className={
-                                                                                                    classes.buttonIcon}
+                                                                                                    <IconButton
+                                                                                                        onClick={
+                                                                                                            saveAndRedirect
+                                                                                                        }
+                                                                                                        size='large'>
+                                                                                                        <LaunchIcon
+                                                                                                            style={{
+                                                                                                                marginLeft:
+                                                                                                                    '2px'
+                                                                                                            }}
+                                                                                                            fontSize='small'
+                                                                                                            color='primary'
+                                                                                                        />
+                                                                                                    </IconButton>
+                                                                                                </Typography>
+                                                                                            </div>
+                                                                                            <Button
+                                                                                                className={classes.button}
+                                                                                                aria-label='Settings'
+                                                                                                onClick={() =>
+                                                                                                    toggleAdvanceConfig(
+                                                                                                        0, '',
+                                                                                                        'sandbox_endpoints',
+                                                                                                    )}
+                                                                                                disabled={
+                                                                                                    (isRestricted(
+                                                                                                        ['apim:api_create'],
+                                                                                                        api,
+                                                                                                    )
+                                                                                                    )
+                                                                                                }
+                                                                                                variant='outlined'
                                                                                             >
-                                                                                                settings
-                                                                                            </Icon>
-                                                                                            <Typography>
+                                                                                                <Icon
+                                                                                                    className={
+                                                                                                        classes.buttonIcon}
+                                                                                                >
+                                                                                                    settings
+                                                                                                </Icon>
+                                                                                                <Typography>
+                                                                                                    <FormattedMessage
+                                                                                                        id={'Apis.Details.'
+                                                                                                        + 'Endpoints'
+                                                                                                        + '.EndpointOverview.'
+                                                                                                        + 'advance'
+                                                                                                        + '.endpoint.'
+                                                                                                        + 'configuration'}
+                                                                                                        defaultMessage={
+                                                                                                            'Advanced '
+                                                                                                            + 'Configurations'}
+                                                                                                    />
+                                                                                                </Typography>
+                                                                                            </Button>
+                                                                                        </InlineMessage>
+                                                                                    )
+                                                                                    : (
+                                                                                    <> <GenericEndpoint
+                                                                                            autoFocus
+                                                                                            name={(
                                                                                                 <FormattedMessage
                                                                                                     id={'Apis.Details.'
-                                                                                                    + 'Endpoints'
-                                                                                                    + '.EndpointOverview.'
-                                                                                                    + 'advance'
-                                                                                                    + '.endpoint.'
-                                                                                                    + 'configuration'}
+                                                                                                        + 'Endpoints.'
+                                                                                                        + 'EndpointOverview.'
+                                                                                                        + 'sandbox.'
+                                                                                                        + 'endpoint.sandbox.'
+                                                                                                        + 'header'}
                                                                                                     defaultMessage={
-                                                                                                        'Advanced '
-                                                                                                        + 'Configurations'}
+                                                                                                        'Sandbox '
+                                                                                                        + 'Endpoint'}
                                                                                                 />
-                                                                                            </Typography>
-                                                                                        </Button>
-                                                                                    </InlineMessage>
-                                                                                )
-                                                                                : (
-                                                                                   <> <GenericEndpoint
-                                                                                        autoFocus
-                                                                                        name={(
-                                                                                            <FormattedMessage
-                                                                                                id={'Apis.Details.'
-                                                                                                    + 'Endpoints.'
-                                                                                                    + 'EndpointOverview.'
-                                                                                                    + 'sandbox.'
-                                                                                                    + 'endpoint.sandbox.'
-                                                                                                    + 'header'}
-                                                                                                defaultMessage={
-                                                                                                    'Sandbox '
-                                                                                                    + 'Endpoint'}
-                                                                                            />
-                                                                                        )}
-                                                                                        className={classes.
-                                                                                            defaultEndpointWrapper}
-                                                                                        endpointURL={getEndpoints
-                                                                                        (
-                                                                                            'sandbox_endpoints'
-                                                                                        )}
-                                                                                        type=''
-                                                                                        index={0}
-                                                                                        category='sandbox_endpoints'
-                                                                                        editEndpoint={editEndpoint}
-                                                                                        esCategory='sandbox'
-                                                                                        setAdvancedConfigOpen=
-                                                                                            {toggleAdvanceConfig}
-                                                                                        setESConfigOpen=
-                                                                                            {toggleEndpointSecurityConfig}
-                                                                                        apiId={api.id}
-                                                                                    />
-                                                                                    {endpointCategory.sandbox && // eslint-disable-line
-                                                                                        api.subtypeConfiguration?.subtype === 'AIAPI' && // eslint-disable-line
-                                                                                        (apiKeyParamConfig.authHeader || apiKeyParamConfig.authQueryParameter) && // eslint-disable-line
-                                                                                        (<AIEndpointAuth
-                                                                                            api={api}
-                                                                                            saveEndpointSecurityConfig={saveEndpointSecurityConfig} // eslint-disable-line
-                                                                                            apiKeyParamConfig={apiKeyParamConfig} // eslint-disable-line
-                                                                                    />)}</> // eslint-disable-line
-                                                                                )}
-                                                                        </Collapse>
+                                                                                            )}
+                                                                                            className={classes.
+                                                                                                defaultEndpointWrapper}
+                                                                                            endpointURL={getEndpoints
+                                                                                            (
+                                                                                                'sandbox_endpoints'
+                                                                                            )}
+                                                                                            type=''
+                                                                                            index={0}
+                                                                                            category='sandbox_endpoints'
+                                                                                            editEndpoint={editEndpoint}
+                                                                                            esCategory='sandbox'
+                                                                                            setAdvancedConfigOpen=
+                                                                                                {toggleAdvanceConfig}
+                                                                                            setESConfigOpen=
+                                                                                                {toggleEndpointSecurityConfig}
+                                                                                            apiId={api.id}
+                                                                                            componentValidator={componentValidator}
+                                                                                        />
+                                                                                        {endpointCategory.sandbox && // eslint-disable-line
+                                                                                            api.subtypeConfiguration?.subtype === 'AIAPI' && // eslint-disable-line
+                                                                                            (apiKeyParamConfig.authHeader || apiKeyParamConfig.authQueryParameter) && // eslint-disable-line
+                                                                                            (<AIEndpointAuth
+                                                                                                api={api}
+                                                                                                saveEndpointSecurityConfig={saveEndpointSecurityConfig} // eslint-disable-line
+                                                                                                apiKeyParamConfig={apiKeyParamConfig} // eslint-disable-line
+                                                                                        />)}</> // eslint-disable-line
+                                                                                    )}
+                                                                            </Collapse>
+                                                                        </>}
                                                                     </div>
                                                                 )}
                                                         </>
@@ -1314,8 +1330,8 @@ function EndpointOverview(props) {
                         || api.type === 'WS'
                         || endpointType.key === 'awslambda'
                         || endpointType.key === 'service'
-                        || api.gatewayType === 'wso2/apk'
                         || api.subtypeConfiguration?.subtype === 'AIAPI'
+                        || !componentValidator.includes('loadBalanceAndFailoverConfigurations')
                         ? <div />
                         : (
                             <Grid item xs={12}>
@@ -1341,12 +1357,13 @@ function EndpointOverview(props) {
                                     handleEndpointTypeSelect={handleEndpointTypeSelect}
                                     globalEpType={endpointType}
                                     apiType={api.type}
+                                    componentValidator={componentValidator}
                                 />
                             </Grid>
                         )
                 }
             </Grid>
-            {api.gatewayType !== 'wso2/apk' && (
+            {componentValidator.includes('advancedConfigurations') && (
                 <Dialog open={advanceConfigOptions.open}>
                     <DialogTitle>
                         <Typography className={classes.configDialogHeader}>
@@ -1366,77 +1383,84 @@ function EndpointOverview(props) {
                     </DialogContent>
                 </Dialog>
             )}
-            <Dialog open={endpointSecurityConfig.open}>
-                <DialogTitle>
-                    <Typography className={classes.configDialogHeader}>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.security.configuration'
-                            defaultMessage='Endpoint Security Configurations'
-                        />
-                    </Typography>
-                </DialogTitle>
-                <DialogContent>
-                    {endpointSecurityConfig.category === 'production' ? (
-                        <EndpointSecurity
-                            securityInfo={endpointSecurityInfo
-                                && (endpointSecurityInfo.production
-                                    ? endpointSecurityInfo.production : endpointSecurityInfo)}
-                            onChangeEndpointAuth={handleEndpointSecurityChange}
-                            saveEndpointSecurityConfig={saveEndpointSecurityConfig}
-                            closeEndpointSecurityConfig={closeEndpointSecurityConfig}
-                            isProduction
-                        />
-                    ) : (
-                        <EndpointSecurity
-                            securityInfo={endpointSecurityInfo
-                                && (endpointSecurityInfo.sandbox
-                                    ? endpointSecurityInfo.sandbox : endpointSecurityInfo)}
-                            onChangeEndpointAuth={handleEndpointSecurityChange}
-                            saveEndpointSecurityConfig={saveEndpointSecurityConfig}
-                            closeEndpointSecurityConfig={closeEndpointSecurityConfig}
-                        />
-                    )}
-                </DialogContent>
-            </Dialog>
-            <Dialog open={typeChangeConfirmation.openDialog}>
-                <DialogTitle>
-                    <Typography className={classes.configDialogHeader}>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation'
-                            defaultMessage='Change Endpoint Type'
-                        />
-                    </Typography>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation.message'
-                            defaultMessage='Your current endpoint configuration will be lost.'
-                        />
-                    </Typography>
-                </DialogContent>
-                <DialogActions>
-                    <Button
-                        onClick={() => { setTypeChangeConfirmation({ openDialog: false, serviceInfo: false }); }}
-                        color='primary'
-                    >
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.change.type.cancel'
-                            defaultMessage='Cancel'
-                        />
-                    </Button>
-                    <Button
-                        onClick={() => { changeEndpointType(typeChangeConfirmation.type); }}
-                        color='primary'
-                        id='change-endpoint-type-btn'
-                    >
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints..EndpointOverview.change.type.proceed'
-                            defaultMessage='Proceed'
-                        />
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            {endpointSecurityTypes && endpointSecurityTypes.length > 0 &&
+                <>
+                    <Dialog open={endpointSecurityConfig.open}>
+                        <DialogTitle>
+                            <Typography className={classes.configDialogHeader}>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.security.configuration'
+                                    defaultMessage='Endpoint Security Configurations'
+                                />
+                            </Typography>
+                        </DialogTitle>
+                        <DialogContent>
+                            {endpointSecurityConfig.category === 'production' ? (
+                                <EndpointSecurity
+                                    securityInfo={endpointSecurityInfo
+                                        && (endpointSecurityInfo.production
+                                            ? endpointSecurityInfo.production : endpointSecurityInfo)}
+                                    onChangeEndpointAuth={handleEndpointSecurityChange}
+                                    saveEndpointSecurityConfig={saveEndpointSecurityConfig}
+                                    closeEndpointSecurityConfig={closeEndpointSecurityConfig}
+                                    isProduction
+                                    endpointSecurityTypes={endpointSecurityTypes}
+                                />
+                            ) : (
+                                <EndpointSecurity
+                                    securityInfo={endpointSecurityInfo
+                                        && (endpointSecurityInfo.sandbox
+                                            ? endpointSecurityInfo.sandbox : endpointSecurityInfo)}
+                                    onChangeEndpointAuth={handleEndpointSecurityChange}
+                                    saveEndpointSecurityConfig={saveEndpointSecurityConfig}
+                                    closeEndpointSecurityConfig={closeEndpointSecurityConfig}
+                                />
+                            )}
+                        </DialogContent>
+                    </Dialog>
+                    <Dialog open={typeChangeConfirmation.openDialog}>
+                        <DialogTitle>
+                            <Typography className={classes.configDialogHeader}>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation'
+                                    defaultMessage='Change Endpoint Type'
+                                />
+                            </Typography>
+                        </DialogTitle>
+                        <DialogContent>
+                            <Typography>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.type
+                                        .change.confirmation.message'
+                                    defaultMessage='Your current endpoint configuration will be lost.'
+                                />
+                            </Typography>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button
+                                onClick={() => 
+                                    { setTypeChangeConfirmation({ openDialog: false, serviceInfo: false }); }}
+                                color='primary'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.change.type.cancel'
+                                    defaultMessage='Cancel'
+                                />
+                            </Button>
+                            <Button
+                                onClick={() => { changeEndpointType(typeChangeConfirmation.type); }}
+                                color='primary'
+                                id='change-endpoint-type-btn'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints..EndpointOverview.change.type.proceed'
+                                    defaultMessage='Proceed'
+                                />
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+                </>
+            }
         </Root>
     );
 }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -107,7 +107,7 @@ function EndpointSecurity(props) {
     } = props;
     const [endpointSecurityInfo, setEndpointSecurityInfo] = useState(CONSTS.DEFAULT_ENDPOINT_SECURITY);
 
-    if (!(securityInfo?.proxyConfigs != null)) {
+    if (securityInfo && securityInfo.proxyConfigs == null) {
         securityInfo.proxyConfigs = {
             proxyEnabled: false,
             proxyHost: '',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -104,6 +104,7 @@ function EndpointSecurity(props) {
     const { settings } = useAppContext();
     const {
         intl, securityInfo, onChangeEndpointAuth, isProduction, saveEndpointSecurityConfig, closeEndpointSecurityConfig,
+        endpointSecurityTypes,
     } = props;
     const [endpointSecurityInfo, setEndpointSecurityInfo] = useState(CONSTS.DEFAULT_ENDPOINT_SECURITY);
 
@@ -127,30 +128,9 @@ function EndpointSecurity(props) {
     const endpointType = isProduction ? 'production' : 'sandbox';
 
     const authTypes = () => {
-        const { gatewayType } = api; // Access gatewayType directly from api
-
-        if (gatewayType === 'wso2/apk') {
-            return [
-                {
-                    key: 'NONE',
-                    value: intl.formatMessage({
-                        id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.none',
-                        defaultMessage: 'None',
-                    }),
-                },
-                {
-                    key: 'BASIC',
-                    value: intl.formatMessage({
-                        id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.basic',
-                        defaultMessage: 'Basic Auth',
-                    }),
-                },
-            ];
-        }
-
-        // Default authTypes for other gateway types
-        return [
+        const types = [
             {
+                id: 'none',
                 key: 'NONE',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.none',
@@ -158,6 +138,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'basicAuth',
                 key: 'BASIC',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.basic',
@@ -165,6 +146,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'digest',
                 key: 'DIGEST',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.digest.auth',
@@ -172,6 +154,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'oauth2',
                 key: 'OAUTH',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.oauth',
@@ -179,6 +162,10 @@ function EndpointSecurity(props) {
                 }),
             },
         ];
+
+        const selectedTypes = [types[0]];
+
+        return selectedTypes.concat(types.filter((type) => endpointSecurityTypes?.includes(type.id)));
     };
 
     const grantTypes = [

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
@@ -117,6 +117,7 @@ function GenericEndpoint(props) {
         name,
         id,
         apiId,
+        componentValidator,
     } = props;
     const [serviceUrl, setServiceUrl] = useState(endpointURL);
     const { api } = useContext(APIContext);
@@ -227,28 +228,30 @@ function GenericEndpoint(props) {
                                 ? <div />
                                 : (
                                     <>
-                                        <IconButton
-                                            className={classes.iconButton}
-                                            aria-label='Settings'
-                                            onClick={() => setAdvancedConfigOpen(index, type, category)}
-                                            disabled={(isRestricted(['apim:api_create'], api))}
-                                            id={category + '-endpoint-configuration-icon-btn'}
-                                            size='large'>
-                                            <Tooltip
-                                                placement='top-start'
-                                                interactive
-                                                title={(
-                                                    <FormattedMessage
-                                                        id='Apis.Details.Endpoints.GenericEndpoint.config.endpoint'
-                                                        defaultMessage='Endpoint configurations'
-                                                    />
-                                                )}
-                                            >
-                                                <Icon>
-                                                    settings
-                                                </Icon>
-                                            </Tooltip>
-                                        </IconButton>
+                                        {componentValidator.includes('advancedConfigurations') &&
+                                            <IconButton
+                                                className={classes.iconButton}
+                                                aria-label='Settings'
+                                                onClick={() => setAdvancedConfigOpen(index, type, category)}
+                                                disabled={(isRestricted(['apim:api_create'], api))}
+                                                id={category + '-endpoint-configuration-icon-btn'}
+                                                size='large'>
+                                                <Tooltip
+                                                    placement='top-start'
+                                                    interactive
+                                                    title={(
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Endpoints.GenericEndpoint.config.endpoint'
+                                                            defaultMessage='Endpoint configurations'
+                                                        />
+                                                    )}
+                                                >
+                                                    <Icon>
+                                                        settings
+                                                    </Icon>
+                                                </Tooltip>
+                                            </IconButton>
+                                        }
                                         {api.subtypeConfiguration?.subtype !== 'AIAPI' && (<IconButton
                                             className={classes.iconButton}
                                             aria-label='Security'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
@@ -134,6 +134,7 @@ function LoadbalanceFailoverConfig(props) {
         toggleESConfig,
         globalEpType,
         handleEndpointCategorySelect,
+        componentValidator,
     } = props;
     const { api } = useContext(APIContext);
     const [isConfigExpanded, setConfigExpand] = useState(false);
@@ -377,6 +378,7 @@ function LoadbalanceFailoverConfig(props) {
                                                 setESConfigOpen={toggleESConfig}
                                                 category='production_endpoints'
                                                 apiId={api.id}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}
@@ -412,6 +414,7 @@ function LoadbalanceFailoverConfig(props) {
                                                 setESConfigOpen={toggleESConfig}
                                                 category='sandbox_endpoints'
                                                 apiId={api.id}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
@@ -95,6 +95,7 @@ function NewEndpointCreate(props) {
         intl,
         generateEndpointConfig,
         apiType,
+        componentValidator,
     } = props;
     const [endpointImplType, setImplType] = useState('mock');
     const endpointTypes = [
@@ -138,7 +139,7 @@ function NewEndpointCreate(props) {
             disabled: ['GRAPHQL', 'SSE'],
         },
         {
-            type: 'prototyped',
+            type: 'INLINE',
             name: intl.formatMessage({
                 id: 'Apis.Details.Endpoints.NewEndpointCreate.create.prototype.endpoint',
                 defaultMessage: 'Mock Implementation',
@@ -205,7 +206,7 @@ function NewEndpointCreate(props) {
                 />
             </Typography>
             <Grid container justifyContent='flex-start' spacing={2}>
-                {eligibleTypes.map(((type) => {
+                {(eligibleTypes.filter(ep => componentValidator.includes(ep.type)).map((type) => {
                     return (
                         <Grid item className={classes.inlineMessageContainer}>
                             <Card className={classes.endpointTypeCard}>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Permission.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Permission.jsx
@@ -33,7 +33,7 @@ export default function SimplePopper(props) {
     } = props;
     const [anchorEl, setAnchorEl] = React.useState(null);
 
-    let msg = roles.toString();
+    let msg = roles?.toString();
     if (type === 'PUBLIC') {
         msg = 'No Visibility Restrictions!';
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/ExternalStores/ExternalStores.jsx
@@ -82,7 +82,7 @@ export default function ExternalStores() {
     const [isUpdating, setUpdating] = useState(false);
 
     const intl = useIntl();
-    if (!settings.externalStoresEnabled) {
+    if (settings && !settings.externalStoresEnabled) {
         const resourceNotFoundMessageText = defineMessages({
             titleMessage: {
                 id: 'Apis.Details.ExternalStores.ExternalStores.external.stores.not.found.title',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
@@ -145,7 +145,10 @@ function MetaData(props) {
                             </Grid>
                             <Grid item xs={12} md={6} lg={8}>
                                 <Typography component='p' variant='body1'>
-                                    {api.gatewayType === 'wso2/synapse' ? 'Regular' : 'APK'}
+                                    {api.gatewayType === 'wso2/synapse' && 'Regular'}
+                                    {api.gatewayType === 'wso2/apk' && 'APK'}
+                                    {api.gatewayType !== 'wso2/synapse' && api.gatewayType !== 'wso2/apk' 
+                                        && api.gatewayType}
                                 </Typography>
                             </Grid>
                         </>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operation.jsx
@@ -197,7 +197,7 @@ class Operation extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            isSecurity: false,
+            isSecurity: props.componentValidator.includes('operationSecurity'),
         };
         this.handleScopeChange = this.handleScopeChange.bind(this);
         this.handlePolicyChange = this.handlePolicyChange.bind(this);
@@ -255,7 +255,7 @@ class Operation extends React.Component {
      */
     render() {
         const {
-            operation, theme, apiPolicies, scopes, isOperationRateLimiting, sharedScopes, intl,
+            operation, theme, apiPolicies, scopes, isOperationRateLimiting, sharedScopes, intl, componentValidator,
         } = this.props;
         const dropdownScopes = [...scopes];
         const { isSecurity } = this.state;
@@ -288,127 +288,138 @@ class Operation extends React.Component {
                         className={classes.chipActive}
                     />
                 </TableCell>
-                <TableCell>
-                    <Select
-                        className={classes.dropDown}
-                        value={isOperationRateLimiting ? operation.throttlingPolicy : ''}
-                        disabled={(!isOperationRateLimiting || isRestricted(['apim:api_publish', 'apim:api_create']))}
-                        onChange={this.handlePolicyChange}
-                        fieldName='Throttling Policy'
-                    >
-                        {apiPolicies.map((policy) => (
-                            <MenuItem
-                                key={policy.name}
-                                value={policy.name}
-                            >
-                                {policy.displayName}
-                            </MenuItem>
-                        ))}
-                    </Select>
-                </TableCell>
-                <TableCell>
-                    <TextField
-                        id='operation_scope'
-                        select
-                        SelectProps={{
-                            multiple: true,
-                            renderValue: (selected) => (Array.isArray(selected) ? selected.join(', ') : selected),
-                        }}
-                        fullWidth
-                        label={dropdownScopes.length !== 0 || sharedScopes ? intl.formatMessage({
-                            id: 'Apis.Details.Operations.Operation.operation.scope.label.default',
-                            defaultMessage: 'Operation scope',
-                        }) : intl.formatMessage({
-                            id: 'Apis.Details.Operations.Operation.operation.scope.label.notAvailable',
-                            defaultMessage: 'No scope available',
-                        })}
-                        value={operation.scopes}
-                        onChange={({ target: { value } }) => this.handleScopeChange({
-                            data: { value: value ? [value] : [] },
-                        })}
-                        helperText={(
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.helperText'
-                                defaultMessage='Select a scope to control permissions to this operation'
-                            />
-                        )}
-                        margin='dense'
-                        variant='outlined'
-                        disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
-                    >
-                        <ListSubheader>
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.select.local'
-                                defaultMessage='API Scopes'
-                            />
-                        </ListSubheader>
-                        {filteredApiScopes.length !== 0 ? filteredApiScopes.map((apiScope) => (
-                            <MenuItem
-                                key={apiScope.scope.name}
-                                value={apiScope.scope.name}
-                                dense
-                            >
-                                <Checkbox checked={operation.scopes.includes(apiScope.scope.name)} color='primary' />
-                                {apiScope.scope.name}
-                            </MenuItem>
-                        )) : (
-                            <MenuItem
-                                value=''
-                                disabled
-                            >
-                                <em>
+                {componentValidator.includes('operationLevelRateLimiting') &&
+                    <TableCell>
+                        <Select
+                            className={classes.dropDown}
+                            value={isOperationRateLimiting ? operation.throttlingPolicy : ''}
+                            disabled={(!isOperationRateLimiting || 
+                                isRestricted(['apim:api_publish', 'apim:api_create']))}
+                            onChange={this.handlePolicyChange}
+                            fieldName='Throttling Policy'
+                        >
+                            {apiPolicies.map((policy) => (
+                                <MenuItem
+                                    key={policy.name}
+                                    value={policy.name}
+                                >
+                                    {policy.displayName}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </TableCell>
+                }
+                {componentValidator.includes('operationSecurity') &&
+                    <>
+                        <TableCell>
+                            <TextField
+                                id='operation_scope'
+                                select
+                                SelectProps={{
+                                    multiple: true,
+                                    renderValue: (selected) => 
+                                        (Array.isArray(selected) ? selected.join(', ') : selected),
+                                }}
+                                fullWidth
+                                label={dropdownScopes.length !== 0 || sharedScopes ? intl.formatMessage({
+                                    id: 'Apis.Details.Operations.Operation.operation.scope.label.default',
+                                    defaultMessage: 'Operation scope',
+                                }) : intl.formatMessage({
+                                    id: 'Apis.Details.Operations.Operation.operation.scope.label.notAvailable',
+                                    defaultMessage: 'No scope available',
+                                })}
+                                value={operation.scopes}
+                                onChange={({ target: { value } }) => this.handleScopeChange({
+                                    data: { value: value ? [value] : [] },
+                                })}
+                                helperText={(
                                     <FormattedMessage
-                                        id='Apis.Details.Operations.Operation.operation.no.api.scope.available'
-                                        defaultMessage='No API scopes available'
+                                        id='Apis.Details.Operations.Operation.operation.scope.helperText'
+                                        defaultMessage='Select a scope to control permissions to this operation'
                                     />
-                                </em>
-                            </MenuItem>
-                        )}
-                        <ListSubheader>
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.select.shared'
-                                defaultMessage='Shared Scopes'
-                            />
-                        </ListSubheader>
-                        {sharedScopes && sharedScopes.length !== 0 ? sharedScopes.map((sharedScope) => (
-                            <MenuItem
-                                key={sharedScope.scope.name}
-                                value={sharedScope.scope.name}
-                                dense
+                                )}
+                                margin='dense'
+                                variant='outlined'
+                                disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
                             >
-                                <Checkbox checked={operation.scopes.includes(sharedScope.scope.name)} color='primary' />
-                                {sharedScope.scope.name}
-                            </MenuItem>
-                        )) : (
-                            <MenuItem
-                                value=''
-                                disabled
-                            >
-                                <em>
+                                <ListSubheader>
                                     <FormattedMessage
-                                        id='Apis.Details.Operations.Operation.operation.no.sharedpi.scope.available'
-                                        defaultMessage='No shared scopes available'
+                                        id='Apis.Details.Operations.Operation.operation.scope.select.local'
+                                        defaultMessage='API Scopes'
                                     />
-                                </em>
-                            </MenuItem>
-                        )}
-                    </TextField>
-                </TableCell>
-                <TableCell>
-                    <Switch
-                        checked={(() => {
-                            if (operation.authType === 'None') {
-                                return false;
-                            }
-                            return true;
-                        })()}
-                        onChange={this.handleChange}
-                        value={isSecurity}
-                        color='primary'
-                        disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
-                        data-testid={operation.target + '-security-btn'}
-                    />
-                </TableCell>
+                                </ListSubheader>
+                                {filteredApiScopes.length !== 0 ? filteredApiScopes.map((apiScope) => (
+                                    <MenuItem
+                                        key={apiScope.scope.name}
+                                        value={apiScope.scope.name}
+                                        dense
+                                    >
+                                        <Checkbox checked={operation.scopes.includes(apiScope.scope.name)} 
+                                            color='primary' />
+                                        {apiScope.scope.name}
+                                    </MenuItem>
+                                )) : (
+                                    <MenuItem
+                                        value=''
+                                        disabled
+                                    >
+                                        <em>
+                                            <FormattedMessage
+                                                id='Apis.Details.Operations.Operation.operation.no.api.scope.available'
+                                                defaultMessage='No API scopes available'
+                                            />
+                                        </em>
+                                    </MenuItem>
+                                )}
+                                <ListSubheader>
+                                    <FormattedMessage
+                                        id='Apis.Details.Operations.Operation.operation.scope.select.shared'
+                                        defaultMessage='Shared Scopes'
+                                    />
+                                </ListSubheader>
+                                {sharedScopes && sharedScopes.length !== 0 ? sharedScopes.map((sharedScope) => (
+                                    <MenuItem
+                                        key={sharedScope.scope.name}
+                                        value={sharedScope.scope.name}
+                                        dense
+                                    >
+                                        <Checkbox checked={operation.scopes.includes(sharedScope.scope.name)} 
+                                            color='primary' />
+                                        {sharedScope.scope.name}
+                                    </MenuItem>
+                                )) : (
+                                    <MenuItem
+                                        value=''
+                                        disabled
+                                    >
+                                        <em>
+                                            <FormattedMessage
+                                                id='Apis.Details.Operations
+                                                    .Operation.operation.no.sharedpi.scope.available'
+                                                defaultMessage='No shared scopes available'
+                                            />
+                                        </em>
+                                    </MenuItem>
+                                )}
+                            </TextField>
+                        </TableCell>
+                        <TableCell>
+                            <Switch
+                                checked={(() => {
+                                    if (operation.authType === 'None') {
+                                        return false;
+                                    }
+                                    return true;
+                                })()}
+                                onChange={this.handleChange}
+                                value={isSecurity}
+                                color='primary'
+                                disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
+                                data-testid={operation.target + '-security-btn'}
+                            />
+                        </TableCell>
+                    </>
+                }
             </StyledTableRow>
         );
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operations.jsx
@@ -351,7 +351,7 @@ class Operations extends React.Component {
      * @inheritdoc
      */
     render() {
-        const { api, resourceNotFoundMessage, intl} = this.props;
+        const { api, resourceNotFoundMessage, intl, componentValidator} = this.props;
         const {
             operations, apiPolicies, apiThrottlingPolicy, isSaving,
             filterKeyWord, notFound, sharedScopes, enableReadOnly,
@@ -429,30 +429,37 @@ class Operations extends React.Component {
                                                 />
                                             </Typography>
                                         </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.throttling.policy'
-                                                    defaultMessage='Rate Limiting'
-                                                />
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.scopes'
-                                                    defaultMessage='Scope'
-                                                />
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.authType'
-                                                    defaultMessage='Security Enabled'
-                                                />
-                                            </Typography>
-                                        </TableCell>
+                                        {componentValidator.includes("operationLevelRateLimiting") &&
+                                            <TableCell>
+                                                <Typography variant='subtitle2'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Operations.Operation
+                                                            .throttling.policy'
+                                                        defaultMessage='Rate Limiting'
+                                                    />
+                                                </Typography>
+                                            </TableCell>
+                                        }
+                                        {componentValidator.includes("operationSecurity") &&
+                                            <>
+                                                <TableCell>
+                                                    <Typography variant='subtitle2'>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Operations.Operation.scopes'
+                                                            defaultMessage='Scope'
+                                                        />
+                                                    </Typography>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Typography variant='subtitle2'>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Operations.Operation.authType'
+                                                            defaultMessage='Security Enabled'
+                                                        />
+                                                    </Typography>
+                                                </TableCell>
+                                            </>
+                                        }
                                     </TableRow>
                                     {operations.filter(
                                         (operation) => operation.target.toLowerCase().includes(filterKeyWord),
@@ -465,6 +472,7 @@ class Operations extends React.Component {
                                                 sharedScopes={sharedScopes}
                                                 isOperationRateLimiting={!apiThrottlingPolicy}
                                                 apiPolicies={apiPolicies}
+                                                componentValidator={componentValidator}
                                             />
                                         );
                                     })}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -96,7 +96,7 @@ const Policies: React.FC = () => {
     const [policies, setPolicies] = useState<Policy[]>([]);
     const [allPolicies, setAllPolicies] = useState<PolicySpec[] | null>(null);
     const [expandedResource, setExpandedResource] = useState<string | null>(null);
-    const [isChoreoConnectEnabled, setIsChoreoConnectEnabled] = useState(api.gatewayType === 'wso2/apk');
+    const [isChoreoConnectEnabled, setIsChoreoConnectEnabled] = useState(api.gatewayType !== 'wso2/synapse');
     const { showMultiVersionPolicies } = Configurations.apis;
     const [selectedTab, setSelectedTab] = useState((api.apiPolicies != null) ? 0 : 1);
 
@@ -203,10 +203,21 @@ const Policies: React.FC = () => {
             commonPolicyByPolicyDisplayName.sort(
                 (a: Policy, b: Policy) => a.name.localeCompare(b.name))
 
+            let gatewayType;
+            if (isChoreoConnectEnabled) {
+                // Get CC gateway supported policies
+                gatewayType = 'ChoreoConnect';
+            } else if (api.gatewayType === "aws") {
+                // Get AWS gateway supported policies
+                gatewayType = 'AWS';
+            } else {
+                // Get synpase gateway supported policies
+                gatewayType = 'Synapse';
+            }
+
             let filteredApiPolicyByGatewayTypeList = null;
             let filteredCommonPolicyByGatewayTypeList = null;
             
-            let gatewayType = isChoreoConnectEnabled ? 'ChoreoConnect' : 'Synapse';
             // Get relevant gateway supported policies
             filteredApiPolicyByGatewayTypeList = apiPolicyByPolicyDisplayName.filter(
                 (policy: Policy) => policy.supportedGateways.includes(gatewayType));

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -34,16 +34,19 @@ import SwaggerClient from 'swagger-client';
 import { isRestricted } from 'AppData/AuthManager';
 import CONSTS from 'AppData/Constants';
 import Configurations from 'Config';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
+import APIRateLimiting from './components/APIRateLimiting';
 import Operation from './components/Operation';
 import GroupOfOperations from './components/GroupOfOperations';
 import AddOperation from './components/AddOperation';
 import GoToDefinitionLink from './components/GoToDefinitionLink';
-import APIRateLimiting from './components/APIRateLimiting';
 import {
     extractPathParameters, isSelectAll, mapAPIOperations, getVersion, VERSIONS,
 } from './operationUtils';
 import OperationsSelector from './components/OperationsSelector';
 import SaveOperations from './components/SaveOperations';
+
 
 /**
  * This component handles the Resource page in API details though it's written in a sharable way
@@ -62,6 +65,7 @@ export default function Resources(props) {
         disableAddOperation,
     } = props;
 
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const [api, updateAPI] = useAPI();
     const [pageError, setPageError] = useState(false);
     const [operationRateLimits, setOperationRateLimits] = useState([]);
@@ -75,6 +79,7 @@ export default function Resources(props) {
     const [resolvedSpec, setResolvedSpec] = useState({ spec: {}, errors: [] });
     const [focusOperationLevel, setFocusOperationLevel] = useState(false);
     const [expandedResource, setExpandedResource] = useState(false);
+    const [componentValidator, setComponentValidator] = useState([]);
 
     const intl = useIntl();
     /**
@@ -516,6 +521,13 @@ export default function Resources(props) {
     }, []);
 
     useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(JSON.parse(publisherSettings.gatewayFeatureCatalog)
+                .gatewayFeatures[api.gatewayType].resources);
+        }
+    }, [isLoading]);
+
+    useEffect(() => {
         setApiThrottlingPolicy(api.apiThrottlingPolicy);
     }, [api.apiThrottlingPolicy]);
 
@@ -611,6 +623,9 @@ export default function Resources(props) {
             </Grid>
         );
     }
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     return (
         <Grid container direction='row' justifyContent='flex-start' spacing={2} alignItems='stretch'>
             {pageError && (
@@ -621,6 +636,7 @@ export default function Resources(props) {
             {!disableRateLimiting && (
                 <Grid item md={12}>
                     <APIRateLimiting
+                        api={api}
                         operationRateLimits={operationRateLimits}
                         value={apiThrottlingPolicy}
                         onChange={setApiThrottlingPolicy}
@@ -644,6 +660,7 @@ export default function Resources(props) {
                             setSelectedOperation={setSelectedOperation}
                             enableSecurity={enableSecurity}
                             disableSecurity={disableSecurity}
+                            componentValidator={componentValidator}
                         />
                     )}
                     {Object.entries(operations).map(([target, verbObject]) => (
@@ -688,6 +705,7 @@ export default function Resources(props) {
                                                     setFocusOperationLevel={setFocusOperationLevel}
                                                     expandedResource={expandedResource}
                                                     setExpandedResource={setExpandedResource}
+                                                    componentValidator={componentValidator}
                                                 />
                                             </Grid>
                                         ) : null;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/APIRateLimiting.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/APIRateLimiting.jsx
@@ -38,6 +38,8 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { isRestricted } from 'AppData/AuthManager';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
 
 const PREFIX = 'APIRateLimiting';
 
@@ -70,15 +72,16 @@ const RateLimitingLevels = {
  */
 function APIRateLimiting(props) {
     const {
-        updateAPI, operationRateLimits, onChange, value: currentApiThrottlingPolicy, isAPIProduct,
+        api, updateAPI, operationRateLimits, onChange, value: currentApiThrottlingPolicy, isAPIProduct,
         setFocusOperationLevel, focusOperationLevel,
     } = props;
     const intl = useIntl();
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const [apiThrottlingPolicy, setApiThrottlingPolicy] = useState(currentApiThrottlingPolicy);
     const [isSaving, setIsSaving] = useState(false);
-
-    const isResourceLevel = apiThrottlingPolicy === null;
-    const rateLimitingLevel = isResourceLevel ? RateLimitingLevels.RESOURCE : RateLimitingLevels.API;
+    const [componentValidator, setComponentValidator] = useState([]);
+    const [isResourceLevel, setIsResourceLevel] = useState(false);
+    const [rateLimitingLevel, setRateLimitingLevel] = useState(RateLimitingLevels.API);
     const [apiFromContext] = useAPI();
 
     // Following effect is used to handle the controlled component case, If user provide onChange handler to
@@ -92,6 +95,18 @@ function APIRateLimiting(props) {
             }
         }
     }, [onChange, currentApiThrottlingPolicy]); // Do not expect to change the onChange during the runtime
+
+    useEffect(() => {
+        setIsResourceLevel(apiThrottlingPolicy === null || !componentValidator.includes('apiLevelRateLimiting'));
+        setRateLimitingLevel(isResourceLevel ? RateLimitingLevels.RESOURCE : RateLimitingLevels.API);
+    }, [apiThrottlingPolicy, isResourceLevel]);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(JSON.parse(publisherSettings.gatewayFeatureCatalog)
+                .gatewayFeatures[api.gatewayType].resources);
+        }
+    }, [isLoading]);
 
     /**
      *
@@ -108,7 +123,7 @@ function APIRateLimiting(props) {
         } else {
             setApiThrottlingPolicy(userSelection);
         }
-        if (event.target.value === RateLimitingLevels.RESOURCE) {
+        if (event.target.value === RateLimitingLevels.RESOURCE && setFocusOperationLevel) {
             setFocusOperationLevel(false);
         }
     }
@@ -160,154 +175,163 @@ function APIRateLimiting(props) {
             </Typography>
         );
     }
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     return (
-        <StyledPaper>
-            <Grid container direction='row' justifyContent='flex-start' alignItems='flex-start'>
-                <Grid item md={12} xs={12} sx={{ p: 1 }}>
-                    <Box>
-                        <Typography variant='subtitle1' component='h3' gutterBottom>
-                            <FormattedMessage
-                                id='Apis.Details.Rate.Limiting.operations.configuration'
-                                defaultMessage='Operations Configuration'
-                            />
-                            <Tooltip
-                                fontSize='small'
-                                title={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.operations.configuration.tooltip',
-                                    defaultMessage: 'Configurations that affects on all the resources',
-                                })}
-                                placement='right-end'
-                                interactive
-                            >
-                                <IconButton aria-label='Operations Configuration help text' size='large'>
-                                    <HelpOutline />
-                                </IconButton>
-                            </Tooltip>
-                        </Typography>
-                    </Box>
-                    <Divider variant='middle' />
-                </Grid>
-                <Grid item md={6} xs={12} sx={{ p: 1 }}>
-                    <FormControl component='fieldset'>
-                        <FormLabel component='legend'>
-                            <FormattedMessage
-                                id='Apis.Details.Resources.components.APIRateLimiting.rate.limiting.level'
-                                defaultMessage='Rate limiting level'
-                            />
-                        </FormLabel>
-                        <RadioGroup
-                            aria-label='Apply rate limiting in'
-                            value={rateLimitingLevel}
-                            onChange={updateRateLimitingPolicy}
-                            row
-                        >
-                            <FormControlLabel
-                                value={RateLimitingLevels.API}
-                                control={(
-                                    <Radio
-                                        color='primary'
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.level.api.level',
-                                    defaultMessage: 'API Level',
-                                })}
-                                labelPlacement='end'
-                                id='api-rate-limiting-api-level'
-                            />
-                            <FormControlLabel
-                                value={RateLimitingLevels.RESOURCE}
-                                control={(
-                                    <Radio
-                                        color='primary'
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    />
-                                )}
-                                className={focusOperationLevel && classes.focusLabel}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.level.operation.level',
-                                    defaultMessage: 'Operation Level',
-                                })}
-                                labelPlacement='end'
-                                id='api-rate-limiting-operation-level'
-                            />
-                        </RadioGroup>
-                    </FormControl>
-                </Grid>
-                <Grid item md={6} xs={12} sx={{ p: 1 }}>
-                    <Box minHeight={70} pl={10} sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.2)' }}>
-                        {isResourceLevel ? (
-                            operationRateLimitMessage
-                        ) : (
-                            <TextField
-                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                id='operation_throttling_policy'
-                                select
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.policies',
-                                    defaultMessage: 'Rate limiting policies',
-                                })}
-                                value={apiThrottlingPolicy}
-                                onChange={({ target: { value } }) => (
-                                    onChange ? onChange(value) : setApiThrottlingPolicy(value))}
-                                helperText={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.policies.helper.text',
-                                    defaultMessage: 'Selected rate limiting policy will be applied to whole API',
-                                })}
-                                margin='dense'
-                                variant='outlined'
-                            >
-                                {operationRateLimits.map((rateLimit) => (
-                                    <MenuItem
-                                        key={rateLimit.name}
-                                        value={rateLimit.name}
-                                        id={'api-rate-limiting-api-level-' + rateLimit.name}
-                                    >
-                                        {rateLimit.displayName}
-                                    </MenuItem>
-                                ))}
-                            </TextField>
-                        )}
-                    </Box>
-                </Grid>
-                {/* If onChange handler is provided we assume that component is getting controlled by its parent
-                so that, hide the save cancel action */}
-                {!onChange && (
-                    <>
-                        <Grid item md={12}>
-                            <Divider />
-                        </Grid>
-                        <Grid item>
-                            <Box ml={1}>
-                                <Button
-                                    onClick={saveChanges}
-                                    disabled={false}
-                                    variant='outlined'
-                                    size='small'
-                                    color='primary'
+        ["apiLevelRateLimiting", "operationLevelRateLimiting"]
+            .some(type => componentValidator.includes(type)) &&
+            <StyledPaper>
+                <Grid container direction='row' justifyContent='flex-start' alignItems='flex-start'>
+                    <Grid item md={12} xs={12} sx={{ p: 1 }}>
+                        <Box>
+                            <Typography variant='subtitle1' component='h3' gutterBottom>
+                                <FormattedMessage
+                                    id='Apis.Details.Rate.Limiting.operations.configuration'
+                                    defaultMessage='Operations Configuration'
+                                />
+                                <Tooltip
+                                    fontSize='small'
+                                    title={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.operations.configuration.tooltip',
+                                        defaultMessage: 'Configurations that affects on all the resources',
+                                    })}
+                                    placement='right-end'
+                                    interactive
                                 >
-                                    <FormattedMessage
-                                        id='Apis.Details.Rate.Limiting.operations.save.btn'
-                                        defaultMessage='Save'
+                                    <IconButton aria-label='Operations Configuration help text' size='large'>
+                                        <HelpOutline />
+                                    </IconButton>
+                                </Tooltip>
+                            </Typography>
+                        </Box>
+                        <Divider variant='middle' />
+                    </Grid>
+                    <Grid item md={6} xs={12} sx={{ p: 1 }}>
+                        <FormControl component='fieldset'>
+                            <FormLabel component='legend'>
+                                <FormattedMessage
+                                    id='Apis.Details.Resources.components.APIRateLimiting.rate.limiting.level'
+                                    defaultMessage='Rate limiting level'
+                                />
+                            </FormLabel>
+                            <RadioGroup
+                                aria-label='Apply rate limiting in'
+                                value={rateLimitingLevel}
+                                onChange={updateRateLimitingPolicy}
+                                row
+                            >
+                                {componentValidator.includes('apiLevelRateLimiting') &&
+                                    <FormControlLabel
+                                        value={RateLimitingLevels.API}
+                                        control={(
+                                            <Radio
+                                                color='primary'
+                                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            />
+                                        )}
+                                        label={intl.formatMessage({
+                                            id: 'Apis.Details.Rate.Limiting.rate.limiting.level.api.level',
+                                            defaultMessage: 'API Level',
+                                        })}
+                                        labelPlacement='end'
+                                        id='api-rate-limiting-api-level'
                                     />
-                                    
-                                    {isSaving && <CircularProgress size={24} />}
-                                </Button>
-                                <Box display='inline' ml={1}>
-                                    <Button size='small' onClick={resetChanges}>
+                                }
+                                {componentValidator.includes('operationLevelRateLimiting') &&
+                                    <FormControlLabel
+                                        value={RateLimitingLevels.RESOURCE}
+                                        control={(
+                                            <Radio
+                                                color='primary'
+                                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            />
+                                        )}
+                                        className={focusOperationLevel && classes.focusLabel}
+                                        label={intl.formatMessage({
+                                            id: 'Apis.Details.Rate.Limiting.rate.limiting.level.operation.level',
+                                            defaultMessage: 'Operation Level',
+                                        })}
+                                        labelPlacement='end'
+                                        id='api-rate-limiting-operation-level'
+                                    />
+                                }
+                            </RadioGroup>
+                        </FormControl>
+                    </Grid>
+                    <Grid item md={6} xs={12} sx={{ p: 1 }}>
+                        <Box minHeight={70} pl={10} sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.2)' }}>
+                            {isResourceLevel ? (
+                                operationRateLimitMessage
+                            ) : (
+                                <TextField
+                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                    id='operation_throttling_policy'
+                                    select
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.rate.limiting.policies',
+                                        defaultMessage: 'Rate limiting policies',
+                                    })}
+                                    value={apiThrottlingPolicy}
+                                    onChange={({ target: { value } }) => (
+                                        onChange ? onChange(value) : setApiThrottlingPolicy(value))}
+                                    helperText={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.rate.limiting.policies.helper.text',
+                                        defaultMessage: 'Selected rate limiting policy will be applied to whole API',
+                                    })}
+                                    margin='dense'
+                                    variant='outlined'
+                                >
+                                    {operationRateLimits.map((rateLimit) => (
+                                        <MenuItem
+                                            key={rateLimit.name}
+                                            value={rateLimit.name}
+                                            id={'api-rate-limiting-api-level-' + rateLimit.name}
+                                        >
+                                            {rateLimit.displayName}
+                                        </MenuItem>
+                                    ))}
+                                </TextField>
+                            )}
+                        </Box>
+                    </Grid>
+                    {/* If onChange handler is provided we assume that component is getting controlled by its parent
+                    so that, hide the save cancel action */}
+                    {!onChange && (
+                        <>
+                            <Grid item md={12}>
+                                <Divider />
+                            </Grid>
+                            <Grid item>
+                                <Box ml={1}>
+                                    <Button
+                                        onClick={saveChanges}
+                                        disabled={false}
+                                        variant='outlined'
+                                        size='small'
+                                        color='primary'
+                                    >
                                         <FormattedMessage
-                                            id='Apis.Details.Rate.Limiting.operations.reset.btn'
-                                            defaultMessage='Reset'
+                                            id='Apis.Details.Rate.Limiting.operations.save.btn'
+                                            defaultMessage='Save'
                                         />
+                                        
+                                        {isSaving && <CircularProgress size={24} />}
                                     </Button>
+                                    <Box display='inline' ml={1}>
+                                        <Button size='small' onClick={resetChanges}>
+                                            <FormattedMessage
+                                                id='Apis.Details.Rate.Limiting.operations.reset.btn'
+                                                defaultMessage='Reset'
+                                            />
+                                        </Button>
+                                    </Box>
                                 </Box>
-                            </Box>
-                        </Grid>
-                    </>
-                )}
-            </Grid>
-        </StyledPaper>
+                            </Grid>
+                        </>
+                    )}
+                </Grid>
+            </StyledPaper>
     );
 }
 APIRateLimiting.defaultProps = {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
@@ -94,6 +94,7 @@ function AsyncOperation(props) {
         target,
         verb,
         sharedScopes,
+        componentValidator
     } = props;
 
     const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
@@ -253,6 +254,7 @@ function AsyncOperation(props) {
                                     target={target}
                                     verb={verb}
                                     sharedScopes={sharedScopes}
+                                    componentValidator={componentValidator}
                                 />
                                 {(api.type === 'WS' || api.type === 'WEBSUB') && (
                                     <Runtime

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
@@ -132,6 +132,7 @@ function Operation(props) {
         setFocusOperationLevel,
         expandedResource,
         setExpandedResource,
+        componentValidator,
     } = props;
     const apiOperation = api.operations[target] && api.operations[target][verb.toUpperCase()];
     const isUsedInAPIProduct = apiOperation && Array.isArray(
@@ -342,6 +343,7 @@ function Operation(props) {
                             verb={verb}
                             sharedScopes={sharedScopes}
                             setFocusOperationLevel={setFocusOperationLevel}
+                            componentValidator={componentValidator}
                         />
                         {!hideParameters && (
                             <Parameters

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
@@ -39,7 +39,7 @@ import { useIntl } from 'react-intl';
  */
 export default function OperationsSelector(props) {
     const {
-        selectedOperations, setSelectedOperation, operations, enableSecurity, disableSecurity,
+        selectedOperations, setSelectedOperation, operations, enableSecurity, disableSecurity, componentValidator,
     } = props;
     const [apiFromContext] = useAPI();
     const intl = useIntl();
@@ -92,7 +92,8 @@ export default function OperationsSelector(props) {
                             </div>
                         </Tooltip>
                     )}
-                    { (operationWithSecurityCount === operationCount)
+                    { (componentValidator.includes('operationSecurity') && 
+                    (operationWithSecurityCount === operationCount))
                     && (
                         <Tooltip
                             title={intl.formatMessage({
@@ -112,7 +113,8 @@ export default function OperationsSelector(props) {
                             </div>
                         </Tooltip>
                     )}
-                    { (operationWithSecurityCount !== 0 && operationWithSecurityCount !== operationCount)
+                    { (componentValidator.includes('operationSecurity') && 
+                    operationWithSecurityCount !== 0 && operationWithSecurityCount !== operationCount)
                     && (
                         <Tooltip
                             title={intl.formatMessage({

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/OperationGovernance.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/OperationGovernance.jsx
@@ -54,10 +54,11 @@ const checkedIcon = <CheckBoxIcon fontSize='small' />;
 export default function OperationGovernance(props) {
     const {
         operation, operationsDispatcher, operationRateLimits, api, disableUpdate, spec, target, verb, sharedScopes,
-        setFocusOperationLevel,
+        setFocusOperationLevel, componentValidator
     } = props;
     const operationScopes = getOperationScopes(operation, spec);
-    const isOperationRateLimiting = api.apiThrottlingPolicy === null;
+    const isOperationRateLimiting = api.apiThrottlingPolicy === null || 
+        !componentValidator.includes('apiLevelRateLimiting');
     const filteredApiScopes = api.scopes.filter((sharedScope) => !sharedScope.shared);
     const intl = useIntl();
     const scrollToTop = () => {
@@ -82,251 +83,262 @@ export default function OperationGovernance(props) {
                 </Typography>
             </Grid>
             <Grid item xs={1} />
-            <Grid item xs={11}>
-                <FormControl disabled={disableUpdate} component='fieldset'>
-                    <FormControlLabel
-                        control={(
-                            <Switch
-                                data-testid={'security-' + verb + target}
-                                checked={operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none'}
-                                onChange={({ target: { checked } }) => operationsDispatcher({
-                                    action: 'authType',
-                                    data: { target, verb, value: checked },
-                                })}
-                                size='small'
-                                color='primary'
-                            />
-                        )}
-                        label={intl.formatMessage({
-                            id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                + 'security.switch',
-                            defaultMessage: 'Security',
-                        })}
-                        labelPlacement='start'
-                    />
-                </FormControl>
-                <sup style={{ marginLeft: '10px' }}>
-                    <Tooltip
-                        title={(
-                            <FormattedMessage
-                                id={'Apis.Details.Resources.components.operationComponents.OperationGovernance.Security'
-                                + '.tooltip'}
-                                defaultMessage='This will enable/disable Application Level securities defined in the
-                                Runtime Configurations page.'
-                            />
-                        )}
-                        fontSize='small'
-                        placement='right-end'
-                        interactive
-                    >
-                        <HelpOutline />
-                    </Tooltip>
-                </sup>
-            </Grid>
+            {componentValidator.includes('operationSecurity') &&
+                <Grid item xs={11}>
+                    <FormControl disabled={disableUpdate} component='fieldset'>
+                        <FormControlLabel
+                            control={(
+                                <Switch
+                                    data-testid={'security-' + verb + target}
+                                    checked={operation['x-auth-type'] && 
+                                        operation['x-auth-type'].toLowerCase() !== 'none'}
+                                    onChange={({ target: { checked } }) => operationsDispatcher({
+                                        action: 'authType',
+                                        data: { target, verb, value: checked },
+                                    })}
+                                    size='small'
+                                    color='primary'
+                                />
+                            )}
+                            label={intl.formatMessage({
+                                id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
+                                    + 'security.switch',
+                                defaultMessage: 'Security',
+                            })}
+                            labelPlacement='start'
+                        />
+                    </FormControl>
+                    <sup style={{ marginLeft: '10px' }}>
+                        <Tooltip
+                            title={(
+                                <FormattedMessage
+                                    id={'Apis.Details.Resources.components'
+                                       + '.operationComponents.OperationGovernance.Security.tooltip'}
+                                    defaultMessage='This will enable/disable Application Level securities defined in the
+                                    Runtime Configurations page.'
+                                />
+                            )}
+                            fontSize='small'
+                            placement='right-end'
+                            interactive
+                        >
+                            <HelpOutline />
+                        </Tooltip>
+                    </sup>
+                </Grid>
+            }
             <Grid item md={1} />
             <Grid item md={5}>
-                <Box display='flex' flexDirection='row' alignItems='flex-start'>
-                    <TextField
-                        select
-                        fullWidth={!isOperationRateLimiting}
-                        SelectProps={{
-                            autoWidth: true,
-                            IconComponent: isOperationRateLimiting ? ArrowDropDownIcon : 'span',
-                        }}
-                        disabled={disableUpdate || !isOperationRateLimiting}
-                        label={
-                            isOperationRateLimiting
-                                ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.rate.limiting.policy',
-                                    defaultMessage: 'Rate limiting policy',
-                                })
-                                : (
-                                    <div>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.governed.by'}
-                                            defaultMessage='Rate limiting is governed by '
-                                        />
-                                        <Box
-                                            fontWeight='fontWeightBold'
-                                            display='inline'
-                                            color='primary.main'
-                                            cursor='pointer'
-                                        >
+                {componentValidator.includes('operationLevelRateLimiting') &&
+                    <Box display='flex' flexDirection='row' alignItems='flex-start'>
+                        <TextField
+                            select
+                            fullWidth={!isOperationRateLimiting}
+                            SelectProps={{
+                                autoWidth: true,
+                                IconComponent: isOperationRateLimiting ? ArrowDropDownIcon : 'span',
+                            }}
+                            disabled={disableUpdate || !isOperationRateLimiting}
+                            label={
+                                isOperationRateLimiting
+                                    ? intl.formatMessage({
+                                        id: 'Apis.Details.Resources.components.operationComponents.'
+                                    + 'OperationGovernance.rate.limiting.policy',
+                                        defaultMessage: 'Rate limiting policy',
+                                    })
+                                    : (
+                                        <div>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.API.level'}
-                                                defaultMessage='API Level'
+                                + 'OperationGovernance.rate.limiting.governed.by'}
+                                                defaultMessage='Rate limiting is governed by '
                                             />
-                                        </Box>
-                                    </div>
-                                )
-                        }
-                        value={
-                            isOperationRateLimiting
-                            && operation['x-throttling-tier']
-                                ? operation['x-throttling-tier']
-                                : ''
-                        }
-                        onChange={({ target: { value } }) => operationsDispatcher({
-                            action: 'throttlingPolicy',
-                            data: { target, verb, value },
-                        })}
-                        helperText={
-                            isOperationRateLimiting
-                                ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.rate.limiting.policy.select',
-                                    defaultMessage: 'Select a rate limit policy for this operation',
-                                })
-                                : (
-                                    <span>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section1'}
-                                            defaultMessage='Use '
-                                        />
-                                        <Box fontWeight='fontWeightBold' display='inline' color='primary.main'>
+                                            <Box
+                                                fontWeight='fontWeightBold'
+                                                display='inline'
+                                                color='primary.main'
+                                                cursor='pointer'
+                                            >
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.API.level'}
+                                                    defaultMessage='API Level'
+                                                />
+                                            </Box>
+                                        </div>
+                                    )
+                            }
+                            value={
+                                isOperationRateLimiting
+                                && operation['x-throttling-tier']
+                                    ? operation['x-throttling-tier']
+                                    : ''
+                            }
+                            onChange={({ target: { value } }) => operationsDispatcher({
+                                action: 'throttlingPolicy',
+                                data: { target, verb, value },
+                            })}
+                            helperText={
+                                isOperationRateLimiting
+                                    ? intl.formatMessage({
+                                        id: 'Apis.Details.Resources.components.operationComponents.'
+                                    + 'OperationGovernance.rate.limiting.policy.select',
+                                        defaultMessage: 'Select a rate limit policy for this operation',
+                                    })
+                                    : (
+                                        <span>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section2'}
-                                                defaultMessage='Operation Level'
+                                + 'OperationGovernance.rate.limiting.helperText.section1'}
+                                                defaultMessage='Use '
                                             />
-                                        </Box>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section3'}
-                                            defaultMessage=' rate limiting to '
-                                        />
-                                        <b>
+                                            <Box fontWeight='fontWeightBold' display='inline' color='primary.main'>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section2'}
+                                                    defaultMessage='Operation Level'
+                                                />
+                                            </Box>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section4'}
-                                                defaultMessage='enable'
+                                + 'OperationGovernance.rate.limiting.helperText.section3'}
+                                                defaultMessage=' rate limiting to '
                                             />
-                                        </b>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section5'}
-                                            defaultMessage=' rate limiting per operation'
-                                        />
-                                    </span>
-                                )
-                        }
-                        margin='dense'
-                        variant='outlined'
-                        id={verb + target + '-operation_throttling_policy'}
-                    >
-                        {operationRateLimits.map((rateLimit) => (
-                            <MenuItem
-                                key={rateLimit.name}
-                                value={rateLimit.name}
-                                id={verb + target + '-operation_throttling_policy-' + rateLimit.name}
-                            >
-                                {rateLimit.displayName}
-                            </MenuItem>
-                        ))}
-                    </TextField>
-                    {!isOperationRateLimiting && (
-                        <Button onClick={scrollToTop}>
-                            <FormattedMessage
-                                id={
-                                    'Apis.Details.Resources.components.operationComponents.'
-                                    + 'OperationGovernance.rate.limiting.button.text'
-                                }
-                                defaultMessage='Change rate limiting level'
-                            />
-                            <ExpandLessIcon />
-                        </Button>
-                    )}
-                </Box>
+                                            <b>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section4'}
+                                                    defaultMessage='enable'
+                                                />
+                                            </b>
+                                            <FormattedMessage
+                                                id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section5'}
+                                                defaultMessage=' rate limiting per operation'
+                                            />
+                                        </span>
+                                    )
+                            }
+                            margin='dense'
+                            variant='outlined'
+                            id={verb + target + '-operation_throttling_policy'}
+                        >
+                            {operationRateLimits.map((rateLimit) => (
+                                <MenuItem
+                                    key={rateLimit.name}
+                                    value={rateLimit.name}
+                                    id={verb + target + '-operation_throttling_policy-' + rateLimit.name}
+                                >
+                                    {rateLimit.displayName}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                        {!isOperationRateLimiting && (
+                            <Button onClick={scrollToTop}>
+                                <FormattedMessage
+                                    id={
+                                        'Apis.Details.Resources.components.operationComponents.'
+                                        + 'OperationGovernance.rate.limiting.button.text'
+                                    }
+                                    defaultMessage='Change rate limiting level'
+                                />
+                                <ExpandLessIcon />
+                            </Button>
+                        )}
+                    </Box>
+                }
             </Grid>
             <Grid item md={6} />
             <Grid item md={1} />
-            <Grid item md={7}>
-                {operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? (
-                    <Autocomplete
-                        multiple
-                        limitTags={5}
-                        id={verb + target + '-operation-scope-autocomplete'}
-                        options={[...filteredApiScopes, ...sharedScopes]}
-                        groupBy={(option) => option.shared ? 'Shared Scopes' : 'API Scopes'}
-                        noOptionsText={intl.formatMessage({
-                            id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                + 'no.scopes.available',
-                            defaultMessage: 'No scopes available',
-                        })}
-                        disableCloseOnSelect
-                        value={operationScopes.map((scope) => ({ scope: { name: scope } }))}
-                        getOptionLabel={(option) => option.scope.name}
-                        isOptionEqualToValue={(option, value) => option.scope.name === value.scope.name}
-                        onChange={(event, newValue) => {
-                            const selectedScopes = newValue.map((val) => val.scope.name);
-                            operationsDispatcher({
-                                action: 'scopes',
-                                data: { target, verb, value: selectedScopes ? [selectedScopes] : [] },
-                            });
-                        }}
-                        renderOption={(listOfOptions, option, { selected }) => (
-                            <li {...listOfOptions}>
-                                <Checkbox
-                                    id={verb + target + '-operation-scope-' + option.scope.name}
-                                    icon={icon}
-                                    checkedIcon={checkedIcon}
-                                    style={{ marginRight: 8 }}
-                                    checked={selected}
-                                />
-                                {option.scope.name}
-                            </li>
-                        )}
-                        style={{ width: 500 }}
-                        renderInput={(params) => (
-                            <TextField {...params}
-                                disabled={disableUpdate}
-                                fullWidth
-                                label={api.scopes.length !== 0 || sharedScopes ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                        + 'OperationGovernance.operation.scope.label.default',
-                                    defaultMessage: 'Operation scope',
-                                }) : intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                        + 'OperationGovernance.operation.scope.label.notAvailable',
-                                    defaultMessage: 'No scope available',
-                                })}
-                                placeholder={intl.formatMessage({
+            {componentValidator.includes('operationSecurity') &&
+                <>
+                    <Grid item md={7}>
+                        {operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? (
+                            <Autocomplete
+                                multiple
+                                limitTags={5}
+                                id={verb + target + '-operation-scope-autocomplete'}
+                                options={[...filteredApiScopes, ...sharedScopes]}
+                                groupBy={(option) => option.shared ? 'Shared Scopes' : 'API Scopes'}
+                                noOptionsText={intl.formatMessage({
                                     id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                        + 'search.scopes.placeholder',
-                                    defaultMessage: 'Search scopes',
+                                        + 'no.scopes.available',
+                                    defaultMessage: 'No scopes available',
                                 })}
-                                helperText={(
-                                    <FormattedMessage
-                                        id={'Apis.Details.Resources.components.operationComponents.'
-                                            + 'OperationGovernance.operation.scope.helperText'}
-                                        defaultMessage='Select a scope to control permissions to this operation'
-                                    />
+                                disableCloseOnSelect
+                                value={operationScopes.map((scope) => ({ scope: { name: scope } }))}
+                                getOptionLabel={(option) => option.scope.name}
+                                isOptionEqualToValue={(option, value) => option.scope.name === value.scope.name}
+                                onChange={(event, newValue) => {
+                                    const selectedScopes = newValue.map((val) => val.scope.name);
+                                    operationsDispatcher({
+                                        action: 'scopes',
+                                        data: { target, verb, value: selectedScopes ? [selectedScopes] : [] },
+                                    });
+                                }}
+                                renderOption={(listOfOptions, option, { selected }) => (
+                                    <li {...listOfOptions}>
+                                        <Checkbox
+                                            id={verb + target + '-operation-scope-' + option.scope.name}
+                                            icon={icon}
+                                            checkedIcon={checkedIcon}
+                                            style={{ marginRight: 8 }}
+                                            checked={selected}
+                                        />
+                                        {option.scope.name}
+                                    </li>
                                 )}
-                                margin='dense'
-                                variant='outlined'
-                                id={verb + target + '-operation-scope-select'} />
-                        )}
-                    />
-                ) : null}
-            </Grid>
-            <Grid item md={3} style={{ marginTop: '14px' }}>
-                { operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? !disableUpdate && (
-                    <Link to={`/apis/${api.id}/scopes/create`} target='_blank'>
-                        <Typography style={{ marginLeft: '10px' }} color='primary' display='inline' variant='caption'>
-                            <FormattedMessage
-                                id={'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.operation.scope.create.new.scope'}
-                                defaultMessage='Create New Scope'
+                                style={{ width: 500 }}
+                                renderInput={(params) => (
+                                    <TextField {...params}
+                                        disabled={disableUpdate}
+                                        fullWidth
+                                        label={api.scopes.length !== 0 || sharedScopes ? intl.formatMessage({
+                                            id: 'Apis.Details.Resources.components.operationComponents.'
+                                                + 'OperationGovernance.operation.scope.label.default',
+                                            defaultMessage: 'Operation scope',
+                                        }) : intl.formatMessage({
+                                            id: 'Apis.Details.Resources.components.operationComponents.'
+                                                + 'OperationGovernance.operation.scope.label.notAvailable',
+                                            defaultMessage: 'No scope available',
+                                        })}
+                                        placeholder={intl.formatMessage({
+                                            id: 'Apis.Details.Topics.components.operationComponents'
+                                                + '.OperationGovernance.search.scopes.placeholder',
+                                            defaultMessage: 'Search scopes',
+                                        })}
+                                        helperText={(
+                                            <FormattedMessage
+                                                id={'Apis.Details.Resources.components.operationComponents.'
+                                                    + 'OperationGovernance.operation.scope.helperText'}
+                                                defaultMessage='Select a scope to control permissions to this operation'
+                                            />
+                                        )}
+                                        margin='dense'
+                                        variant='outlined'
+                                        id={verb + target + '-operation-scope-select'} />
+                                )}
                             />
-                            <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
-                        </Typography>
-                    </Link>
-                ) : null}
-            </Grid>
+                        ) : null}
+                    </Grid>
+                    <Grid item md={3} style={{ marginTop: '14px' }}>
+                        { operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' 
+                            ? !disableUpdate && (
+                                <Link to={`/apis/${api.id}/scopes/create`} target='_blank'>
+                                    <Typography style={{ marginLeft: '10px' }} color='primary' 
+                                        display='inline' variant='caption'>
+                                        <FormattedMessage
+                                            id={'Apis.Details.Resources.components.operationComponents.'
+                                            + 'OperationGovernance.operation.scope.create.new.scope'}
+                                            defaultMessage='Create New Scope'
+                                        />
+                                        <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
+                                    </Typography>
+                                </Link>
+                            ) : null}
+                    </Grid>
+                </>
+            }
             <Grid item md={1} />
         </>
     );

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
@@ -114,7 +114,8 @@ const AccordionDetails = MuiAccordionDetails;
  */
 export default function DevelopSectionMenu(props) {
     const {
-        pathPrefix, isAPIProduct, api, getLeftMenuItemForResourcesByType, getLeftMenuItemForDefinitionByType,
+        pathPrefix, isAPIProduct, api, getLeftMenuItemForResourcesByType, getLeftMenuItemForDefinitionByType, 
+        componentValidator,
     } = props;
     const user = useUser();
     const [portalConfigsExpanded, setPortalConfigsExpanded] = useState(user
@@ -175,7 +176,7 @@ export default function DevelopSectionMenu(props) {
                             id='left-menu-itembusinessinfo'
                             route='business-info'
                         />
-                        {!isAPIProduct && (
+                        {(componentValidator.subscriptions.includes("subscriptions") && !isAPIProduct) && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.subscriptions',
@@ -258,7 +259,7 @@ export default function DevelopSectionMenu(props) {
                         root: classes.root2
                     }}>
                     <div>
-                        {!isAPIProduct && !api.isWebSocket() && (api.gatewayVendor === 'wso2') && (
+                        {!isAPIProduct && !api.isWebSocket() && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.runtime.configs',
@@ -308,7 +309,8 @@ export default function DevelopSectionMenu(props) {
                                 id='left-menu-itemendpoints'
                             />
                         )}
-                        {!isAPIProduct && (api.gatewayVendor === 'wso2') && (
+                        {(componentValidator.localScopes.includes("localScopes") 
+                            && (!isAPIProduct)) && 
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.left.menu.scope',
@@ -319,7 +321,7 @@ export default function DevelopSectionMenu(props) {
                                 Icon={<ScopesIcon />}
                                 id='left-menu-itemLocalScopes'
                             />
-                        )}
+                        }
                         {api.advertiseInfo && !api.advertiseInfo.advertised && !isAPIProduct
                             && (api.type === 'HTTP' || api.type === 'SOAP' || api.type === 'SOAPTOREST') && (
                             <LeftMenuItem
@@ -345,9 +347,10 @@ export default function DevelopSectionMenu(props) {
                             id='left-menu-itemproperties'
                         />
 
-                        {!api.isWebSocket() && !isRestricted(['apim:api_publish'], api) && (
+                        {(componentValidator.monetization.includes("monetization") && 
+                            (!api.isWebSocket() && !isRestricted(['apim:api_publish'], api))) && (
                             <>
-                                {!isAPIProduct && (api.gatewayVendor === 'wso2') && (
+                                {!isAPIProduct && (
                                     <LeftMenuItem
                                         text={intl.formatMessage({
                                             id: 'Apis.Details.index.monetization',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -764,7 +764,8 @@ class Details extends Component {
                 >
                     <Box className={classes.LeftMenu}>
                         <nav name='secondaryNavigation' aria-label='secondary navigation'>
-                            <Link to={'/' + (isAPIProduct ? 'api-products' : 'apis') + '/'} aria-label='ALL APIs'>
+                            <Link to={'/' + (isAPIProduct ? 'api-products' : 'apis') + '/'} 
+                                aria-label='ALL APIs'>
                                 <div className={classes.leftLInkMain}>
                                     <CustomIcon
                                         className={classes.customIcon}
@@ -785,7 +786,8 @@ class Details extends Component {
                                 id='left-menu-overview'
                             />
                             <Typography className={classes.headingText}>
-                                <FormattedMessage id='Apis.Details.index.develop.title' defaultMessage='Develop' />
+                                <FormattedMessage id='Apis.Details.index.develop.title' 
+                                    defaultMessage='Develop' />
                             </Typography>
                             <DevelopSectionMenu
                                 pathPrefix={pathPrefix}
@@ -793,6 +795,9 @@ class Details extends Component {
                                 api={api}
                                 getLeftMenuItemForResourcesByType={this.getLeftMenuItemForResourcesByType}
                                 getLeftMenuItemForDefinitionByType={this.getLeftMenuItemForDefinitionByType}
+                                componentValidator=
+                                    {settings && JSON.parse(settings.gatewayFeatureCatalog)
+                                        .gatewayFeatures[api.gatewayType]}  
                             />
                             <Divider />
                             {!isAPIProduct && (
@@ -835,8 +840,8 @@ class Details extends Component {
                                     />
                                 </>
                             )}
-                            {!readOnlyUser && (isAPIProduct || (!isAPIProduct && !api.isWebSocket() && !api.isGraphql()
-                                && !isAsyncAPI)) && (
+                            {!readOnlyUser && (isAPIProduct || (!isAPIProduct && !api.isWebSocket() 
+                                && !api.isGraphql() && !isAsyncAPI)) && (
                                 <div>
                                     <Divider />
                                     <Typography className={classes.headingText}>
@@ -936,7 +941,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.API_DEFINITION}
-                                        component={() => <APIDefinition api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <APIDefinition api={api} 
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.WSDL}
@@ -952,7 +958,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.ASYNCAPI_DEFINITION}
-                                        component={() => <APIDefinition api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <APIDefinition api={api} 
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.LIFE_CYCLE}
@@ -964,7 +971,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.CONFIGURATION}
-                                        component={() => <DesignConfigurations api={api} updateAPI={this.updateAPI}/>}
+                                        component={() => <DesignConfigurations api={api} 
+                                            updateAPI={this.updateAPI}/>}
                                     />
                                     <Route
                                         path={Details.subPaths.RUNTIME_CONFIGURATION}
@@ -976,11 +984,13 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.TOPICS}
-                                        component={() => <Topics api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Topics api={api} 
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.CONFIGURATION_PRODUCT}
-                                        component={() => <DesignConfigurations api={api} updateAPI={this.updateAPI}/>}
+                                        component={() => <DesignConfigurations api={api} 
+                                            updateAPI={this.updateAPI}/>}
                                     />
                                     <Route
                                         path={Details.subPaths.RUNTIME_CONFIGURATION_PRODUCT}
@@ -1000,7 +1010,11 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.OPERATIONS}
-                                        component={() => <Operations api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Operations api={api} 
+                                            componentValidator={settings && 
+                                                JSON.parse(settings.gatewayFeatureCatalog)
+                                                    .gatewayFeatures[api.gatewayType].resources}
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         exact
@@ -1017,8 +1031,12 @@ class Details extends Component {
                                         key={Details.subPaths.RESOURCES}
                                         component={APIOperations}
                                     />
-
-                                    <Route path={Details.subPaths.SCOPES} component={() => <Scope api={api} />} />
+                                    {settings && JSON.parse(settings.gatewayFeatureCatalog)
+                                        .gatewayFeatures[api.gatewayType]
+                                        .localScopes.includes("operationScopes") &&
+                                        <Route path={Details.subPaths.SCOPES} component={() => 
+                                            <Scope api={api} />} />
+                                    }
                                     <Route
                                         path={Details.subPaths.DOCUMENTS}
                                         component={() => <Documents api={api} />}
@@ -1027,16 +1045,24 @@ class Details extends Component {
                                         path={Details.subPaths.DOCUMENTS_PRODUCT}
                                         component={() => <Documents api={api} />}
                                     />
-                                    <Route
-                                        path={Details.subPaths.SUBSCRIPTIONS}
-                                        component={() => <Subscriptions api={api} updateAPI={this.updateAPI} />}
-                                    />
+                                    {settings && JSON.parse(settings.gatewayFeatureCatalog)
+                                        .gatewayFeatures[api.gatewayType]
+                                        .subscriptions.includes("subscriptions") &&
+                                        <Route
+                                            path={Details.subPaths.SUBSCRIPTIONS}
+                                            component={() => <Subscriptions api={api} 
+                                                updateAPI={this.updateAPI} />}
+                                        />
+                                    }
                                     <Route
                                         path={Details.subPaths.SUBSCRIPTIONS_PRODUCT}
-                                        component={() => <Subscriptions api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Subscriptions api={api} 
+                                            updateAPI={this.updateAPI} />}
                                     />
-                                    <Route path={Details.subPaths.SECURITY} component={() => <Security api={api} />} />
-                                    <Route path={Details.subPaths.COMMENTS} component={() => <Comments api={api} />} />
+                                    <Route path={Details.subPaths.SECURITY} component={() => 
+                                        <Security api={api} />} />
+                                    <Route path={Details.subPaths.COMMENTS} component={() => 
+                                        <Comments api={api} />} />
                                     <Route
                                         path={Details.subPaths.BUSINESS_INFO}
                                         component={() => <BusinessInformation api={api} />}
@@ -1053,16 +1079,22 @@ class Details extends Component {
                                         path={Details.subPaths.PROPERTIES_PRODUCT}
                                         component={() => <Properties api={api} />}
                                     />
-                                    <Route path={Details.subPaths.NEW_VERSION} component={() => <CreateNewVersion />} />
+                                    <Route path={Details.subPaths.NEW_VERSION} component={() => 
+                                        <CreateNewVersion />} />
                                     <Route
                                         path={Details.subPaths.NEW_VERSION_PRODUCT}
                                         component={() => <CreateNewVersion />} />
 
-                                    <Route path={Details.subPaths.SUBSCRIPTIONS} component={() => <Subscriptions />} />
-                                    <Route
-                                        path={Details.subPaths.MONETIZATION}
-                                        component={() => <Monetization api={api} />}
-                                    />
+                                    <Route path={Details.subPaths.SUBSCRIPTIONS} component={() => 
+                                        <Subscriptions />} />
+                                    {settings && JSON.parse(settings.gatewayFeatureCatalog)
+                                        .gatewayFeatures[api.gatewayType]
+                                        .monetization.includes("monetization") &&
+                                        <Route
+                                            path={Details.subPaths.MONETIZATION}
+                                            component={() => <Monetization api={api} />}
+                                        />
+                                    }
                                     <Route
                                         path={Details.subPaths.MONETIZATION_PRODUCT}
                                         component={() => <Monetization api={api} />}
@@ -1075,7 +1107,8 @@ class Details extends Component {
                                         path={Details.subPaths.TRYOUT_PRODUCT}
                                         component={() => <TryOutConsole apiObj={api} />}
                                     />
-                                    <Route path={Details.subPaths.EXTERNAL_STORES} component={ExternalStores} />
+                                    <Route path={Details.subPaths.EXTERNAL_STORES} 
+                                        component={ExternalStores} />
                                     <Route
                                         path={Details.subPaths.COMMENTS}
                                         component={() => <Comments apiObj={api} />}

--- a/tests/cypress/fixtures/api_artifacts/advanceConfigFalse.json
+++ b/tests/cypress/fixtures/api_artifacts/advanceConfigFalse.json
@@ -388,5 +388,6 @@
 	  "SignUpRoles": [
 		"Internal/subscriber"
 	  ]
-	}
+	},
+	"AllowSubscriptionValidationDisabling": false
 }

--- a/tests/cypress/fixtures/api_artifacts/advanceConfigTrue.json
+++ b/tests/cypress/fixtures/api_artifacts/advanceConfigTrue.json
@@ -388,5 +388,6 @@
 	  "SignUpRoles": [
 		"Internal/subscriber"
 	  ]
-	}
+	},
+	"AllowSubscriptionValidationDisabling": false
 }

--- a/tests/cypress/fixtures/api_artifacts/tenant-conf.json
+++ b/tests/cypress/fixtures/api_artifacts/tenant-conf.json
@@ -1,7 +1,7 @@
 {
-  "EnableMonetization": false,
-  "EnableRecommendation": false,
-  "IsUnlimitedTierPaid": false,
+  "EnableMonetization" : false,
+  "EnableRecommendation" : false,
+  "IsUnlimitedTierPaid" : false,
   "ExtensionHandlerPosition": "bottom",
   "RESTAPIScopes": {
     "Scope": [
@@ -122,7 +122,7 @@
         "Roles": "admin,Internal/subscriber,Internal/devops"
       },
       {
-        "Name": "apim:monetization_usage_publish",
+        "Name" : "apim:monetization_usage_publish",
         "Roles": "admin, Internal/publisher"
       },
       {
@@ -266,6 +266,14 @@
         "Roles": "admin"
       },
       {
+        "Name": "apim:keymanagers_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:api_category",
+        "Roles": "admin"
+      },
+      {
         "Name": "apim:shared_scope_manage",
         "Roles": "admin"
       },
@@ -302,38 +310,6 @@
         "Roles": "admin,Internal/creator"
       },
       {
-        "Name": "apim:keymanagers_manage",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:api_category",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:policies_import_export",
-        "Roles": "admin,Internal/devops"
-      },
-      {
-        "Name": "apim:admin_tier_manage",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:admin_tier_view",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:api_provider_change",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:gateway_policy_manage",
-        "Roles": "admin"
-      },
-      {
-        "Name": "apim:gateway_policy_view",
-        "Roles": "admin,Internal/creator,Internal/publisher,Internal/observer"
-      },
-      {
         "Name": "apim:comment_view",
         "Roles": "admin,Internal/creator,Internal/publisher"
       },
@@ -368,56 +344,86 @@
       {
         "Name": "apim:common_operation_policy_manage",
         "Roles": "admin,Internal/creator"
+      },
+      {
+        "Name": "apim:policies_import_export",
+        "Roles": "admin,Internal/devops"
+      },
+      {
+        "Name": "apim:admin_tier_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:admin_tier_view",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:api_provider_change",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:gateway_policy_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:gateway_policy_view",
+        "Roles": "admin,Internal/creator,Internal/publisher,Internal/observer"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },
-  "Meta": {
+  "Meta" : {
     "Migration": {
       "3.0.0": true
     }
   },
-  "NotificationsEnabled": "false",
-  "Notifications": [
-    {
-      "Type": "new_api_version",
-      "Notifiers": [
-        {
-          "Class": "org.wso2.carbon.apimgt.impl.notification.NewAPIVersionEmailNotifier",
-          "ClaimsRetrieverImplClass": "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever",
-          "Title": "Version $2 of $1 Released",
-          "Template": " <html> <body> <h3 style=\"color:Black;\">We’re happy to announce the arrival of the next major version $2 of $1 API which is now available in Our API Store.</h3><a href=\"https://localhost:9443/store\">Click here to Visit WSO2 API Store</a></body></html>"
-        }
-      ]
-    }
+  "NotificationsEnabled":"false",
+  "Notifications":[{
+    "Type":"new_api_version",
+    "Notifiers" :[{
+      "Class":"org.wso2.carbon.apimgt.impl.notification.NewAPIVersionEmailNotifier",
+      "ClaimsRetrieverImplClass":"org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever",
+      "Title": "Version $2 of $1 Released",
+      "Template": " <html> <body> <h3 style=\"color:Black;\">We’re happy to announce the arrival of the next major version $2 of $1 API which is now available in Our API Store.</h3><a href=\"https://localhost:9443/devportal\">Click here to Visit WSO2 API Store</a></body></html>"
+    }]
+  }
   ],
-  "DefaultRoles": {
-    "PublisherRole": {
-      "CreateOnTenantLoad": true,
-      "RoleName": "Internal/publisher"
+  "DefaultRoles" : {
+    "PublisherRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/publisher"
     },
-    "CreatorRole": {
-      "CreateOnTenantLoad": true,
-      "RoleName": "Internal/creator"
+    "CreatorRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/creator"
     },
-    "SubscriberRole": {
-      "CreateOnTenantLoad": true
+    "SubscriberRole" : {
+      "CreateOnTenantLoad" : true
     },
-    "DevOpsRole": {
-      "CreateOnTenantLoad": true,
-      "RoleName": "Internal/devops"
+    "DevOpsRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/devops"
     },
-    "ObserverRole": {
-      "CreateOnTenantLoad": true,
-      "RoleName": "Internal/observer"
+    "ObserverRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/observer"
     },
-    "IntegrationDeveloperRole": {
-      "CreateOnTenantLoad": true,
-      "RoleName": "Internal/integration_dev"
+    "IntegrationDeveloperRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/integration_dev"
     }
   },
   "SelfSignUp": {
     "SignUpRoles": [
       "Internal/subscriber"
     ]
-  }
+  },
+  "AllowSubscriptionValidationDisabling": false
 }

--- a/tests/cypress/integration/admin/03-add-edit-delete-subscription-throttle-policies.spec.js
+++ b/tests/cypress/integration/admin/03-add-edit-delete-subscription-throttle-policies.spec.js
@@ -27,6 +27,7 @@ describe("Add Edit Delete subscription throttle policies", () => {
         const policyName = 'Platinum';
         cy.get('[data-testid="Subscription Policies-child-link"]').click();
         cy.get('[data-testid="throttling-subscription-add-button"]').contains('Add Policy').click();
+        cy.get('[data-testid="throttling-subscription-add-policy-menu-item"]').click();
         cy.get('input[name="policyName"]').type(policyName);
         cy.get('textarea[name="description"]').type('Allows 10k requests per minute');
         cy.get('input[name="requestCount"]').type('10000');

--- a/tests/cypress/integration/publisher/011-lifecycle/01-block-demote-to-created-depricate-api.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/01-block-demote-to-created-depricate-api.spec.js
@@ -104,10 +104,12 @@ describe("Lifecycle changes", () => {
             // Deprecate
 
             cy.get('button[data-testid="Deprecate-btn"]', {timeout: Cypress.config().largeTimeout}).click();
+            cy.get('#itest-id-conf', {timeout: Cypress.config().largeTimeout}).contains('DEPRECATE').click();
+
             cy.get('button[data-testid="Retire-btn"]').should('exist');
             cy.wait(2000);
-
-            cy.get('button[data-testid="Retire-btn"]', {timeout: Cypress.config().largeTimeout}).click();   
+            cy.get('button[data-testid="Retire-btn"]', {timeout: Cypress.config().largeTimeout}).click(); 
+            cy.get('#itest-id-conf', {timeout: Cypress.config().largeTimeout}).contains('RETIRE').click();
         });
     });
     afterEach(() => {

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -104,7 +104,7 @@ describe("Depricate old versions of api before publishing", () => {
             timeout: Cypress.config().largeTimeout,
           }).click();
           cy.wait(3000);
-          cy.get(`div[data-testid="card-action-${apiName}1.0.0"]>div>span`, {
+          cy.get(`div[data-testid="card-action-${apiName}1.0.0"]>div>div>span`, {
             timeout: Cypress.config().largeTimeout,
           })
             .contains("DEPRECATED")

--- a/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
+++ b/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
@@ -97,6 +97,7 @@ describe("Publish thirdparty api", () => {
                 cy.get('#left-menu-itemsubscriptions').click();
                 cy.get('[name="Unlimited"]').click();
                 cy.get('#subscriptions-save-btn').click();
+                cy.get('#disable-sub-validation-yes-btn').click();
                 cy.get('#itest-api-details-portal-config-acc').click();
                 cy.get('#itest-api-details-api-config-acc').click();
                 cy.get('#left-menu-itemRuntimeConfigurations').should('exist');
@@ -129,7 +130,7 @@ describe("Publish thirdparty api", () => {
                 cy.get(`div[data-testid="card-action-${apiName}1.0.0"]`, {timeout: Cypress.config().largeTimeout})
                     .click();
                 cy.wait(3000)
-                cy.get(`div[data-testid="card-action-${apiName}1.0.0"]>div>span`,
+                cy.get(`div[data-testid="card-action-${apiName}1.0.0"]>div>div>span`,
                     {timeout: Cypress.config().largeTimeout})
                     .contains('PUBLISHED').should('exist');
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -466,7 +466,7 @@ Cypress.Commands.add('modifyGraphqlSchemaDefinition', (filepath) => {
     cy.get('#import-open-api-btn').click();
     cy.get('#import-open-api-btn').should('not.exist')
     const searchCmd = Cypress.platform === 'darwin' ? '{cmd}f' : '{ctrl}f'
-    cy.get('.react-monaco-editor-container', { timeout: 30000 }).get('.monaco-editor textarea:first')
+    cy.get('.monaco-scrollable-element', { timeout: 30000 }).get('.monaco-editor textarea:first')
         .type(searchCmd, { force: true });
     cy.get('.find-part .input').type('modified schema file');
     cy.contains('.find-actions', '1 of').should('be.visible');


### PR DESCRIPTION
### Description
This PR introduced a filtering mechanism to render publisher features in a controlled manner for federated gateways. Also the deployment flow is optimised for the federated gateways.

### Fixes
- [x] Added a new context called GatewayFeatureCatalogContextProvider to memorise the supported gateway features of each type of gateway.
- [x]  use the gateway feature catalog to filter out componnets