### PR TITLE
Add Publisher Portal Changes for Organization Feature

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -51,6 +51,7 @@ import StoreVisibility from './components/StoreVisibility';
 import Tags from './components/Tags';
 import Social from './components/Social';
 import APICategories from './components/APICategories';
+import SharedOrganizations from './components/SharedOrganizations';
 
 const PREFIX = 'DesignConfigurations';
 
@@ -249,6 +250,7 @@ function configReducer(state, configAction) {
         case 'enableSchemaValidation':
         case 'maxTps':
         case 'categories':
+        case 'visibleOrganizations':
         case 'tags':
             nextState[action] = value;
             return nextState;
@@ -261,8 +263,6 @@ function configReducer(state, configAction) {
         case 'accessControlRoles':
             return { ...copyAPIConfig(state), [action]: value };
         case 'visibleRoles':
-            return { ...copyAPIConfig(state), [action]: value };
-        case 'visibleOrganizations':
             return { ...copyAPIConfig(state), [action]: value };
         case 'github_repo':
         case 'slack_url': {
@@ -295,7 +295,6 @@ function configReducer(state, configAction) {
         case 'visibility':
             if (nextState[action] !== value && value !== 'RESTRICTED') {
                 nextState.visibleRoles = [];
-                nextState.visibleOrganizations = [];
             }
             nextState[action] = value;
             return nextState;
@@ -602,6 +601,13 @@ export default function DesignConfigurations() {
                                             api={apiConfig}
                                             configDispatcher={configDispatcher}
                                             categories={api.categories}
+                                        />
+                                    </Box>
+                                    <Box py={1}>
+                                        <SharedOrganizations
+                                            api={apiConfig}
+                                            configDispatcher={configDispatcher}
+                                            organizations={api.visibleOrganizations}
                                         />
                                     </Box>
                                     <Box py={1}>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
@@ -1,0 +1,194 @@
+/*eslint-disable*/
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { styled } from '@mui/material/styles';
+import PropTypes from 'prop-types';
+import TextField from '@mui/material/TextField';
+import { FormattedMessage, useIntl } from 'react-intl';
+import Autocomplete from '@mui/material/Autocomplete';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import Checkbox from '@mui/material/Checkbox';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import HelpOutline from '@mui/icons-material/HelpOutline';
+import API from 'AppData/api';
+import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
+import { isRestricted } from 'AppData/AuthManager';
+
+const PREFIX = 'SharedOrganizations';
+
+const classes = {
+    tooltip: `${PREFIX}-tooltip`,
+    listItemText: `${PREFIX}-listItemText`
+};
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    [`& .${classes.tooltip}`]: {
+        position: 'absolute',
+        right: theme.spacing(-4),
+        top: theme.spacing(1),
+    },
+
+    [`& .${classes.listItemText}`]: {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    }
+}));
+
+const icon = <CheckBoxOutlineBlankIcon fontSize='small' />;
+const checkedIcon = <CheckBoxIcon fontSize='small' />;
+
+/**
+ * Render the organizations drop down.
+ * @param {JSON} props props passed from it's parents.
+ * @returns {JSX} Render the organizations drop down.
+ */
+function SharedOrganizations(props) {
+    const [organizations, setOrganizations] = useState({
+        count: 2,
+        list: [
+            {
+                organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
+                externalOrganizationId: "external-org-1",
+                parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+                displayName: "Mock Organization 1",
+                description: "This is a mock organization 1",
+            },
+            {
+                organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
+                externalOrganizationId: "external-org-2",
+                parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+                displayName: "Mock Organization 2",
+                description: "This is a mock organization 2",
+            },
+        ],
+    });
+    const { api, configDispatcher } = props;
+
+    const [apiFromContext] = useAPI();
+    const intl = useIntl();
+
+    useEffect(() => {
+        // currently using mock data for organizations
+        // API.sharedOrganizations().then((response) => setOrganizations(response.body));
+    }, []);
+
+    if (organizations && !organizations.list) {
+        return null;
+    } else if (organizations && organizations.list) {
+        return (
+            <StyledBox style={{ position: 'relative', marginTop: 10 }}>
+                <Autocomplete
+                    disabled={isRestricted(['apim:api_create', 'apim:api_publish'], apiFromContext)
+                        || organizations.list.length === 0
+                    }
+                    multiple
+                    fullWidth
+                    limitTags={5}
+                    id='SharedOrganizations-autocomplete'
+                    options={organizations.list} // Pass the full organization object
+                    getOptionLabel={(option) => option.displayName} // Show displayName in dropdown
+                    noOptionsText='No Organizations selected'
+                    disableCloseOnSelect
+                    value={organizations.list.filter(org => api.visibleOrganizations.includes(org.organizationId))} // Map organizationId to objects
+                    onChange={(e, newValue) => {
+                        const selectedOrgIds = newValue.map(org => org.organizationId); // Extract only organizationId
+                        configDispatcher({ action: 'visibleOrganizations', value: selectedOrgIds });
+                    }}
+                    renderOption={(props, organization, { selected }) => (
+                        <li {...props}>
+                            <Checkbox
+                                id={organization.organizationId}
+                                key={organization.organizationId}
+                                icon={icon}
+                                checkedIcon={checkedIcon}
+                                style={{ marginRight: 8 }}
+                                checked={selected}
+                            />
+                            {organization.displayName} {/* Display Name */}
+                        </li>
+                    )}
+                    renderInput={(params) => (
+                        <TextField {...params}
+                            disabled={isRestricted(['apim:api_create', 'apim:api_publish'], apiFromContext)
+                                || organizations.list.length === 0
+                            }
+                            fullWidth
+                            label={organizations.list.length !== 0 ? (
+                                <FormattedMessage
+                                    id='Apis.Details.Configurations.shared.organizations'
+                                    defaultMessage='Shared Organizations'
+                                />
+                            ) : (
+                                <FormattedMessage
+                                    id='Apis.Details.Configurations.shared.organizations.empty'
+                                    defaultMessage='No organizations selected.'
+                                />
+                            )}
+                            placeholder={intl.formatMessage({
+                                id:'Apis.Details.Configurations.shared.organizations.placeholder.text',
+                                defaultMessage:'Search Organizations'
+                            })}
+                            helperText={(
+                                <FormattedMessage
+                                    id='Apis.Details.Configurations.shared.organizations.helper.text'
+                                    defaultMessage='Select organizations for sharing the API'
+                                />
+                            )}
+                            margin='normal'
+                            variant='outlined'
+                            id='SharedOrganizations'
+                        />
+                    )}
+                />
+                <Tooltip
+                    title={(
+                        <>
+                            <p>
+                                <FormattedMessage
+                                    id='Shared.organizations.dropdown.tooltip'
+                                    defaultMessage={'Allow to share API with other organizations.'
+                                        + ' There has to be pre-defined organizations in the'
+                                        + ' environment in order to share the API.'}
+                                />
+                            </p>
+                        </>
+                    )}
+                    aria-label='Shared Organizations'
+                    placement='right-end'
+                    interactive
+                    className={classes.tooltip}
+                >
+                    <HelpOutline />
+                </Tooltip>
+            </StyledBox>
+        );
+    }
+}
+
+SharedOrganizations.defaultProps = {
+    organizations: [],
+    api: PropTypes.shape({}).isRequired,
+    configDispatcher: PropTypes.func.isRequired,
+};
+
+export default SharedOrganizations;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
@@ -1,4 +1,3 @@
-/*eslint-disable*/
 /*
  * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
@@ -21,7 +20,7 @@ import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import TextField from '@mui/material/TextField';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import Autocomplete from '@mui/material/Autocomplete';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
@@ -30,8 +29,6 @@ import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
 import HelpOutline from '@mui/icons-material/HelpOutline';
 import API from 'AppData/api';
-import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
-import { isRestricted } from 'AppData/AuthManager';
 
 const PREFIX = 'SharedOrganizations';
 
@@ -66,9 +63,6 @@ function SharedOrganizations(props) {
     const [organizations, setOrganizations] = useState({});
     const { api, configDispatcher } = props;
 
-    const [apiFromContext] = useAPI();
-    const intl = useIntl();
-
     useEffect(() => {
         API.getOrganizations().then((response) => setOrganizations(response.body));
     }, []);
@@ -81,6 +75,8 @@ function SharedOrganizations(props) {
         const handleChange = (event, newValue) => {
             if (newValue.some((org) => org.organizationId === "all")) {
                 configDispatcher({ action: "visibleOrganizations", value: ["all"] });
+            } else if (newValue.length === 0) {
+                configDispatcher({ action: "visibleOrganizations", value: [] });
             } else {
                 configDispatcher({
                     action: "visibleOrganizations",
@@ -94,9 +90,9 @@ function SharedOrganizations(props) {
                     multiple
                     fullWidth
                     limitTags={5}
-                    id="SharedOrganizations-autocomplete"
+                    id='SharedOrganizations-autocomplete'
                     options={optionsList}
-                    noOptionsText="No Organizations selected"
+                    noOptionsText='No Organizations selected'
                     disableCloseOnSelect
                     getOptionLabel={(option) => option.displayName}
                     isOptionEqualToValue={(option, value) => option.organizationId === value.organizationId}
@@ -106,8 +102,8 @@ function SharedOrganizations(props) {
                             : organizations.list.filter((org) => api.visibleOrganizations.includes(org.organizationId))
                     }
                     onChange={handleChange}
-                    renderOption={(props, option, { selected }) => (
-                        <li {...props}>
+                    renderOption={(optionProps, option, { selected }) => (
+                        <li {...optionProps}>
                             <Checkbox
                                 key={option.organizationId}
                                 icon={icon}
@@ -122,11 +118,11 @@ function SharedOrganizations(props) {
                         <TextField
                             {...params}
                             fullWidth
-                            label="Shared Organizations"
-                            placeholder="Search Organizations"
-                            helperText="Select organizations for sharing the API"
-                            margin="normal"
-                            variant="outlined"
+                            label='Shared Organizations'
+                            placeholder='Add Organizations'
+                            helperText='Select organizations for sharing the API'
+                            margin='normal'
+                            variant='outlined'
                         />
                     )}
                 />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
@@ -89,74 +89,63 @@ function SharedOrganizations(props) {
 
     useEffect(() => {
         // currently using mock data for organizations
-        // API.sharedOrganizations().then((response) => setOrganizations(response.body));
+        // API.getOrganizations().then((response) => setOrganizations(response.body));
     }, []);
 
     if (organizations && !organizations.list) {
         return null;
     } else if (organizations && organizations.list) {
+        const allOption = { organizationId: "all", displayName: "All Organizations" };
+        const optionsList = [allOption, ...organizations.list];
+        const handleChange = (event, newValue) => {
+            if (newValue.some((org) => org.organizationId === "all")) {
+                configDispatcher({ action: "visibleOrganizations", value: ["all"] });
+            } else {
+                configDispatcher({
+                    action: "visibleOrganizations",
+                    value: newValue.map((org) => org.organizationId),
+                });
+            }
+        };
         return (
             <StyledBox style={{ position: 'relative', marginTop: 10 }}>
                 <Autocomplete
-                    disabled={isRestricted(['apim:api_create', 'apim:api_publish'], apiFromContext)
-                        || organizations.list.length === 0
-                    }
                     multiple
                     fullWidth
                     limitTags={5}
-                    id='SharedOrganizations-autocomplete'
-                    options={organizations.list} // Pass the full organization object
-                    getOptionLabel={(option) => option.displayName} // Show displayName in dropdown
-                    noOptionsText='No Organizations selected'
+                    id="SharedOrganizations-autocomplete"
+                    options={optionsList}
+                    noOptionsText="No Organizations selected"
                     disableCloseOnSelect
-                    value={organizations.list.filter(org => api.visibleOrganizations.includes(org.organizationId))} // Map organizationId to objects
-                    onChange={(e, newValue) => {
-                        const selectedOrgIds = newValue.map(org => org.organizationId); // Extract only organizationId
-                        configDispatcher({ action: 'visibleOrganizations', value: selectedOrgIds });
-                    }}
-                    renderOption={(props, organization, { selected }) => (
+                    getOptionLabel={(option) => option.displayName}
+                    isOptionEqualToValue={(option, value) => option.organizationId === value.organizationId}
+                    value={
+                        api.visibleOrganizations.includes("all")
+                            ? [allOption]
+                            : organizations.list.filter((org) => api.visibleOrganizations.includes(org.organizationId))
+                    }
+                    onChange={handleChange}
+                    renderOption={(props, option, { selected }) => (
                         <li {...props}>
                             <Checkbox
-                                id={organization.organizationId}
-                                key={organization.organizationId}
+                                key={option.organizationId}
                                 icon={icon}
                                 checkedIcon={checkedIcon}
                                 style={{ marginRight: 8 }}
                                 checked={selected}
                             />
-                            {organization.displayName} {/* Display Name */}
+                            {option.displayName}
                         </li>
                     )}
                     renderInput={(params) => (
-                        <TextField {...params}
-                            disabled={isRestricted(['apim:api_create', 'apim:api_publish'], apiFromContext)
-                                || organizations.list.length === 0
-                            }
+                        <TextField
+                            {...params}
                             fullWidth
-                            label={organizations.list.length !== 0 ? (
-                                <FormattedMessage
-                                    id='Apis.Details.Configurations.shared.organizations'
-                                    defaultMessage='Shared Organizations'
-                                />
-                            ) : (
-                                <FormattedMessage
-                                    id='Apis.Details.Configurations.shared.organizations.empty'
-                                    defaultMessage='No organizations selected.'
-                                />
-                            )}
-                            placeholder={intl.formatMessage({
-                                id:'Apis.Details.Configurations.shared.organizations.placeholder.text',
-                                defaultMessage:'Search Organizations'
-                            })}
-                            helperText={(
-                                <FormattedMessage
-                                    id='Apis.Details.Configurations.shared.organizations.helper.text'
-                                    defaultMessage='Select organizations for sharing the API'
-                                />
-                            )}
-                            margin='normal'
-                            variant='outlined'
-                            id='SharedOrganizations'
+                            label="Shared Organizations"
+                            placeholder="Search Organizations"
+                            helperText="Select organizations for sharing the API"
+                            margin="normal"
+                            variant="outlined"
                         />
                     )}
                 />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/SharedOrganizations.jsx
@@ -63,33 +63,14 @@ const checkedIcon = <CheckBoxIcon fontSize='small' />;
  * @returns {JSX} Render the organizations drop down.
  */
 function SharedOrganizations(props) {
-    const [organizations, setOrganizations] = useState({
-        count: 2,
-        list: [
-            {
-                organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
-                externalOrganizationId: "external-org-1",
-                parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-                displayName: "Mock Organization 1",
-                description: "This is a mock organization 1",
-            },
-            {
-                organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
-                externalOrganizationId: "external-org-2",
-                parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-                displayName: "Mock Organization 2",
-                description: "This is a mock organization 2",
-            },
-        ],
-    });
+    const [organizations, setOrganizations] = useState({});
     const { api, configDispatcher } = props;
 
     const [apiFromContext] = useAPI();
     const intl = useIntl();
 
     useEffect(() => {
-        // currently using mock data for organizations
-        // API.getOrganizations().then((response) => setOrganizations(response.body));
+        API.getOrganizations().then((response) => setOrganizations(response.body));
     }, []);
 
     if (organizations && !organizations.list) {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/StoreVisibility.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/StoreVisibility.jsx
@@ -30,7 +30,6 @@ import APIValidation from 'AppData/APIValidation';
 import base64url from 'base64url';
 import Error from '@mui/icons-material/Error';
 import InputAdornment from '@mui/material/InputAdornment';
-import { useAppContext } from 'AppComponents/Shared/AppContext';
 import Chip from '@mui/material/Chip';
 import { red } from '@mui/material/colors/';
 import Alert from 'AppComponents/Shared/Alert';
@@ -68,14 +67,10 @@ const Root = styled('div')((
 export default function StoreVisibility(props) {
     const [roleValidity, setRoleValidity] = useState(true);
     const [roleExists, setRoleExists] = useState(true);
-    const [orgValidity, setOrgValidity] = useState(true);
-    const [orgExists, setOrgExists] = useState(true);
     const { api, configDispatcher, setIsDisabled } = props;
     const [invalidRoles, setInvalidRoles] = useState([]);
-    const [invalidOrgs, setInvalidOrgs] = useState([]);
     const isRestrictedByRoles = api.visibility === 'RESTRICTED';
     const [apiFromContext] = useAPI();
-    const { settings } = useAppContext();
 
     const restApi = new API();
     const intl = useIntl();
@@ -95,14 +90,6 @@ export default function StoreVisibility(props) {
             setRoleExists(true);
         }
     }, [invalidRoles]);
-    useEffect(() => {
-        if (invalidOrgs.length === 0) {
-            setOrgValidity(true);
-        }
-        if (api.visibility === 'RESTRICTED_BY_ORG' && api.visibleOrganizations.length !== 0) {
-            setOrgExists(true);
-        }
-    }, [invalidOrgs]);
     useEffect(() => {
         setIsDisabled(!roleValidity || !roleExists);
     }, [roleValidity, roleExists])
@@ -149,30 +136,6 @@ export default function StoreVisibility(props) {
         });
     };
 
-    const handleOrgAddition = (orgs) => {
-        setOrgExists(true);
-        setOrgValidity(true);
-        configDispatcher({
-            action: 'visibleOrganizations',
-            value: [...api.visibleOrganizations, orgs],
-        });
-        console.log(orgs);
-    };
-    const handleOrgDeletion = (org) => {
-        if (invalidOrgs.includes(org)) {
-            setInvalidOrgs(invalidOrgs.filter((existingOrgs) => existingOrgs !== org));
-        }
-        if (api.visibility === 'RESTRICTED_BY_ORG' && api.visibleOrganizations.length > 1) {
-            setOrgExists(true);
-        } else {
-            setOrgExists(false);
-        }
-        configDispatcher({
-            action: 'visibleOrganizations',
-            value: api.visibleOrganizations.filter((existingOrgs) => existingOrgs !== org),
-        });
-    };
-
     const handleChangeVisibility = (event) => {
         if (event.target.value === 'PUBLIC') {
             setRoleValidity(true);
@@ -181,9 +144,6 @@ export default function StoreVisibility(props) {
         }
         if (event.target.value === 'RESTRICTED' && api.visibleRoles.length === 0) {
             setRoleValidity(false);
-        }
-        if (event.target.value === 'RESTRICTED_BY_ORG' && api.visibleRoles.length === 0) {
-            setOrgValidity(false);
         }
         configDispatcher({ action: 'visibility', value: event.target.value });
     }
@@ -347,66 +307,6 @@ export default function StoreVisibility(props) {
                     />
                 </Box>
             )}
-            {
-                settings.orgAccessControlEnabled && (
-                    <Box py={2} style={{ marginTop: -10, marginBottom: 10 }}>
-                        <ChipInput
-                            data-testid='visibility-select-role'
-                            fullWidth
-                            variant='outlined'
-                            label={(
-                                <FormattedMessage
-                                    id='Apis.Details.Configuration.components.storeVisibility.orgs'
-                                    defaultMessage='Developer Portal Organization Visibility'
-                                />
-                            )}
-                            disabled={isRestricted(['apim:api_create', 'apim:api_publish'], apiFromContext)}
-                            value={api.visibleOrganizations.concat(invalidOrgs)}
-                            alwaysShowPlaceholder={false}
-                            placeholder='Enter organization and press Enter'
-                            blurBehavior='clear'
-                            InputProps={{
-                                endAdornment: !orgValidity && (
-                                    <InputAdornment position='end'>
-                                        <Error color='error' style={{ paddingBottom: 8 }} />
-                                    </InputAdornment>
-                                ),
-                            }}
-                            onAdd={handleOrgAddition}
-                            error={!orgValidity || !orgExists}
-                            helperText={
-                                orgValidity ? (
-                                    <FormattedMessage
-                                        id='Apis.Details.Scopes.visibility.CreateScope.orgs.help'
-                                        defaultMessage='Enter valid organization and press enter'
-                                    />
-                                ) : (
-                                    <FormattedMessage
-                                        id='Apis.Details.Scopes.Orgs.Invalid'
-                                        defaultMessage='Organization is invalid'
-                                    />
-                                )
-                            }
-                            chipRenderer={({ value }, key) => (
-                                <Chip
-                                    key={key}
-                                    size='small'
-                                    label={value}
-                                    onDelete={() => {
-                                        handleOrgDeletion(value);
-                                    }}
-                                    style={{
-                                        backgroundColor: invalidOrgs.includes(value) ? red[300] : null,
-                                        margin: '0 8px 12px 0',
-                                        float: 'left',
-                                    }}
-                                />
-                            )}
-                        />
-                    </Box>
-                )
-            }
-
         </Root>)
     );
 }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
@@ -1,4 +1,3 @@
-/*eslint-disable*/
 /*
  * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
@@ -17,33 +16,24 @@
  * under the License.
  */
 
-import { useEffect, useState } from 'react';
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import PropTypes from 'prop-types';
 import Checkbox from '@mui/material/Checkbox';
 import Typography from '@mui/material/Typography';
-import FormControl from '@mui/material/FormControl';
-import FormGroup from '@mui/material/FormGroup';
-import Box from '@mui/material/Box';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
+import PropTypes from 'prop-types';
 import API from 'AppData/api';
-import { isRestricted } from 'AppData/AuthManager';
 import Configurations from 'Config';
 import CONSTS from 'AppData/Constants';
 import Tooltip from '@mui/material/Tooltip';
 import InfoIcon from '@mui/icons-material/Info';
-import { Table, TableRow, Chip } from '@mui/material';
+import { Table, TableRow, Chip, Autocomplete, TextField, ListItem } from '@mui/material';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableContainer from '@mui/material/TableContainer';
-import { Autocomplete, TextField, ListItem } from "@mui/material";
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-
 
 const PREFIX = 'OrganizationSubscriptionPoliciesManage';
 
@@ -53,7 +43,6 @@ const classes = {
     gridLabel: `${PREFIX}-gridLabel`,
     mainTitle: `${PREFIX}-mainTitle`
 };
-
 
 const Root = styled('div')((
     {
@@ -78,6 +67,17 @@ const Root = styled('div')((
     }
 }));
 
+/**
+ * Manage organization based subscription policies of the API
+ * 
+ * @param {Object} props - The properties passed to the component
+ * @param {Object} props.api - The API object
+ * @param {Array} props.organizations - The list of all organizations
+ * @param {Array} props.visibleOrganizations - The list of visible organizations
+ * @param {Array} props.organizationPolicies - The list of organization policies
+ * @param {Function} props.setOrganizationPolicies - The function to set organization policies
+ * @returns {JSX.Element} The rendered component
+ */
 function OrganizationSubscriptionPoliciesManage(props) {
     const { api, organizations, visibleOrganizations, organizationPolicies, setOrganizationPolicies } = props;
     const [filteredOrganizations, setFilteredOrganizations] = useState([]);
@@ -132,8 +132,8 @@ function OrganizationSubscriptionPoliciesManage(props) {
         setOrganizationPolicies(updatedOrganizationPolicies);
     };
 
-    const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
-    const checkedIcon = <CheckBoxIcon fontSize="small" />;
+    const icon = <CheckBoxOutlineBlankIcon fontSize='small' />;
+    const checkedIcon = <CheckBoxIcon fontSize='small' />;
 
     const getPolicyDetails = (policy) => {
         const details = [];
@@ -159,84 +159,103 @@ function OrganizationSubscriptionPoliciesManage(props) {
     };
 
     return (
-        <>
-        <Typography variant='h6' style={{ marginTop: '20px' }}>Organization Specific Business Plans</Typography>
-        <Paper>
-            <TableContainer>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>Organization</TableCell>
-                            <TableCell>Policies</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {filteredOrganizations.map(org => (
-                            <TableRow key={org.organizationId}>
-                                <TableCell>{org.displayName}</TableCell>
-                                <TableCell>
-                                    <Autocomplete
-                                        multiple
-                                        disableCloseOnSelect
-                                        options={subscriptionPolicies}
-                                        getOptionLabel={(option) => 
-                                            option?.displayName ? `${option.displayName} - ${option.description}` : String(option)
-                                        }
-                                        value={subscriptionPolicies.filter(policy => 
-                                            organizationPolicies.find(op => op.organizationID === org.organizationId)?.policies.includes(policy.name)
-                                        ) || []}
-                                        onChange={(event, value) => handlePolicyChange(org.organizationId, value)}
-                                        renderOption={(props, option, { selected }) => {
-                                            const { key, ...optionProps } = props;
-                                            if (option.displayName.includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN)) {
-                                                return null;
-                                            }
-                                            return (
-                                                <ListItem key={key} {...optionProps}>
-                                                    <Checkbox
-                                                        icon={icon}
-                                                        checkedIcon={checkedIcon}
-                                                        style={{ marginRight: 8 }}
-                                                        checked={selected}
-                                                    />
-                                                    {option.displayName} - {option.description} 
-                                                    <Tooltip title={getPolicyDetails(option)}>
-                                                        <InfoIcon
-                                                            color='action'
-                                                            style={{ marginLeft: 5, fontSize: 20, cursor: 'default' }}
-                                                        />
-                                                    </Tooltip>
-                                                </ListItem>
-                                            );
-                                        }}
-                                        renderTags={(selected, getTagProps) =>
-                                            selected
-                                                .filter(option => !option.displayName.includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN))
-                                                .map((option, index) => (
-                                                    <Chip
-                                                        {...getTagProps({ index })}
-                                                        key={option.name}
-                                                        label={option.displayName}
-                                                    />
-                                                ))
-                                        }
-                                        renderInput={(params) => (
-                                            <TextField
-                                                {...params}
-                                                variant='outlined'
-                                                placeholder='Select Policies'
-                                            />
-                                        )}
-                                    />
-                                </TableCell>
+        <Root>
+            <Typography variant='h6' style={{ marginTop: '20px' }}>Organization Specific Business Plans</Typography>
+            <Paper>
+                <TableContainer>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Organization</TableCell>
+                                <TableCell>Policies</TableCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-        </Paper>
-        </>
+                        </TableHead>
+                        <TableBody>
+                            {filteredOrganizations.map(org => (
+                                <TableRow key={org.organizationId}>
+                                    <TableCell>{org.displayName}</TableCell>
+                                    <TableCell>
+                                        <Autocomplete
+                                            multiple
+                                            disableCloseOnSelect
+                                            options={subscriptionPolicies}
+                                            getOptionLabel={(option) =>
+                                                option?.displayName ?
+                                                    `${option.displayName} - ${option.description}` : String(option)
+                                            }
+                                            value={subscriptionPolicies.filter(policy => 
+                                                organizationPolicies.find(
+                                                    op => op.organizationID === org.organizationId)?.
+                                                    policies.includes(policy.name)
+                                            ) || []}
+                                            onChange={(event, value) => handlePolicyChange(org.organizationId, value)}
+                                            renderOption={(optionProps, option, { selected }) => {
+                                                const { key, ...restOptionProps } = optionProps;
+                                                if (option.displayName.includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN)) {
+                                                    return null;
+                                                }
+                                                return (
+                                                    <ListItem key={key} {...restOptionProps}>
+                                                        <Checkbox
+                                                            icon={icon}
+                                                            checkedIcon={checkedIcon}
+                                                            style={{ marginRight: 8 }}
+                                                            checked={selected}
+                                                        />
+                                                        {option.displayName} - {option.description} 
+                                                        <Tooltip title={getPolicyDetails(option)}>
+                                                            <InfoIcon
+                                                                color='action'
+                                                                style={{
+                                                                    marginLeft: 5, fontSize: 20, cursor: 'default'
+                                                                }}
+                                                            />
+                                                        </Tooltip>
+                                                    </ListItem>
+                                                );
+                                            }}
+                                            renderTags={(selected, getTagProps) =>
+                                                selected
+                                                    .filter(option => !option.displayName
+                                                        .includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN))
+                                                    .map((option, index) => (
+                                                        <Chip
+                                                            {...getTagProps({ index })}
+                                                            key={option.name}
+                                                            label={option.displayName}
+                                                        />
+                                                    ))
+                                            }
+                                            renderInput={(params) => (
+                                                <TextField
+                                                    {...params}
+                                                    variant='outlined'
+                                                    placeholder='Select Policies'
+                                                />
+                                            )}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Paper>
+        </Root>
     );
 }
+
+OrganizationSubscriptionPoliciesManage.propTypes = {
+    api: PropTypes.shape({ policies: PropTypes.arrayOf(PropTypes.shape({})) }).isRequired,
+    organizations: PropTypes.arrayOf(PropTypes.shape({
+        organizationId: PropTypes.string.isRequired,
+    })).isRequired,
+    visibleOrganizations: PropTypes.arrayOf(PropTypes.string).isRequired,
+    organizationPolicies: PropTypes.arrayOf(PropTypes.shape({
+        organizationID: PropTypes.string.isRequired,
+        policies: PropTypes.arrayOf(PropTypes.string).isRequired,
+    })).isRequired,
+    setOrganizationPolicies: PropTypes.func.isRequired,
+};
 
 export default OrganizationSubscriptionPoliciesManage;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
@@ -1,0 +1,225 @@
+/* eslint-disable */
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import React, { Component } from 'react';
+import { styled } from '@mui/material/styles';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import Checkbox from '@mui/material/Checkbox';
+import Typography from '@mui/material/Typography';
+import FormControl from '@mui/material/FormControl';
+import FormGroup from '@mui/material/FormGroup';
+import Box from '@mui/material/Box';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Paper from '@mui/material/Paper';
+import API from 'AppData/api';
+import { isRestricted } from 'AppData/AuthManager';
+import Configurations from 'Config';
+import CONSTS from 'AppData/Constants';
+import Tooltip from '@mui/material/Tooltip';
+import InfoIcon from '@mui/icons-material/Info';
+import { Table, TableRow, Chip } from '@mui/material';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableContainer from '@mui/material/TableContainer';
+import { Autocomplete, TextField, ListItem } from "@mui/material";
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+
+
+const PREFIX = 'OrganizationSubscriptionPoliciesManage';
+
+const classes = {
+    subscriptionPoliciesPaper: `${PREFIX}-subscriptionPoliciesPaper`,
+    grid: `${PREFIX}-grid`,
+    gridLabel: `${PREFIX}-gridLabel`,
+    mainTitle: `${PREFIX}-mainTitle`
+};
+
+
+const Root = styled('div')((
+    {
+        theme
+    }
+) => ({
+    [`& .${classes.subscriptionPoliciesPaper}`]: {
+        marginTop: theme.spacing(2),
+        padding: theme.spacing(2),
+    },
+
+    [`& .${classes.grid}`]: {
+        margin: theme.spacing(1.25),
+    },
+
+    [`& .${classes.gridLabel}`]: {
+        marginTop: theme.spacing(1.5),
+    },
+
+    [`& .${classes.mainTitle}`]: {
+        paddingLeft: 0,
+    }
+}));
+
+function OrganizationSubscriptionPoliciesManage(props) {
+    const { api, organizations, visibleOrganizations, organizationPolicies, setOrganizationPolicies } = props;
+    const [filteredOrganizations, setFilteredOrganizations] = useState([]);
+    const [subscriptionPolicies, setSubscriptionPolicies] = useState([]);
+
+    useEffect(() => {
+        const limit = Configurations.app.subscriptionPolicyLimit;
+        const isAiApi = api?.subtypeConfiguration?.subtype?.toLowerCase().includes('aiapi') ?? false;
+        const policyPromise = API.policies('subscription', limit || undefined, isAiApi);
+
+        policyPromise
+            .then((res) => {
+                setSubscriptionPolicies(res.body.list);
+            })
+            .catch((error) => {
+                console.error(error);
+            });
+
+        if (visibleOrganizations.includes('all')) {
+            setFilteredOrganizations(organizations);
+        } else {
+            setFilteredOrganizations(organizations.filter(org => visibleOrganizations.includes(org.organizationId)));
+        }
+    }, [organizations, visibleOrganizations]);
+
+    const handlePolicyChange = (organizationId, selectedPolicies) => {
+        
+        const selectedPolicyNames = selectedPolicies.map(policy => policy.name);
+        const updatedOrganizationPolicies = organizationPolicies.map(orgPolicy =>
+            orgPolicy.organizationID === organizationId
+                ? { ...orgPolicy, policies: selectedPolicyNames }
+                : orgPolicy
+        );
+    
+        setOrganizationPolicies(updatedOrganizationPolicies);
+    };
+
+    const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
+    const checkedIcon = <CheckBoxIcon fontSize="small" />;
+
+    const getPolicyDetails = (policy) => {
+        const details = [];
+        if (policy.requestCount && policy.requestCount !== 0) details.push(`Request Count: ${policy.requestCount}`);
+        if (policy.dataUnit) details.push(`Data Unit: ${policy.dataUnit}`);
+        if (policy.timeUnit && policy.unitTime && policy.unitTime !== 0) {
+            details.push(`Unit Time: ${policy.unitTime}  ${policy.timeUnit}`);
+        }
+        if (policy.rateLimitCount && policy.rateLimitCount !== 0) {
+            details.push(`Rate Limit Count: ${policy.rateLimitCount}`);
+        }
+        if (policy.rateLimitTimeUnit) details.push(`Rate Limit Time Unit: ${policy.rateLimitTimeUnit}`);
+        if (policy.totalTokenCount && policy.totalTokenCount !== 0) {
+            details.push(`Total Token Count: ${policy.totalTokenCount}`);
+        }
+        if (policy.promptTokenCount && policy.promptTokenCount !== 0) {
+            details.push(`Prompt Token Count: ${policy.promptTokenCount}`);
+        }
+        if (policy.completionTokenCount && policy.completionTokenCount !== 0) {
+            details.push(`Completion Token Count: ${policy.completionTokenCount}`);
+        }
+        return details.length > 0 ? details.join(', ') : 'No additional details';
+    };
+
+    return (
+        <>
+        <Typography variant="h6" style={{ marginTop: '20px' }}>Organization Specific Business Plans</Typography>
+        <Paper>
+            <TableContainer>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>Organization</TableCell>
+                            <TableCell>Policies</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {filteredOrganizations.map(org => (
+                            <TableRow key={org.organizationId}>
+                                <TableCell>{org.displayName}</TableCell>
+                                <TableCell>
+                                    <Autocomplete
+                                        multiple
+                                        disableCloseOnSelect
+                                        options={subscriptionPolicies}
+                                        getOptionLabel={(option) => 
+                                            option?.displayName ? `${option.displayName} - ${option.description}` : String(option)
+                                        }
+                                        value={subscriptionPolicies.filter(policy => 
+                                            organizationPolicies.find(op => op.organizationID === org.organizationId)?.policies.includes(policy.name)
+                                        ) || []}
+                                        onChange={(event, value) => handlePolicyChange(org.organizationId, value)}
+                                        renderOption={(props, option, { selected }) => {
+                                            const { key, ...optionProps } = props;
+                                            if (option.displayName.includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN)) {
+                                                return null;
+                                            }
+                                            return (
+                                                <ListItem key={key} {...optionProps}>
+                                                    <Checkbox
+                                                        icon={icon}
+                                                        checkedIcon={checkedIcon}
+                                                        style={{ marginRight: 8 }}
+                                                        checked={selected}
+                                                    />
+                                                    {option.displayName} - {option.description} 
+                                                    <Tooltip title={getPolicyDetails(option)}>
+                                                        <InfoIcon
+                                                            color='action'
+                                                            style={{ marginLeft: 5, fontSize: 20, cursor: 'default' }}
+                                                        />
+                                                    </Tooltip>
+                                                </ListItem>
+                                            );
+                                        }}
+                                        renderTags={(selected, getTagProps) =>
+                                            selected
+                                                .filter(option => !option.displayName.includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN))
+                                                .map((option, index) => (
+                                                    <Chip
+                                                        {...getTagProps({ index })}
+                                                        key={option.name}
+                                                        label={option.displayName}
+                                                    />
+                                                ))
+                                        }
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                variant="outlined"
+                                                placeholder="Select Policies"
+                                            />
+                                        )}
+                                    />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </Paper>
+        </>
+    );
+}
+
+export default OrganizationSubscriptionPoliciesManage;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/OrganizationSubscriptionPoliciesManage.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/*eslint-disable*/
 /*
  * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
@@ -104,14 +104,31 @@ function OrganizationSubscriptionPoliciesManage(props) {
     }, [organizations, visibleOrganizations]);
 
     const handlePolicyChange = (organizationId, selectedPolicies) => {
-        
         const selectedPolicyNames = selectedPolicies.map(policy => policy.name);
-        const updatedOrganizationPolicies = organizationPolicies.map(orgPolicy =>
-            orgPolicy.organizationID === organizationId
-                ? { ...orgPolicy, policies: selectedPolicyNames }
-                : orgPolicy
+        const existingOrgPolicyIndex = organizationPolicies.findIndex(
+            orgPolicy => orgPolicy.organizationID === organizationId
         );
-    
+        let updatedOrganizationPolicies;
+
+        if (existingOrgPolicyIndex !== -1) {
+            updatedOrganizationPolicies = organizationPolicies.map(orgPolicy =>
+                orgPolicy.organizationID === organizationId
+                    ? { ...orgPolicy, policies: selectedPolicyNames }
+                    : orgPolicy
+            );
+        } else {
+            const organizationName = organizations.find(org => org.organizationId === organizationId).displayName;
+            updatedOrganizationPolicies = [
+                ...organizationPolicies,
+                { 
+                    organizationID: organizationId,
+                    organizationName,
+                    policies: selectedPolicyNames
+                }
+            ];
+        }
+        updatedOrganizationPolicies = updatedOrganizationPolicies.filter(orgPolicy => orgPolicy.policies.length > 0);
+
         setOrganizationPolicies(updatedOrganizationPolicies);
     };
 
@@ -143,7 +160,7 @@ function OrganizationSubscriptionPoliciesManage(props) {
 
     return (
         <>
-        <Typography variant="h6" style={{ marginTop: '20px' }}>Organization Specific Business Plans</Typography>
+        <Typography variant='h6' style={{ marginTop: '20px' }}>Organization Specific Business Plans</Typography>
         <Paper>
             <TableContainer>
                 <Table>
@@ -206,8 +223,8 @@ function OrganizationSubscriptionPoliciesManage(props) {
                                         renderInput={(params) => (
                                             <TextField
                                                 {...params}
-                                                variant="outlined"
-                                                placeholder="Select Policies"
+                                                variant='outlined'
+                                                placeholder='Select Policies'
                                             />
                                         )}
                                     />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -86,9 +85,7 @@ function Subscriptions(props) {
     const { settings } = useAppContext();
     const isSubValidationDisabled = api.policies && api.policies.length === 1 
     && api.policies[0].includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN);
-    const isOrganizationAccessControlEnabled = true;
     const [organizationPolicies, setOrganizationPolicies] = useState([]);
-    const [originalOrganizationPolicies, setOriginalOrganizationPolicies] = useState([]);
     const [organizations, setOrganizations] = useState({});
     const [visibleOrganizations, setVisibleOrganizations] = useState(api.visibleOrganizations);
 
@@ -141,7 +138,6 @@ function Subscriptions(props) {
         setPolices([...api.policies]);
         setOriginalPolicies([...api.policies]);
         setOrganizationPolicies([...api.organizationPolicies]);
-        setOriginalOrganizationPolicies([...api.organizationPolicies]);
         setVisibleOrganizations([...api.visibleOrganizations]);
     }, []);
 
@@ -176,7 +172,8 @@ function Subscriptions(props) {
     return (
         (<Root>
             {(api.gatewayVendor === 'wso2') &&
-            (   <>
+            (   
+                <>
                     <SubscriptionPoliciesManage
                         api={api}
                         policies={policies}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/Subscriptions.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
  * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -37,6 +38,7 @@ import { useAppContext } from 'AppComponents/Shared/AppContext';
 import { isRestricted } from 'AppData/AuthManager';
 import SubscriptionsTable from './SubscriptionsTable';
 import SubscriptionPoliciesManage from './SubscriptionPoliciesManage';
+import OrganizationSubscriptionPoliciesManage from './OrganizationSubscriptionPoliciesManage';
 import SubscriptionAvailability from './SubscriptionAvailability';
 
 const PREFIX = 'Subscriptions';
@@ -84,6 +86,11 @@ function Subscriptions(props) {
     const { settings } = useAppContext();
     const isSubValidationDisabled = api.policies && api.policies.length === 1 
     && api.policies[0].includes(CONSTS.DEFAULT_SUBSCRIPTIONLESS_PLAN);
+    const isOrganizationAccessControlEnabled = true;
+    const [organizationPolicies, setOrganizationPolicies] = useState([]);
+    const [originalOrganizationPolicies, setOriginalOrganizationPolicies] = useState([]);
+    const [organizations, setOrganizations] = useState({});
+    const [visibleOrganizations, setVisibleOrganizations] = useState(api.visibleOrganizations);
 
     /**
      * Save subscription information (policies, subscriptionAvailability, subscriptionAvailableTenants)
@@ -93,6 +100,7 @@ function Subscriptions(props) {
         const { subscriptionAvailability } = availability;
         const newApi = {
             policies,
+            organizationPolicies,
             subscriptionAvailability,
             subscriptionAvailableTenants: tenantList,
         };
@@ -126,8 +134,15 @@ function Subscriptions(props) {
             .then((result) => {
                 setSubscriptions(result.body.count);
             });
+        restApi.organizations()
+            .then((result) => {
+                setOrganizations(result.body.list);
+            })
         setPolices([...api.policies]);
         setOriginalPolicies([...api.policies]);
+        setOrganizationPolicies([...api.organizationPolicies]);
+        setOriginalOrganizationPolicies([...api.organizationPolicies]);
+        setVisibleOrganizations([...api.visibleOrganizations]);
     }, []);
 
     const handleSubscriptionSave = () => {
@@ -161,13 +176,23 @@ function Subscriptions(props) {
     return (
         (<Root>
             {(api.gatewayVendor === 'wso2') &&
-            (
-                <SubscriptionPoliciesManage
-                    api={api}
-                    policies={policies}
-                    setPolices={setPolices}
-                    subValidationDisablingAllowed={settings.allowSubscriptionValidationDisabling}
-                />
+            (   <>
+                    <SubscriptionPoliciesManage
+                        api={api}
+                        policies={policies}
+                        setPolices={setPolices}
+                        subValidationDisablingAllowed={settings.allowSubscriptionValidationDisabling}
+                    />
+                    {organizations?.length > 0 &&
+                        <OrganizationSubscriptionPoliciesManage
+                            api={api}
+                            organizations={organizations}
+                            visibleOrganizations={visibleOrganizations}
+                            organizationPolicies={organizationPolicies}
+                            setOrganizationPolicies={setOrganizationPolicies}
+                        />
+                    }
+                </>
             )}
             {isSubValidationDisabled && (
                 <Box mb={2} mt={2}>

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -2822,6 +2822,48 @@ class API extends Resource {
             );
         });
     }
+
+    // /**
+    //  * @static
+    //  * Get all Organizations of the given tenant
+    //  * @return {Promise}
+    //  * */
+    // static sharedOrganizations() {
+    //     const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+    //     return apiClient.then(client => {
+    //         return client.apis["Organization (Collection)"].getAllOrganizations(
+    //             this._requestMetaData(),
+    //         );
+    //     });
+    // }
+
+    /**
+     * @static
+     * Get all Organizations of the given tenant (Mock Data)
+     * @return {Promise}
+     */
+    static sharedOrganizations() {
+        return {
+            count: 2,
+            list: [
+                {
+                    organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
+                    externalOrganizationId: "external-org-1",
+                    parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+                    displayName: "Mock Organization 1",
+                    description: "This is a mock organization 1",
+                },
+                {
+                    organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
+                    externalOrganizationId: "external-org-2",
+                    parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+                    displayName: "Mock Organization 2",
+                    description: "This is a mock organization 2",
+                },
+            ],
+        };
+    }
+
     static keyManagers() {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         return apiClient.then(client => {

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -2842,7 +2842,7 @@ class API extends Resource {
      * Get all Organizations of the given tenant (Mock Data)
      * @return {Promise}
      */
-    static sharedOrganizations() {
+    static getOrganizations() {
         return {
             count: 2,
             list: [

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -1356,6 +1356,19 @@ class API extends Resource {
         return promise_subscription;
     }
 
+    /**
+     * Get all Organizations of the given tenant
+     * @return {Promise}
+     * */
+    organizations() {
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+        return apiClient.then(client => {
+            return client.apis["Organizations"].get_organizations(
+                this._requestMetaData(),
+            );
+        });
+    }
+
     addDocument(api_id, body) {
         const promised_addDocument = this.client.then(client => {
             const payload = {
@@ -2540,7 +2553,7 @@ class API extends Resource {
      * @returns {Promise}
      *
      */
-    static policies(policyLevel, limit, isAiApi ) {
+    static policies(policyLevel, limit, isAiApi, organizationId ) {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         return apiClient.then(client => {
             return client.apis['Throttling Policies'].getAllThrottlingPolicies(
@@ -2548,6 +2561,7 @@ class API extends Resource {
                     policyLevel: policyLevel,
                     limit,
                     isAiApi,
+                    organizationId,
                 },
                 this._requestMetaData(),
             );

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -2823,46 +2823,46 @@ class API extends Resource {
         });
     }
 
-    // /**
-    //  * @static
-    //  * Get all Organizations of the given tenant
-    //  * @return {Promise}
-    //  * */
-    // static sharedOrganizations() {
-    //     const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
-    //     return apiClient.then(client => {
-    //         return client.apis["Organization (Collection)"].getAllOrganizations(
-    //             this._requestMetaData(),
-    //         );
-    //     });
-    // }
-
     /**
      * @static
-     * Get all Organizations of the given tenant (Mock Data)
+     * Get all Organizations of the given tenant
      * @return {Promise}
-     */
+     * */
     static getOrganizations() {
-        return {
-            count: 2,
-            list: [
-                {
-                    organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
-                    externalOrganizationId: "external-org-1",
-                    parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-                    displayName: "Mock Organization 1",
-                    description: "This is a mock organization 1",
-                },
-                {
-                    organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
-                    externalOrganizationId: "external-org-2",
-                    parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-                    displayName: "Mock Organization 2",
-                    description: "This is a mock organization 2",
-                },
-            ],
-        };
+        const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
+        return apiClient.then(client => {
+            return client.apis["Organizations"].get_organizations(
+                this._requestMetaData(),
+            );
+        });
     }
+
+    // /**
+    //  * @static
+    //  * Get all Organizations of the given tenant (Mock Data)
+    //  * @return {Promise}
+    //  */
+    // static getOrganizations() {
+    //     return {
+    //         count: 2,
+    //         list: [
+    //             {
+    //                 organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
+    //                 externalOrganizationId: "external-org-1",
+    //                 parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+    //                 displayName: "Mock Organization 1",
+    //                 description: "This is a mock organization 1",
+    //             },
+    //             {
+    //                 organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
+    //                 externalOrganizationId: "external-org-2",
+    //                 parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
+    //                 displayName: "Mock Organization 2",
+    //                 description: "This is a mock organization 2",
+    //             },
+    //         ],
+    //     };
+    // }
 
     static keyManagers() {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -2851,33 +2851,6 @@ class API extends Resource {
         });
     }
 
-    // /**
-    //  * @static
-    //  * Get all Organizations of the given tenant (Mock Data)
-    //  * @return {Promise}
-    //  */
-    // static getOrganizations() {
-    //     return {
-    //         count: 2,
-    //         list: [
-    //             {
-    //                 organizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e9",
-    //                 externalOrganizationId: "external-org-1",
-    //                 parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-    //                 displayName: "Mock Organization 1",
-    //                 description: "This is a mock organization 1",
-    //             },
-    //             {
-    //                 organizationId: "b123fca4-9dcd-432d-88e2-456708bca90e",
-    //                 externalOrganizationId: "external-org-2",
-    //                 parentOrganizationId: "ece92bdc-e1e6-325c-b6f4-656208a041e1",
-    //                 displayName: "Mock Organization 2",
-    //                 description: "This is a mock organization 2",
-    //             },
-    //         ],
-    //     };
-    // }
-
     static keyManagers() {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         return apiClient.then(client => {


### PR DESCRIPTION
### Purpose

-  Initial solution for: https://github.com/wso2/api-manager/issues/3531
- This PR provides initial publisher portal UI for:
   - Add/edit shared organizations in the `Basic Info` page of an API
<img width="822" alt="Screenshot 2025-02-03 at 19 04 13" src="https://github.com/user-attachments/assets/f64a7823-3678-41cd-93df-c05216c99a5a" />

   - Add/edit business plans for shared organizations in the `Subscriptions` page of an API
<img width="1261" alt="Screenshot 2025-02-03 at 19 04 57" src="https://github.com/user-attachments/assets/164d29e2-3d16-4e18-b42b-5381bf69b72d" />

- Todo:
   - Add radio buttons for shared organizations selection (All, None, Selected Organizations)
   - Add current organization subscriptions and shared organization subscriptions in a single table