### PR TITLE
fix: condition check if the sourceUrl and otherTypeName is NULL

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/CreateEditForm.jsx
@@ -460,14 +460,14 @@ class CreateEditForm extends React.Component {
             nameNotDuplicate &&
             !nameMaxLengthExceeds &&
             !invalidDocName &&
-            ((!invalidUrl && sourceUrl !== '') || sourceType !== 'URL')
+            ((!invalidUrl && sourceUrl) || sourceType !== 'URL')
         ) {
             setSaveDisabled(false);
         } else {
             setSaveDisabled(true);
         }
 
-        if (type === 'OTHER' && otherTypeName === '') {
+        if (type === 'OTHER' && !otherTypeName) {
             setSaveDisabled(true);
         }
         return (


### PR DESCRIPTION
### Purpose

Resolves: https://github.com/wso2/api-manager/issues/126

### Issue

On the edit metadata page of a document in the publisher portal, when the document type is changed from `How To` to `Other,` the save button is still enabled even `Other Document Type` mandatory field is empty.

### Approach

Before the fix, it only checks for empty string and not for NULL values. Fixed to validate `NULL` values

<img width="1116" alt="Screenshot 2025-02-06 at 12 24 41" src="https://github.com/user-attachments/assets/2bd1a8a2-f832-4b10-9008-7b686e395afb" />
