### PR TITLE
Fix registered orgs not loading in adding new key manager

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -346,6 +346,7 @@ function AddEditKeyManager(props) {
             });
         } else {
             updateKeyManagerConnectorConfiguration(defaultKMType);
+            getOrganizations();
         }
     }, []);
 


### PR DESCRIPTION
### Implementation:

Called the function to get all registered organizations when adding new key managers.