### PR TITLE
[Gateway Federation][Feature][4.5.0] Add Publisher and Devportal UI Restrictions for Federated Gateway Types

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -446,7 +446,7 @@ class ApiConsole extends React.Component {
             securitySchemeType, username, password, productionAccessToken, sandboxAccessToken, selectedKeyType,
             productionApiKey, sandboxApiKey, api, advAuthHeaderValue,
         } = this.state;
-        if (api.advertiseInfo && api.advertiseInfo.advertised) {
+        if ((api.advertiseInfo && api.advertiseInfo.advertised) || api.gatewayVendor !== 'wso2') {
             return advAuthHeaderValue;
         }
         if (securitySchemeType === 'BASIC') {
@@ -556,7 +556,8 @@ class ApiConsole extends React.Component {
             <Root>
                 <Paper className={classes.paper}>
                     <Grid container className={classes.grid}>
-                        {!user && (!api.advertiseInfo || !api.advertiseInfo.advertised) && (
+                        {!user && (!api.advertiseInfo || !api.advertiseInfo.advertised)
+                            && api.gatewayVendor !== 'wso2' && (
                             <Grid item md={6}>
                                 <Paper className={classes.userNotificationPaper}>
                                     <Typography variant='h5' component='h3'>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GoToTryOut.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GoToTryOut.jsx
@@ -250,6 +250,7 @@ export default function GoToTryOut() {
     if (!defaultApplication
         || subscribedApplications.length > 0
         || api.advertiseInfo.advertised
+        || api.gatewayVendor !== 'wso2'
         || !user
         || isAsyncAPI
         || isPrototypedAPI) {

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -587,7 +587,7 @@ class DetailsLegacy extends React.Component {
                                 open={open}
                                 id='left-menu-overview'
                             />
-                            {user && showCredentials && !isSubValidationDisabled && (
+                            {user && showCredentials && !isSubValidationDisabled && api.gatewayVendor === 'wso2' && (
                                 <>
 
                                     <LeftMenuItem
@@ -606,7 +606,7 @@ class DetailsLegacy extends React.Component {
 
                                 </>
                             )}
-                            {showTryout && (api.gatewayVendor === 'wso2'
+                            {showTryout && (api.gatewayType !== 'wso2/apk'
                                 || (api.type === 'APIPRODUCT' && !api.gatewayVendor)) && (
                                 <>
                                     <Accordion
@@ -665,7 +665,8 @@ class DetailsLegacy extends React.Component {
                                                     open={open}
                                                     id='left-menu-test'
                                                 />
-                                                {api.type !== CONSTANTS.API_TYPES.GRAPHQL && !isAsyncApi && apiChatEnabled && (
+                                                {api.type !== CONSTANTS.API_TYPES.GRAPHQL && !isAsyncApi
+                                                    && apiChatEnabled && api.gatewayVendor === 'wso2' && (
                                                     <LeftMenuItem
                                                         text={(
                                                             <FormattedMessage

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/AdvertiseDetailsPanel.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/AdvertiseDetailsPanel.jsx
@@ -38,6 +38,7 @@ const AdvertiseDetailsPanel = (props) => {
             transport,
             securityScheme,
             authorizationHeader,
+            gatewayVendor,
         },
     } = props;
 
@@ -112,59 +113,61 @@ const AdvertiseDetailsPanel = (props) => {
                     />
                 </Grid>
             </Grid>
-            <Grid x={12} md={6} className={classes.centerItems}>
-                <Typography
-                    variant='h6'
-                    component='label'
-                    id='key-type'
-                    color='textSecondary'
-                    className={classes.tryoutHeading}
-                >
-                    <FormattedMessage
-                        id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint.heading'
-                        defaultMessage='API Endpoint'
-                    />
-                </Typography>
-                <TextField
-                    fullWidth
-                    select
-                    id='selectedEndpoint'
-                    label={(
+            {gatewayVendor === 'wso2' &&
+                <Grid x={12} md={6} className={classes.centerItems}>
+                    <Typography
+                        variant='h6'
+                        component='label'
+                        id='key-type'
+                        color='textSecondary'
+                        className={classes.tryoutHeading}
+                    >
                         <FormattedMessage
-                            defaultMessage='Endpoint type'
-                            id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint'
+                            id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint.heading'
+                            defaultMessage='API Endpoint'
                         />
-                    )}
-                    value={selectedEndpoint}
-                    name='selectedEndpoint'
-                    onChange={handleChanges}
-                    helperText={(
-                        <FormattedMessage
-                            defaultMessage='Please select an endpoint type'
-                            id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint.help'
-                        />
-                    )}
-                    margin='normal'
-                    variant='outlined'
-                >
-                    {advertiseInfo.apiExternalProductionEndpoint && (
-                        <MenuItem
-                            value='PRODUCTION'
-                            className={classes.menuItem}
-                        >
-                            Production
-                        </MenuItem>
-                    )}
-                    {advertiseInfo.apiExternalSandboxEndpoint && (
-                        <MenuItem
-                            value='SANDBOX'
-                            className={classes.menuItem}
-                        >
-                            Sandbox
-                        </MenuItem>
-                    )}
-                </TextField>
-            </Grid>
+                    </Typography>
+                    <TextField
+                        fullWidth
+                        select
+                        id='selectedEndpoint'
+                        label={(
+                            <FormattedMessage
+                                defaultMessage='Endpoint type'
+                                id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint'
+                            />
+                        )}
+                        value={selectedEndpoint}
+                        name='selectedEndpoint'
+                        onChange={handleChanges}
+                        helperText={(
+                            <FormattedMessage
+                                defaultMessage='Please select an endpoint type'
+                                id='Apis.Details.ApiConsole.AdvertiseDetailsPanel.endpoint.help'
+                            />
+                        )}
+                        margin='normal'
+                        variant='outlined'
+                    >
+                        {advertiseInfo.apiExternalProductionEndpoint && (
+                            <MenuItem
+                                value='PRODUCTION'
+                                className={classes.menuItem}
+                            >
+                                Production
+                            </MenuItem>
+                        )}
+                        {advertiseInfo.apiExternalSandboxEndpoint && (
+                            <MenuItem
+                                value='SANDBOX'
+                                className={classes.menuItem}
+                            >
+                                Sandbox
+                            </MenuItem>
+                        )}
+                    </TextField>
+                </Grid>
+            }
             {(availableTransports || securitySchemes || authorizationHeader) && (
                 <Grid x={12} md={6} className={classes.centerItems} style={{ marginTop: '10px' }}>
                     <MuiAlert severity='info' variant='filled' sx={{ bgcolor: 'background.paper' }}>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
@@ -602,7 +602,8 @@ function TryOutController(props) {
         <Root>
             <Grid x={12} md={6} className={classes.centerItems}>
                 <Box>
-                    {securitySchemeType !== 'TEST' && (!api.advertiseInfo || !api.advertiseInfo.advertised) && (
+                    {securitySchemeType !== 'TEST' && (!api.advertiseInfo || !api.advertiseInfo.advertised) 
+                        && api.gatewayVendor === 'wso2' && (
                         <>
                             <Box mb={1}>
                                 <Typography variant='body1'>
@@ -638,7 +639,7 @@ function TryOutController(props) {
                         </>
                     )}
                     {((isApiKeyEnabled || isBasicAuthEnabled || isOAuthEnabled) && showSecurityType)
-                        && (!api.advertiseInfo || !api.advertiseInfo.advertised) && (
+                        && (!api.advertiseInfo || !api.advertiseInfo.advertised) && api.gatewayVendor === 'wso2' && (
                         <>
                             <Typography variant='h5' component='h2' color='textPrimary' className={classes.categoryHeading}>
                                 <FormattedMessage
@@ -714,6 +715,7 @@ function TryOutController(props) {
                         || (subscriptions.length > 0 && !isSubValidationDisabled))
                         && securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
                         && (!api.advertiseInfo || !api.advertiseInfo.advertised)
+                        && api.gatewayVendor === 'wso2'
                         && (
                             <SelectAppPanel
                                 subscriptions={subscriptions}
@@ -726,7 +728,7 @@ function TryOutController(props) {
                             />
                         )}
                     {subscriptions && subscriptions.length === 0 && securitySchemeType !== 'TEST'
-                    && securitySchemeType !== 'BASIC'
+                    && securitySchemeType !== 'BASIC' && api.gatewayVendor === 'wso2'
                         && (!api.advertiseInfo || !api.advertiseInfo.advertised) && !isSubValidationDisabled ? (
                             <Grid x={8} md={6} className={classes.tokenType} item>
                                 <Box mb={1} alignItems='center'>
@@ -745,7 +747,7 @@ function TryOutController(props) {
                             </Grid>
                         ) : (
                             (!ksGenerated && securitySchemeType === 'OAUTH') && (!api.advertiseInfo
-                                || !api.advertiseInfo.advertised) && (
+                                || !api.advertiseInfo.advertised) && api.gatewayVendor === 'wso2' && (
                                 <Grid x={8} md={6} className={classes.tokenType} item>
                                     <Box mb={1} alignItems='center'>
                                         <Typography variant='body1'>
@@ -765,7 +767,7 @@ function TryOutController(props) {
                                 </Grid>
                             )
                         )}
-                    {(!api.advertiseInfo || !api.advertiseInfo.advertised) ? (
+                    {((!api.advertiseInfo || !api.advertiseInfo.advertised) && api.gatewayVendor === 'wso2') ? (
                         <Box display='block' justifyContent='center'>
                             <Grid x={8} md={6} className={classes.tokenType} item>
                                 {securitySchemeType === 'BASIC' && (
@@ -929,7 +931,7 @@ function TryOutController(props) {
                             api={api}
                         />
                     )}
-                    {(!api.advertiseInfo || !api.advertiseInfo.advertised) && (
+                    {(!api.advertiseInfo || !api.advertiseInfo.advertised) && api.gatewayVendor === 'wso2' && (
                         <Box display='flex' justifyContent='center' className={classes.gatewayEnvironment}>
                             <Grid xs={12} md={6} item>
                                 {(environments && environments.length > 0) && (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy} from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import Progress from 'AppComponents/Shared/Progress';
 import AuthManager from 'AppData/AuthManager';
@@ -73,7 +73,7 @@ const Apis = () => {
                     }
                 }}
             />
-            <Route path='/apis/:apiUUID/' render={(props) => <DeferredDetails {...props} isAPIProduct={false} />} />
+            <Route path='/apis/:apiUUID/' render={(props) =><DeferredDetails {...props} isAPIProduct={false} />} />
             <Route
                 path='/api-products/:apiProdUUID/'
                 render={(props) => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AIAPI/APICreateAIAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AIAPI/APICreateAIAPI.jsx
@@ -21,7 +21,6 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
@@ -80,7 +79,6 @@ function apiInputsReducer(currentState, inputAction) {
 export default function ApiCreateAIAPI(props) {
     const [wizardStep, setWizardStep] = useState(0);
     const { history, multiGateway } = props;
-    const { data: settings } = usePublisherSettings();
 
     const [apiInputs, inputsDispatcher] = useReducer(apiInputsReducer, {
         type: 'ApiCreateAIAPI',
@@ -124,20 +122,12 @@ export default function ApiCreateAIAPI(props) {
         const {
             name, version, context, endpoint, gatewayType, policies = ["Unlimited"], inputValue, llmProviderId,
         } = apiInputs;
-        let defaultGatewayType;
-        if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('Regular')) {
-            defaultGatewayType = 'wso2/synapse';
-        } else if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('APK')) {
-            defaultGatewayType = 'wso2/apk';
-        } else {
-            defaultGatewayType = 'default';
-        }
 
         const additionalProperties = {
             name,
             version,
             context,
-            gatewayType: defaultGatewayType === 'default' ? gatewayType : defaultGatewayType,
+            gatewayType,
             policies,
             subtypeConfiguration: {
                 subtype: 'AIAPI',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -15,11 +15,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { Route, Switch } from 'react-router-dom';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
 import APICreateDefault from './Default/APICreateDefault';
 import APIProductCreateWrapper from './APIProduct/APIProductCreateWrapper';
 import ApiCreateSwagger from './OpenAPI/ApiCreateOpenAPI';
@@ -42,6 +43,27 @@ const Root = styled('div')({
     },
 });
 
+const gatewayDetails = {
+    'wso2/synapse': { 
+        value: 'wso2/synapse',
+        name: 'Regular Gateway', 
+        description: 'API gateway embedded in APIM runtime. Connect directly to APIM.', 
+        isNew: false 
+    },
+    'wso2/apk': { 
+        value: 'wso2/apk',
+        name: 'APK Gateway', 
+        description: 'Fast API gateway on Kubernetes. Manages and secures APIs.', 
+        isNew: false 
+    },
+    'AWS': { 
+        value: 'AWS',
+        name: 'AWS Gateway', 
+        description: 'API gateway offering from AWS cloud to secures APIs efficiently.', 
+        isNew: true 
+    }
+};
+
 // Wrapper component to pass additional props
 const WithSomeValue = (Component, additionalProps) => (routeProps) => (
     <Component {...routeProps} {...additionalProps} />
@@ -54,41 +76,64 @@ const WithSomeValue = (Component, additionalProps) => (routeProps) => (
  * @returns @inheritdoc
  */
 function APICreateRoutes() {
-    const { data: settings } = usePublisherSettings();
-    const [gateway, setGatewayType] = useState(false);
-    
-    const getGatewayType = () => {
-        if (settings != null) {
-            if (settings.gatewayTypes && settings.gatewayTypes.length === 2 ) {
-                setGatewayType(true);
-            } else {
-                setGatewayType(false);
-            }
-        }
-    };
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
+    const [apiTypes, setApiTypes] = useState(null);
+    const [gatewayTypes, setGatewayTypes] = useState(null);
 
     useEffect(() => {
-        getGatewayType();
-    }, [settings]);
+        if (!isLoading) {
+            setApiTypes(publisherSettings.gatewayFeatureCatalog.apiTypes);
+            const data = publisherSettings.gatewayTypes;
+            const updatedData = data.map(item => {
+                if (item === "Regular") return "wso2/synapse";
+                if (item === "APK") return "wso2/apk";
+                return item;
+            });
+            setGatewayTypes(updatedData);
+        }
+    }, [isLoading]);
+
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     
     return (
         <Root className={classes.content}>
             <Switch>
-                <Route path='/apis/create/rest' component={WithSomeValue(APICreateDefault, { multiGateway: gateway })}/>
+                <Route path='/apis/create/rest' component={WithSomeValue(APICreateDefault, 
+                    { multiGateway: apiTypes?.rest
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
                 <Route path='/api-products/create' component={APIProductCreateWrapper} />
                 <Route path='/apis/create/graphQL' component={WithSomeValue(ApiCreateGraphQL,
-                    { multiGateway: gateway })}
+                    { multiGateway: apiTypes?.graphql
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
                 />
                 <Route path='/apis/create/openapi' component={WithSomeValue(ApiCreateSwagger,
-                    { multiGateway: gateway })}
+                    { multiGateway: apiTypes?.rest
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
                 />
-                <Route path='/apis/create/wsdl' component={ApiCreateWSDL} />
+                <Route path='/apis/create/wsdl' component={WithSomeValue(ApiCreateWSDL,
+                    { multiGateway: apiTypes?.soap
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
                 {/* TODO: Remove ApiCreateWebSocket components and associated routes */}
-                <Route path='/apis/create/ws' component={ApiCreateWebSocket} />
-                <Route path='/apis/create/streamingapi/:apiType' component={APICreateStreamingAPI} />
-                <Route path='/apis/create/asyncapi' component={APICreateAsyncAPI} />
+                <Route path='/apis/create/ws' component={WithSomeValue(ApiCreateWebSocket,
+                    { multiGateway: apiTypes?.ws
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
+                <Route path='/apis/create/streamingapi/:apiType' component={WithSomeValue(APICreateStreamingAPI,
+                    { multiGateway: apiTypes?.ws
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
+                <Route path='/apis/create/asyncapi' component={WithSomeValue(APICreateAsyncAPI,
+                    { multiGateway: apiTypes?.ws
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
                 <Route path='/apis/create/ai-api' component={WithSomeValue(ApiCreateAIAPI,
-                    { multiGateway: gateway })}/>
+                    { multiGateway: apiTypes?.ai
+                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                />
                 <Route component={ResourceNotFound} />
             </Switch>
         </Root>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AsyncAPI/ApiCreateAsyncAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/AsyncAPI/ApiCreateAsyncAPI.jsx
@@ -81,7 +81,7 @@ const StyledAPICreateBase = styled(APICreateBase)((
  */
 export default function ApiCreateAsyncAPI(props) {
     const [wizardStep, setWizardStep] = useState(0);
-    const { history } = props;
+    const { history, multiGateway } = props;
     // eslint-disable-next-line no-use-before-define
 
     const [hideEndpoint, setHideEndpoint] = useState(true);
@@ -355,6 +355,7 @@ export default function ApiCreateAsyncAPI(props) {
                             hideEndpoint={hideEndpoint}
                             endpointPlaceholderText='Streaming Provider'
                             appendChildrenBeforeEndpoint
+                            multiGateway={multiGateway}
                         >
                             <Grid container spacing={2}>
                                 {apiInputs.gatewayVendor === 'solace'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -20,7 +20,7 @@ import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
-import { InputAdornment, IconButton, Icon } from '@mui/material';
+import { InputAdornment, IconButton, Icon, RadioGroup, FormControlLabel, Radio } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
@@ -29,9 +29,6 @@ import APIValidation from 'AppData/APIValidation';
 import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormLabel from '@mui/material/FormLabel';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import API from 'AppData/api';
 import { green } from '@mui/material/colors';
 
@@ -655,7 +652,7 @@ export default function DefaultAPIForm(props) {
                         }}
                     />
                 )}
-                {multiGateway  &&
+                {multiGateway && multiGateway.length > 1 && 
                     <Grid container spacing={2}>
                         <FormControl component='fieldset'>
                             <FormLabel sx={{ marginLeft: '15px', marginTop: '20px' }}>
@@ -671,61 +668,30 @@ export default function DefaultAPIForm(props) {
                                 value={api.gatewayType}
                                 onChange={onChange}
                             >
-                                <Grid item xs={6}>
-                                    <FormControlLabel
-                                        value='wso2/synapse'
-                                        className={classes.radioOutline}
-                                        control={<Radio />}
-                                        label={(
-                                            <div>
-                                                <span>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'regular.gateway.type'}
-                                                        defaultMessage='Regular Gateway'
-                                                    />
-                                                </span>
-                                                <Typography variant='body2' color='textSecondary'>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'regular.gateway.type.text'}
-                                                        defaultMessage={'API gateway embedded in APIM '
-                                                            + 'runtime. Connect directly APIManager.'}
-                                                    />
-                                                </Typography>
-                                            </div>
-                                        )}
-                                        sx={{ border: getBorderColor('wso2/synapse') }}
-                                    />
-                                </Grid>
-                                <Grid item xs={6}>
-                                    <FormControlLabel
-                                        value='wso2/apk'
-                                        className={classes.radioOutline}
-                                        control={<Radio />}
-                                        label={(
-                                            <div>
-                                                <span>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'apk.gateway.type'}
-                                                        defaultMessage='APK Gateway'
-                                                    />
-                                                </span>
-                                                <span className={`${classes.label} ${classes.newLabel}`}>New</span>
-                                                <Typography variant='body2' color='textSecondary'>
-                                                    <FormattedMessage
-                                                        id={'Apis.Create.Components.DefaultAPIForm.'
-                                                            + 'apk.gateway.type.text'}
-                                                        defaultMessage={'Fast API gateway running on kubernetes'
-                                                            + ' designed to manage and secure APIs.'}
-                                                    />
-                                                </Typography>
-                                            </div>
-                                        )}
-                                        sx={{ border: getBorderColor('wso2/apk') }}
-                                    />
-                                </Grid>
+                                {multiGateway.map((gateway) =>
+                                    <Grid item xs={Math.floor(12 / multiGateway.length)} key={gateway.value} >
+                                        <FormControlLabel
+                                            value={gateway.value}
+                                            className={classes.radioOutline}
+                                            control={<Radio />}
+                                            label={(
+                                                <div>
+                                                    <span>
+                                                        {gateway.name}
+                                                    </span>
+                                                    {gateway.isNew && (
+                                                        <span className={`${classes.label} 
+                                                            ${classes.newLabel}`}>New</span>
+                                                    )}
+                                                    <Typography variant='body2' color='textSecondary'>
+                                                        {gateway.description}
+                                                    </Typography>
+                                                </div>
+                                            )}
+                                            sx={{ border: getBorderColor(gateway.value) }}
+                                        />
+                                    </Grid>
+                                )}
                             </RadioGroup>
                             <FormHelperText sx={{ marginLeft: '15px' }}><FormattedMessage
                                 id={'Apis.Create.Components.DefaultAPIForm.'
@@ -735,7 +701,7 @@ export default function DefaultAPIForm(props) {
                             </FormHelperText>
                         </FormControl>
                     </Grid>
-                }   
+                }
                 {!appendChildrenBeforeEndpoint && !!children && children}
             </form>
             <Grid container direction='row' justifyContent='flex-end' alignItems='center'>
@@ -762,7 +728,7 @@ DefaultAPIForm.defaultProps = {
 };
 DefaultAPIForm.propTypes = {
     api: PropTypes.shape({}),
-    multiGateway: PropTypes.string.isRequired,
+    multiGateway: PropTypes.isRequired,
     isAPIProduct: PropTypes.shape({}).isRequired,
     isWebSocket: PropTypes.shape({}),
     onChange: PropTypes.func.isRequired,

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
@@ -37,6 +37,11 @@ import APIProduct from 'AppData/APIProduct';
 import AuthManager from 'AppData/AuthManager';
 import Progress from 'AppComponents/Shared/Progress';
 
+const gatewayTypeMap = {
+    'Regular': 'wso2/synapse',
+    'APK': 'wso2/apk',
+    'AWS': 'AWS',
+}
 
 const getPolicies = async () => {
     const promisedPolicies = API.policies('subscription');
@@ -62,31 +67,7 @@ function APICreateDefault(props) {
     const { data: settings, isLoading, error: settingsError } = usePublisherSettings();
     const [isAvailbaleGateway, setIsAvailableGateway] = useState(false);
     const [pageError, setPageError] = useState(null);
-    useEffect(() => {
-        if (settingsError) {
-            setPageError(settingsError.message);
-        }
-    }, [settingsError]);
 
-    useEffect(() => {
-        if (settings != null) {
-            if (settings.gatewayTypes && settings.gatewayTypes.length === 1) {
-                for (const env of settings.environment) {
-                    if (env.gatewayType === settings.gatewayTypes[0]) {
-                        setIsAvailableGateway(true);
-                        break;
-                    }
-                }
-            }
-        }
-    }, [settings]);
-    const [isCreating, setIsCreating] = useState();
-    const [isPublishing, setIsPublishing] = useState(false);
-
-    const [isRevisioning, setIsRevisioning] = useState(false);
-    const [isDeploying, setIsDeploying] = useState(false);
-    const [isMandatoryPropsConfigured, setIsMandatoryPropsConfigured] = useState(false);
-    const [isPublishButtonClicked, setIsPublishButtonClicked] = useState(false);
     /**
      *
      * Reduce the events triggered from API input fields to current state
@@ -107,7 +88,35 @@ function APICreateDefault(props) {
     }
     const [apiInputs, inputsDispatcher] = useReducer(apiInputsReducer, {
         formValidity: false,
+        gatewayType: 'wso2/synapse',
     });
+
+    useEffect(() => {
+        if (settingsError) {
+            setPageError(settingsError.message);
+        }
+    }, [settingsError]);
+
+    useEffect(() => {
+        if (settings != null) {
+            if (settings.gatewayTypes && settings.gatewayTypes.includes('Regular')) {
+                for (const env of settings.environment) {
+                    if (env.gatewayType === 'Regular') {
+                        setIsAvailableGateway(true);
+                        break;
+                    }
+                }
+            }
+        }
+    }, [isLoading]);
+    const [isCreating, setIsCreating] = useState();
+    const [isPublishing, setIsPublishing] = useState(false);
+
+    const [isRevisioning, setIsRevisioning] = useState(false);
+    const [isDeploying, setIsDeploying] = useState(false);
+    const [isMandatoryPropsConfigured, setIsMandatoryPropsConfigured] = useState(false);
+    const [isPublishButtonClicked, setIsPublishButtonClicked] = useState(false);
+
     const isPublishable = apiInputs.endpoint;
     const isAPICreateDisabled = !(apiInputs.name && apiInputs.version && apiInputs.context) || isCreating
                                  || isPublishing;
@@ -120,19 +129,15 @@ function APICreateDefault(props) {
     function handleOnChange(event) {
         const { name: action, value } = event.target;
         inputsDispatcher({ action, value });
-        const settingsEnvList = settings && settings.environment;
-        if (settings && settings.gatewayTypes.length === 2 && (value === 'wso2/synapse' || value === 'wso2/apk')) {
-            for (const env of settingsEnvList) {
-                let tmpEnv = '';
-                if (env.gatewayType === 'APK') {
-                    tmpEnv = 'wso2/apk';
-                } else if (env.gatewayType === 'Regular') {
-                    tmpEnv = 'wso2/synapse';
-                }
-                if (tmpEnv === value) {
-                    setIsAvailableGateway(true);
-                    break;
-                } else {
+        if (action === 'gatewayType') {
+            const settingsEnvList = settings && settings.environment;
+            if (settings && settings.gatewayTypes.length >= 2 && Object.values(gatewayTypeMap).includes(value)) {
+                for (const env of settingsEnvList) {
+                    const tmpEnv = gatewayTypeMap[env.gatewayType];
+                    if (tmpEnv === value) {
+                        setIsAvailableGateway(true);
+                        break;
+                    }
                     setIsAvailableGateway(false);
                 }
             }
@@ -176,7 +181,6 @@ function APICreateDefault(props) {
         } = apiInputs;
         let promisedCreatedAPI;
         let policies;
-        let defaultGatewayType;
         const allPolicies = await getPolicies();
         if (allPolicies.length === 0) {
             Alert.info(intl.formatMessage({
@@ -188,19 +192,12 @@ function APICreateDefault(props) {
         } else {
             policies = [allPolicies[0].name];
         }
-        if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('Regular')) {
-            defaultGatewayType = 'wso2/synapse';
-        } else if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('APK')){
-            defaultGatewayType = 'wso2/apk';
-        } else {
-            defaultGatewayType = 'default';
-        }
 
         const apiData = {
             name,
             version,
             context,
-            gatewayType: defaultGatewayType === 'default' ? gatewayType : defaultGatewayType,
+            gatewayType,
             policies,
         };
         if (endpoint) {
@@ -311,8 +308,7 @@ function APICreateDefault(props) {
                 setIsRevisioning(false);
                 const envList = settings.environment.map((env) => env.name);
                 const body1 = [];
-                const internalGateways = settings.environment.filter((p) => p.provider
-                        && p.provider.toLowerCase().includes('wso2'));
+                const internalGateways = settings.environment;
                 const getFirstVhost = (envName) => {
                     const env = internalGateways.find(
                         (e) => e.name === envName && e.vhosts.length > 0,
@@ -339,12 +335,7 @@ function APICreateDefault(props) {
                     const envList1 = settings.environment;
                     let foundEnv = false;
                     envList1.forEach((env) => {
-                        let tmpEnv = '';
-                        if (env.gatewayType === 'APK') {
-                            tmpEnv = 'wso2/apk';
-                        } else if (env.gatewayType === 'Regular') {
-                            tmpEnv = 'wso2/synapse';
-                        }
+                        const tmpEnv = gatewayTypeMap[env.gatewayType];
                         if (!foundEnv && tmpEnv === apiInputs.gatewayType && getFirstVhost(env.name)) {
                             body1.push({
                                 name: env.name,
@@ -633,7 +624,7 @@ APICreateDefault.WORKFLOW_STATUS = {
 };
 APICreateDefault.propTypes = {
     history: PropTypes.shape({ push: PropTypes.func }).isRequired,
-    multiGateway: PropTypes.string.isRequired,
+    multiGateway: PropTypes.isRequired,
     isAPIProduct: PropTypes.shape({}),
     isWebSocket: PropTypes.shape({}),
     intl: PropTypes.shape({

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/GraphQL/ApiCreateGraphQL.jsx
@@ -31,7 +31,6 @@ import Alert from 'AppComponents/Shared/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import DefaultAPIForm from 'AppComponents/Apis/Create/Components/DefaultAPIForm';
 import APICreateBase from 'AppComponents/Apis/Create/Components/APICreateBase';
-import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 
 import ProvideGraphQL from './Steps/ProvideGraphQL';
 
@@ -47,7 +46,6 @@ export default function ApiCreateGraphQL(props) {
     const { multiGateway } = props;
     const [wizardStep, setWizardStep] = useState(0);
     const history = useHistory();
-    const { data: settings } = usePublisherSettings();
     const [policies, setPolicies] = useState([]);
 
     useEffect(() => {
@@ -152,20 +150,11 @@ export default function ApiCreateGraphQL(props) {
             graphQLInfo: { operations },
         } = apiInputs;
 
-        let defaultGatewayType;
-        if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('Regular')) {
-            defaultGatewayType = 'wso2/synapse';
-        } else if (settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('APK')){
-            defaultGatewayType = 'wso2/apk';
-        } else {
-            defaultGatewayType = 'default';
-        }
-
         const additionalProperties = {
             name,
             version,
             context,
-            gatewayType: defaultGatewayType === 'default' ? gatewayType : defaultGatewayType,
+            gatewayType,
             policies,
             operations,
         };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -54,7 +54,7 @@ const StyledAPICreateBase = styled(APICreateBase)((
 
 const APICreateStreamingAPI = (props) => {
     // const theme = useTheme();
-    const { history } = props;
+    const { history, multiGateway } = props;
     const intl = useIntl();
     const { data: settings, isLoading, error: settingsError } = usePublisherSettings();
     const [pageError, setPageError] = useState(null);
@@ -437,6 +437,7 @@ const APICreateStreamingAPI = (props) => {
                         endpointPlaceholderText='Streaming Provider'
                         appendChildrenBeforeEndpoint
                         hideEndpoint={hideEndpoint}
+                        multiGateway={multiGateway}
                         isWebSocket={(apiType && apiType === protocolKeys.WebSocket)
                             || apiInputs.protocol === protocolKeys.WebSocket}
                     >

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WSDL/ApiCreateWSDL.jsx
@@ -47,7 +47,7 @@ import ProvideWSDL from './Steps/ProvideWSDL';
 export default function ApiCreateWSDL(props) {
     const intl = useIntl();
     const [wizardStep, setWizardStep] = useState(0);
-    const { history } = props;
+    const { history, multiGateway } = props;
     const [policies, setPolicies] = useState([]);
 
     useEffect(() => {
@@ -255,6 +255,7 @@ export default function ApiCreateWSDL(props) {
                             onChange={handleOnChange}
                             api={apiInputs}
                             isAPIProduct={false}
+                            multiGateway={multiGateway}
                         />
                     )}
                 </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WebSocket/ApiCreateWebSocket.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/WebSocket/ApiCreateWebSocket.jsx
@@ -16,7 +16,9 @@
 import React from 'react';
 import APICreateDefault from 'AppComponents/Apis/Create/Default/APICreateDefault';
 
-const ApiCreateWebSocket = () => {
-    return (<APICreateDefault isWebSocket />);
+const ApiCreateWebSocket = (props) => {
+    const {multiGateway} = props;
+
+    return (<APICreateDefault multiGateway={multiGateway} isWebSocket />);
 };
 export default ApiCreateWebSocket;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -807,7 +807,9 @@ export default function DesignConfigurations() {
                                         />
                                     </Box>
                                     <Box py={1}>
-                                        {api.apiType !== API.CONSTS.APIProduct && (
+                                        {api.apiType !== API.CONSTS.APIProduct &&
+                                            settings && settings.gatewayFeatureCatalog
+                                            .gatewayFeatures[api.gatewayType].basic.includes("advertised") && (
                                             <AdvertiseInfo
                                                 oldApi={api}
                                                 api={apiConfig}
@@ -817,12 +819,14 @@ export default function DesignConfigurations() {
                                             />
                                         )}
                                     </Box>
-                                    { settings && !settings.portalConfigurationOnlyModeEnabled && (
-                                        <Box py={1}>
-                                            <DefaultVersion
-                                                api={apiConfig} configDispatcher={configDispatcher} />
-                                        </Box>
-                                    )}
+                                    { settings && !settings.portalConfigurationOnlyModeEnabled &&
+                                        settings.gatewayFeatureCatalog.gatewayFeatures[api.gatewayType]
+                                            .basic.includes("defaultVersion") &&
+                                            <Box py={1}>
+                                                <DefaultVersion api={apiConfig}
+                                                    configDispatcher={configDispatcher} />
+                                            </Box>
+                                    }
                                     <Box pt={2}>
                                         <Button
                                             disabled={

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfigurationWebSocket.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfigurationWebSocket.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useReducer, useContext, useState } from 'react';
+import React, { useReducer, useContext, useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
@@ -38,6 +38,7 @@ import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import CustomSplitButton from 'AppComponents/Shared/CustomSplitButton';
 import { isRestricted } from 'AppData/AuthManager';
 import API from 'AppData/api';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import Endpoints from './components/Endpoints';
 import KeyManager from './components/KeyManager';
 import APILevelRateLimitingPolicies from './components/APILevelRateLimitingPolicies';
@@ -242,6 +243,15 @@ export default function RuntimeConfiguration() {
     const [isUpdating, setIsUpdating] = useState(false);
     const history = useHistory();
     const [apiConfig, configDispatcher] = useReducer(configReducer, copyAPIConfig(api));
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
+    const [endpointSecurity, setEndpointSecurity] = useState([]);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setEndpointSecurity(publisherSettings.gatewayFeatureCatalog
+                .gatewayFeatures[api.gatewayType].endpoints);
+        }
+    }, [isLoading]);
 
 
     const Validate = () => {
@@ -376,7 +386,7 @@ export default function RuntimeConfiguration() {
                         <Paper className={classes.paper} sx={{ height: 'calc(100% - 75px)' }} elevation={0}>
                             {!api.isAPIProduct() && (
                                 <>
-                                    <Endpoints api={api} />
+                                    <Endpoints api={api} endpointSecurity={endpointSecurity} />
                                 </>
                             )}
                         </Paper>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/Topics.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/Topics.jsx
@@ -54,6 +54,7 @@ export default function Topics(props) {
     const {
         disableUpdate,
         disableAddOperation,
+        componentValidator,
     } = props;
 
     const [api, updateAPI] = useAPI();
@@ -541,6 +542,7 @@ export default function Topics(props) {
                                                         && markedOperations[target].subscribe)}
                                                 onMarkAsDelete={onMarkAsDelete}
                                                 disableDelete={api.gatewayVendor === 'solace'}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}
@@ -559,6 +561,7 @@ export default function Topics(props) {
                                                         && markedOperations[target].publish)}
                                                 onMarkAsDelete={onMarkAsDelete}
                                                 disableDelete={api.gatewayVendor === 'solace'}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/APISecurity.jsx
@@ -67,6 +67,7 @@ export default function APISecurity(props) {
         api: { securityScheme, id },
         configDispatcher,
         api,
+        componentValidator,
     } = props;
     const apiContext = useContext(ApiContext);
     const isAPIProduct = apiContext.api.apiType === API.CONSTS.APIProduct;
@@ -133,24 +134,32 @@ export default function APISecurity(props) {
                 {(isAPIProduct || (!isEndpointAvailable || (isEndpointAvailable && !isPrototyped)))
                 && (
                     <>
-                        <Grid item xs={12}>
-                            <TransportLevel
-                                haveMultiLevelSecurity={haveMultiLevelSecurity}
-                                securityScheme={securityScheme}
-                                configDispatcher={configDispatcher}
-                                api={api}
-                                id={id}
-                            />
-                        </Grid>
-                        <Grid item xs={12}>
-                            <ApplicationLevel
-                                haveMultiLevelSecurity={haveMultiLevelSecurity}
-                                securityScheme={securityScheme}
-                                api={api}
-                                configDispatcher={configDispatcher}
-                                id={id}
-                            />
-                        </Grid>
+                        {["transportsHTTP", "transportsHTTPS", "transportsMutualSSL"].some(transport =>
+                            componentValidator?.includes(transport)) &&
+                            <Grid item xs={12}>
+                                <TransportLevel
+                                    haveMultiLevelSecurity={haveMultiLevelSecurity}
+                                    securityScheme={securityScheme}
+                                    configDispatcher={configDispatcher}
+                                    api={api}
+                                    id={id}
+                                    componentValidator={componentValidator}
+                                />
+                            </Grid>
+                        }
+                        {["oauth2", "apikey", "basicAuth", "keyManagerConfig"].some(authType =>
+                            componentValidator?.includes(authType)) &&
+                            <Grid item xs={12}>
+                                <ApplicationLevel
+                                    haveMultiLevelSecurity={haveMultiLevelSecurity}
+                                    securityScheme={securityScheme}
+                                    api={api}
+                                    configDispatcher={configDispatcher}
+                                    id={id}
+                                    componentValidator={componentValidator}
+                                />
+                            </Grid>
+                        }
                         <Grid item xs={12}>
                             <span className={classes.error}>
                                 <Validate />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/ApplicationLevel.jsx
@@ -102,7 +102,7 @@ const Root = styled('div')((
  */
 export default function ApplicationLevel(props) {
     const {
-        haveMultiLevelSecurity, securityScheme, configDispatcher, api,
+        haveMultiLevelSecurity, securityScheme, configDispatcher, api, componentValidator
     } = props;
     const [apiFromContext] = useAPI();
     const [oauth2Enabled, setOauth2Enabled] = useState(securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2));
@@ -191,29 +191,31 @@ export default function ApplicationLevel(props) {
                     </AccordionSummary>
                     <AccordionDetails className={classes.expansionPanelDetails}>
                         <FormGroup style={{ display: 'flow-root' }}>
-                            <FormControlLabel
-                                control={(
-                                    <Checkbox
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                        checked={securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2)}
-                                        onChange={({ target: { checked, value } }) => {
-                                            setOauth2Enabled(checked);
-                                            configDispatcher({
-                                                action: 'securityScheme',
-                                                event: { checked, value },
-                                            });
-                                        }}
-                                        value={DEFAULT_API_SECURITY_OAUTH2}
-                                        color='primary'
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
-                                        + 'ApplicationLevel.security.scheme.oauth2',
-                                    defaultMessage: 'OAuth2',
-                                })}
-                            />
-                            {(apiFromContext.gatewayType === 'wso2/synapse' ||
+                            {componentValidator.includes('oauth2') && 
+                                <FormControlLabel
+                                    control={(
+                                        <Checkbox
+                                            disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            checked={securityScheme.includes(DEFAULT_API_SECURITY_OAUTH2)}
+                                            onChange={({ target: { checked, value } }) => {
+                                                setOauth2Enabled(checked);
+                                                configDispatcher({
+                                                    action: 'securityScheme',
+                                                    event: { checked, value },
+                                                });
+                                            }}
+                                            value={DEFAULT_API_SECURITY_OAUTH2}
+                                            color='primary'
+                                        />
+                                    )}
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
+                                            + 'ApplicationLevel.security.scheme.oauth2',
+                                        defaultMessage: 'OAuth2',
+                                    })}
+                                />
+                            }
+                            {(componentValidator.includes('basicAuth') ||
                                 apiFromContext.apiType === API.CONSTS.APIProduct) && (
                                 <FormControlLabel
                                     control={(
@@ -236,28 +238,31 @@ export default function ApplicationLevel(props) {
                                     })}
                                 />
                             )}
-                            <FormControlLabel
-                                control={(
-                                    <Checkbox
-                                        checked={securityScheme.includes(API_SECURITY_API_KEY)}
-                                        disabled={
-                                            isRestricted(['apim:api_create'], apiFromContext) || isSubValidationDisabled
-                                        }
-                                        onChange={({ target: { checked, value } }) => configDispatcher({
-                                            action: 'securityScheme',
-                                            event: { checked, value },
-                                        })}
-                                        value={API_SECURITY_API_KEY}
-                                        color='primary'
-                                        id='api-security-api-key-checkbox'
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
-                                        + 'ApplicationLevel.security.scheme.api.key',
-                                    defaultMessage: 'Api Key',
-                                })}
-                            />
+                            {componentValidator.includes('apikey') &&
+                                <FormControlLabel
+                                    control={(
+                                        <Checkbox
+                                            checked={securityScheme.includes(API_SECURITY_API_KEY)}
+                                            disabled={
+                                                isRestricted(['apim:api_create'], apiFromContext) 
+                                                || isSubValidationDisabled
+                                            }
+                                            onChange={({ target: { checked, value } }) => configDispatcher({
+                                                action: 'securityScheme',
+                                                event: { checked, value },
+                                            })}
+                                            value={API_SECURITY_API_KEY}
+                                            color='primary'
+                                            id='api-security-api-key-checkbox'
+                                        />
+                                    )}
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Configuration.Components.APISecurity.Components.'
+                                            + 'ApplicationLevel.security.scheme.api.key',
+                                        defaultMessage: 'Api Key',
+                                    })}
+                                />
+                            }
                         </FormGroup>
                         <FormControl className={classes.bottomSpace} component='fieldset'>
                             <RadioGroup
@@ -313,20 +318,24 @@ export default function ApplicationLevel(props) {
                                 />
                             </FormHelperText>
                         </FormControl>
-                        {oauth2Enabled && (
+                        {oauth2Enabled && componentValidator.includes("audienceValidation") && (
                             <Audience
                                 api={api}
                                 configDispatcher={configDispatcher}
                             />
                         )}
-                        {(apiFromContext.apiType === API.CONSTS.API) && oauth2Enabled && (
+                        {(apiFromContext.apiType === API.CONSTS.API) && oauth2Enabled &&
+                            componentValidator.includes("keyManagerConfig") && (
                             <KeyManager
                                 api={api}
                                 configDispatcher={configDispatcher}
                             />
                         )}
-                        <AuthorizationHeader api={api} configDispatcher={configDispatcher} />
-                        <ApiKeyHeader api={api} configDispatcher={configDispatcher} />
+                        {componentValidator.includes('oauth2') &&
+                            <AuthorizationHeader api={api} configDispatcher={configDispatcher} />
+                        } {componentValidator.includes('apikey') &&
+                            <ApiKeyHeader api={api} configDispatcher={configDispatcher} />
+                        }   
                         <FormControl>
                             {!hasResourceWithSecurity
                             && (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/APISecurity/components/TransportLevel.jsx
@@ -94,7 +94,7 @@ const Root = styled('div')((
  */
 function TransportLevel(props) {
     const {
-        haveMultiLevelSecurity, securityScheme, configDispatcher, intl, id, api,
+        haveMultiLevelSecurity, securityScheme, configDispatcher, intl, id, api, componentValidator,
     } = props;
     const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
     const [apiFromContext] = useAPI();
@@ -273,20 +273,23 @@ function TransportLevel(props) {
                         </Typography>
                     </AccordionSummary>
                     <AccordionDetails className={classes.expansionPanelDetails}>
-                        <Transports api={api} configDispatcher={configDispatcher} securityScheme={securityScheme} />
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    checked={isMutualSSLEnabled}
-                                    onChange={handleMutualSSLChange}
-                                    color='primary'
-                                    id='mutual-ssl-checkbox'
-                                />
-                            )}
-                            label='Mutual SSL'
-                        />
-                        {isMutualSSLEnabled && (
+                        <Transports api={api} configDispatcher={configDispatcher} 
+                            securityScheme={securityScheme} componentValidator={componentValidator} />
+                        {componentValidator.includes('transportsMutualSSL') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                        checked={isMutualSSLEnabled}
+                                        onChange={handleMutualSSLChange}
+                                        color='primary'
+                                        id='mutual-ssl-checkbox'
+                                    />
+                                )}
+                                label='Mutual SSL'
+                            />
+                        }
+                        {(isMutualSSLEnabled && componentValidator.includes('transportsMutualSSL')) && (
                             <FormControl component='fieldset'>
                                 <RadioGroup
                                     aria-label='HTTP security SSL mandatory selection'
@@ -343,7 +346,8 @@ function TransportLevel(props) {
                                 </FormHelperText>
                             </FormControl>
                         )}
-                        {(isMutualSSLEnabled && (!api.advertiseInfo || !api.advertiseInfo.advertised)) && (
+                        {(isMutualSSLEnabled && (!api.advertiseInfo || !api.advertiseInfo.advertised)) &&
+                            componentValidator.includes('transportsMutualSSL') && (
                             // TODO:
                             // This is half baked!!!
                             // Refactor the Certificate component to share its capabilities in here and

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Endpoints.jsx
@@ -97,7 +97,7 @@ const showEndpoint = function (api, type) {
  * @returns
  */
 function Endpoints(props) {
-    const { api } = props;
+    const { api, endpointSecurity } = props;
 
     const isPrototypedAvailable = api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped' && api.lifeCycleStatus === 'PROTOTYPED';
@@ -143,51 +143,53 @@ function Endpoints(props) {
                         )
                         : (
                             <>
-                                <Box pb={2}>
-                                    {/* Production Endpoint (TODO) fix the endpoint
-                                                    info when it's available with the api object */}
+                                {endpointSecurity.includes('typePRODUCTION') &&
+                                    <Box pb={2}>
+                                        {/* Production Endpoint (TODO) fix the endpoint
+                                                        info when it's available with the api object */}
 
-                                    { !isPrototypedAvailable ? (
-                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                            <FormattedMessage
-                                                id='Apis.Details.Configuration.components.Endpoints.production'
-                                                defaultMessage='Production'
-                                            />
-                                        </Typography>
-                                    ) : (
-                                        <Typography component='p' variant='subtitle2' className={classes.subtitle}>
-                                            <FormattedMessage
-                                                id='Apis.Details.Configuration.components.Endpoints.prototype'
-                                                defaultMessage='Prototype'
-                                            />
-                                        </Typography>
-                                    )}
-                                    {showEndpoint(api, 'prod')
-                                && (
-                                    <Tooltip
-                                        title={showEndpoint(api, 'prod')}
-                                        interactive
-                                    >
-                                        <Typography component='p' variant='body1' className={classes.textTrim}>
-                                            <>
-                                                {showEndpoint(api, 'prod')}
-                                            </>
-                                        </Typography>
-                                    </Tooltip>
-                                )}
-                                    <Typography component='p' variant='body1' className={classes.notConfigured}>
-                                        {!showEndpoint(api, 'prod') && (
-                                            <>
+                                        { !isPrototypedAvailable ? (
+                                            <Typography component='p' variant='subtitle2' className={classes.subtitle}>
                                                 <FormattedMessage
-                                                    id={'Apis.Details.Configuration.'
-                                                    + 'components.Endpoints.not.set'}
-                                                    defaultMessage='-'
+                                                    id='Apis.Details.Configuration.components.Endpoints.production'
+                                                    defaultMessage='Production'
                                                 />
-                                            </>
+                                            </Typography>
+                                        ) : (
+                                            <Typography component='p' variant='subtitle2' className={classes.subtitle}>
+                                                <FormattedMessage
+                                                    id='Apis.Details.Configuration.components.Endpoints.prototype'
+                                                    defaultMessage='Prototype'
+                                                />
+                                            </Typography>
                                         )}
-                                    </Typography>
-                                </Box>
-                                {!isPrototypedAvailable && (
+                                        {showEndpoint(api, 'prod')
+                                    && (
+                                        <Tooltip
+                                            title={showEndpoint(api, 'prod')}
+                                            interactive
+                                        >
+                                            <Typography component='p' variant='body1' className={classes.textTrim}>
+                                                <>
+                                                    {showEndpoint(api, 'prod')}
+                                                </>
+                                            </Typography>
+                                        </Tooltip>
+                                    )}
+                                        <Typography component='p' variant='body1' className={classes.notConfigured}>
+                                            {!showEndpoint(api, 'prod') && (
+                                                <>
+                                                    <FormattedMessage
+                                                        id={'Apis.Details.Configuration.'
+                                                        + 'components.Endpoints.not.set'}
+                                                        defaultMessage='-'
+                                                    />
+                                                </>
+                                            )}
+                                        </Typography>
+                                    </Box>
+                                }   
+                                {!isPrototypedAvailable && endpointSecurity.includes('typeSANDBOX') && (
                                     <Box pb={2}>
                                         {/* Sandbox Endpoint (TODO) fix the endpoint info when
                                                 it's available with the api object */}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/components/Transports.jsx
@@ -57,7 +57,7 @@ const StyledGrid = styled(Grid)((
  * @returns
  */
 export default function Transports(props) {
-    const { api, configDispatcher, securityScheme } = props;
+    const { api, configDispatcher, securityScheme, componentValidator } = props;
     const [apiFromContext] = useAPI();
 
     const isMutualSSLEnabled = securityScheme.includes(API_SECURITY_MUTUAL_SSL);
@@ -92,39 +92,44 @@ export default function Transports(props) {
                         />
                     </FormLabel>
                     <FormGroup style={{ display: 'flow-root' }}>
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext) || isMutualSSLEnabled}
-                                    checked={api.transport
-                                        ? api.transport.includes('http') && !isMutualSSLEnabled : null}
-                                    onChange={({ target: { checked } }) => configDispatcher({
-                                        action: 'transport',
-                                        event: { checked, value: 'http' },
-                                    })}
-                                    value='http'
-                                    color='primary'
-                                    id='http-transport'
-                                />
-                            )}
-                            label='HTTP'
-                        />
-                        <FormControlLabel
-                            control={(
-                                <Checkbox
-                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    checked={api.transport
-                                        ? api.transport.includes('https') : null}
-                                    onChange={({ target: { checked } }) => configDispatcher({
-                                        action: 'transport',
-                                        event: { checked, value: 'https' },
-                                    })}
-                                    value='https'
-                                    color='primary'
-                                />
-                            )}
-                            label='HTTPS'
-                        />
+                        {componentValidator.includes('transportsHTTP') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext) || 
+                                            isMutualSSLEnabled}
+                                        checked={api.transport
+                                            ? api.transport.includes('http') && !isMutualSSLEnabled : null}
+                                        onChange={({ target: { checked } }) => configDispatcher({
+                                            action: 'transport',
+                                            event: { checked, value: 'http' },
+                                        })}
+                                        value='http'
+                                        color='primary'
+                                        id='http-transport'
+                                    />
+                                )}
+                                label='HTTP'
+                            />
+                        }
+                        {componentValidator.includes('transportsHTTPS') && 
+                            <FormControlLabel
+                                control={(
+                                    <Checkbox
+                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                        checked={api.transport
+                                            ? api.transport.includes('https') : null}
+                                        onChange={({ target: { checked } }) => configDispatcher({
+                                            action: 'transport',
+                                            event: { checked, value: 'https' },
+                                        })}
+                                        value='https'
+                                        color='primary'
+                                    />
+                                )}
+                                label='HTTPS'
+                            />
+                        }
                     </FormGroup>
                 </FormControl>
             </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointListing.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointListing.jsx
@@ -116,6 +116,7 @@ function EndpointListing(props) {
         setAdvancedConfigOpen,
         setESConfigOpen,
         apiId,
+        componentValidator,
     } = props;
     const [endpointType, setEndpointType] = useState(epType);
     const [endpoints, setEndpoints] = useState([{ url: 'http://myservice/endpoint' }]);
@@ -172,6 +173,7 @@ function EndpointListing(props) {
                                         setAdvancedConfigOpen={setAdvancedConfigOpen}
                                         setESConfigOpen={setESConfigOpen}
                                         apiId={apiId}
+                                        componentValidator={componentValidator}
                                     />
                                 );
                             }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -191,6 +191,8 @@ function EndpointOverview(props) {
         isCustomBackendSelected,
         setIsCustomBackendSelected,
         apiKeyParamConfig,
+        componentValidator,
+        endpointSecurityTypes,
     } = props;
     const { endpointConfig } = api;
     const [endpointType, setEndpointType] = useState(endpointTypes[0]);
@@ -279,7 +281,7 @@ function EndpointOverview(props) {
      * @param {Object} apiObject  The representative type of the endpoint.
      * @return {string} The supported endpoint types.
      * */
-    const getSupportedType = (apiObject) => {
+    const getSupportedType = (apiObject, componentValidator) => {
         const { type, subtypeConfiguration } = apiObject;
         let supportedEndpointTypes = [];
         if (type === 'GRAPHQL' && apiObject.gatewayType !== 'wso2/apk') {
@@ -319,7 +321,7 @@ function EndpointOverview(props) {
         if(subtypeConfiguration?.subtype !== 'AIAPI' && apiObject.gatewayType !== 'wso2/apk' && type === 'HTTP' ) {
             supportedEndpointTypes.push({ key: 'sequence_backend', value: 'Sequence Backend' });
         }
-        return supportedEndpointTypes;
+        return supportedEndpointTypes.filter(type => componentValidator.includes(type.key));
     };
 
     /**
@@ -346,7 +348,7 @@ function EndpointOverview(props) {
     }
 
     useEffect(() => {
-        const supportedTypeLists = getSupportedType(api);
+        const supportedTypeLists = getSupportedType(api, componentValidator);
         const epType = getEndpointType(api);
         if (epType.key === 'service') {
             getServices();
@@ -809,104 +811,108 @@ function EndpointOverview(props) {
                                 {endpointType.key === 'service'
                                     ? (
                                         <>
-                                            <FormControlLabel
-                                                control={(
-                                                    <Checkbox
-                                                        disabled={isRestricted(
-                                                            ['apim:api_create'], api)}
-                                                        checked={endpointCategory.prod}
-                                                        value='prod'
-                                                        color='primary'
-                                                        onChange={epCategoryOnChangeHandler}
-                                                    />
-                                                )}
-                                                label={(
-                                                    <Typography>
-                                                        <FormattedMessage
-                                                            id={'Apis.Details.'
-                                                                + 'Endpoints.EndpointOverview'
-                                                                + '.production.endpoint'
-                                                                + '.production.label'}
-                                                            defaultMessage='Production Endpoint'
+                                            {componentValidator.includes("typePRODUCTION") &&
+                                            <>
+                                                <FormControlLabel
+                                                    control={(
+                                                        <Checkbox
+                                                            disabled={isRestricted(
+                                                                ['apim:api_create'], api)}
+                                                            checked={endpointCategory.prod}
+                                                            value='prod'
+                                                            color='primary'
+                                                            onChange={epCategoryOnChangeHandler}
                                                         />
-                                                    </Typography>
-                                                )}
-                                            />
-                                            <Collapse in={endpointCategory.prod}>
-                                                <ServiceEndpoint
-                                                    classes={classes}
-                                                    api={api}
-                                                    services={servicesList}
-                                                    category='production_endpoints'
-                                                    type=''
-                                                    setAdvancedConfigOpen={toggleAdvanceConfig}
-                                                    esCategory='production'
-                                                    setESConfigOpen={toggleEndpointSecurityConfig}
-                                                    name={<FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.production'
-                                                            + '.endpoint.production.header'}
-                                                        defaultMessage='Production Endpoint'
-                                                    />}
-                                                    editEndpoint={editEndpoint}
-                                                    endpointURL={getEndpoints
-                                                    (
-                                                        'production_endpoints'
                                                     )}
-                                                    existingService={getService}
-                                                    editService={editService}
-                                                    index={0} />
-                                            </Collapse>
-                                            <FormControlLabel
-                                                control={(
-                                                    <Checkbox
-                                                        disabled={isRestricted(
-                                                            ['apim:api_create'], api)}
-                                                        checked={endpointCategory.sandbox}
-                                                        value='sandbox'
-                                                        color='primary'
-                                                        onChange={() => (
-                                                            handleOnChangeEndpointCategoryChange
-                                                            (
-                                                                'sandbox',
-                                                            ))}
-                                                    />
-                                                )}
-                                                label={(
-                                                    <FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.sandbox'
-                                                            + '.endpoint'}
-                                                        defaultMessage='Sandbox Endpoint'
-                                                    />
-                                                )}
-                                            />
-                                            <Collapse in={endpointCategory.sandbox}>
-                                                <ServiceEndpoint
-                                                    classes={classes}
-                                                    api={api}
-                                                    services={servicesList}
-                                                    category='sandbox_endpoints'
-                                                    type=''
-                                                    setAdvancedConfigOpen={toggleAdvanceConfig}
-                                                    esCategory='sandbox'
-                                                    setESConfigOpen={toggleEndpointSecurityConfig}
-                                                    name={ <FormattedMessage
-                                                        id={'Apis.Details.Endpoints.'
-                                                            + 'EndpointOverview.sandbox'
-                                                            + '.endpoint'}
-                                                        defaultMessage='Sandbox Endpoint'
-                                                    />}
-                                                    editEndpoint={editEndpoint}
-                                                    endpointURL={getEndpoints
-                                                    (
-                                                        'sandbox_endpoints'
+                                                    label={(
+                                                        <Typography>
+                                                            <FormattedMessage
+                                                                id={'Apis.Details.'
+                                                                    + 'Endpoints.EndpointOverview'
+                                                                    + '.production.endpoint'
+                                                                    + '.production.label'}
+                                                                defaultMessage='Production Endpoint'
+                                                            />
+                                                        </Typography>
                                                     )}
-                                                    index={0} />
-                                            </Collapse>
-
+                                                />
+                                                <Collapse in={endpointCategory.prod}>
+                                                    <ServiceEndpoint
+                                                        classes={classes}
+                                                        api={api}
+                                                        services={servicesList}
+                                                        category='production_endpoints'
+                                                        type=''
+                                                        setAdvancedConfigOpen={toggleAdvanceConfig}
+                                                        esCategory='production'
+                                                        setESConfigOpen={toggleEndpointSecurityConfig}
+                                                        name={<FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.production'
+                                                                + '.endpoint.production.header'}
+                                                            defaultMessage='Production Endpoint'
+                                                        />}
+                                                        editEndpoint={editEndpoint}
+                                                        endpointURL={getEndpoints
+                                                        (
+                                                            'production_endpoints'
+                                                        )}
+                                                        existingService={getService}
+                                                        editService={editService}
+                                                        index={0} />
+                                                </Collapse>
+                                            </>}
+                                            {componentValidator.includes("typeSANDBOX") &&
+                                            <>
+                                                <FormControlLabel
+                                                    control={(
+                                                        <Checkbox
+                                                            disabled={isRestricted(
+                                                                ['apim:api_create'], api)}
+                                                            checked={endpointCategory.sandbox}
+                                                            value='sandbox'
+                                                            color='primary'
+                                                            onChange={() => (
+                                                                handleOnChangeEndpointCategoryChange
+                                                                (
+                                                                    'sandbox',
+                                                                ))}
+                                                        />
+                                                    )}
+                                                    label={(
+                                                        <FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.sandbox'
+                                                                + '.endpoint'}
+                                                            defaultMessage='Sandbox Endpoint'
+                                                        />
+                                                    )}
+                                                />
+                                                <Collapse in={endpointCategory.sandbox}>
+                                                    <ServiceEndpoint
+                                                        classes={classes}
+                                                        api={api}
+                                                        services={servicesList}
+                                                        category='sandbox_endpoints'
+                                                        type=''
+                                                        setAdvancedConfigOpen={toggleAdvanceConfig}
+                                                        esCategory='sandbox'
+                                                        setESConfigOpen={toggleEndpointSecurityConfig}
+                                                        name={ <FormattedMessage
+                                                            id={'Apis.Details.Endpoints.'
+                                                                + 'EndpointOverview.sandbox'
+                                                                + '.endpoint'}
+                                                            defaultMessage='Sandbox Endpoint'
+                                                        />}
+                                                        editEndpoint={editEndpoint}
+                                                        endpointURL={getEndpoints
+                                                        (
+                                                            'sandbox_endpoints'
+                                                        )}
+                                                        index={0} />
+                                                </Collapse>
+                                            </>}
                                         </>
-
                                     )
                                     : (
                                         <>
@@ -950,32 +956,35 @@ function EndpointOverview(props) {
                                                                         />
                                                                     </Typography>
                                                                 )
-                                                                : (
-                                                                    <FormControlLabel
-                                                                        control={(
-                                                                            <Checkbox
-                                                                                id='production-endpoint-checkbox'
-                                                                                disabled={isRestricted(
-                                                                                    ['apim:api_create'], api)}
-                                                                                checked={endpointCategory.prod}
-                                                                                value='prod'
-                                                                                color='primary'
-                                                                                onChange={epCategoryOnChangeHandler}
-                                                                            />
-                                                                        )}
-                                                                        label={(
-                                                                            <Typography>
-                                                                                <FormattedMessage
-                                                                                    id={'Apis.Details.'
-                                                                                        + 'Endpoints.EndpointOverview'
-                                                                                        + '.production.endpoint'
-                                                                                        + '.production.label'}
-                                                                                    defaultMessage='Production Endpoint'
+                                                                :
+                                                                    componentValidator.includes("typePRODUCTION") &&
+                                                                    <>
+                                                                        <FormControlLabel
+                                                                            control={(
+                                                                                <Checkbox
+                                                                                    id='production-endpoint-checkbox'
+                                                                                    disabled={isRestricted(
+                                                                                        ['apim:api_create'], api)}
+                                                                                    checked={endpointCategory.prod}
+                                                                                    value='prod'
+                                                                                    color='primary'
+                                                                                    onChange={epCategoryOnChangeHandler}
                                                                                 />
-                                                                            </Typography>
-                                                                        )}
-                                                                    />
-                                                                )}
+                                                                            )}
+                                                                            label={(
+                                                                                <Typography>
+                                                                                    <FormattedMessage
+                                                                                        id={'Apis.Details.'
+                                                                                            + 'Endpoints.EndpointOverview'
+                                                                                            + '.production.endpoint'
+                                                                                            + '.production.label'}
+                                                                                        defaultMessage='Production Endpoint'
+                                                                                    />
+                                                                                </Typography>
+                                                                            )}
+                                                                        />
+                                                                    </>
+                                                                }
                                                             <Collapse in={endpointCategory.prod}>
                                                                 {endpointType.key === 'default'
                                                                     ? (
@@ -1036,35 +1045,37 @@ function EndpointOverview(props) {
                                                                                     />
                                                                                 </Typography>
                                                                             </Button>
-                                                                            <Button
-                                                                                className={classes.button}
-                                                                                aria-label='Settings'
-                                                                                onClick={() => toggleEndpointSecurityConfig(
-                                                                                    '', 'production',
-                                                                                )}
-                                                                                disabled={
-                                                                                    (isRestricted(
-                                                                                        ['apim:api_create'], api,
-                                                                                    )
-                                                                                    )
-                                                                                }
-                                                                                variant='outlined'
-                                                                            >
-                                                                                <Icon
-                                                                                    className={classes.buttonIcon}
+                                                                            {endpointSecurityTypes.length > 0 &&
+                                                                                <Button
+                                                                                    className={classes.button}
+                                                                                    aria-label='Settings'
+                                                                                    onClick={() => toggleEndpointSecurityConfig(
+                                                                                        '', 'production',
+                                                                                    )}
+                                                                                    disabled={
+                                                                                        (isRestricted(
+                                                                                            ['apim:api_create'], api,
+                                                                                        )
+                                                                                        )
+                                                                                    }
+                                                                                    variant='outlined'
                                                                                 >
-                                                                                    security
-                                                                                </Icon>
-                                                                                <Typography>
-                                                                                    <FormattedMessage
-                                                                                        id={'Apis.Details.Endpoints'
-                                                                                            + '.EndpointOverview.endpoint'
-                                                                                            + '.security.configuration'}
-                                                                                        defaultMessage={'Endpoint '
-                                                                                            + 'Security Configurations'}
-                                                                                    />
-                                                                                </Typography>
-                                                                            </Button>
+                                                                                    <Icon
+                                                                                        className={classes.buttonIcon}
+                                                                                    >
+                                                                                        security
+                                                                                    </Icon>
+                                                                                    <Typography>
+                                                                                        <FormattedMessage
+                                                                                            id={'Apis.Details.Endpoints'
+                                                                                                + '.EndpointOverview.endpoint'
+                                                                                                + '.security.configuration'}
+                                                                                            defaultMessage={'Endpoint '
+                                                                                                + 'Security Configurations'}
+                                                                                        />
+                                                                                    </Typography>
+                                                                                </Button>
+                                                                            }
                                                                         </InlineMessage>
                                                                     )
                                                                     : (
@@ -1098,158 +1109,171 @@ function EndpointOverview(props) {
                                                                             setAdvancedConfigOpen={toggleAdvanceConfig}
                                                                             esCategory='production'
                                                                             setESConfigOpen={toggleEndpointSecurityConfig}
-                                                                            apiId={api.id}
+                                                                            iId={api.id}
+                                                                            componentValidator={componentValidator}
                                                                         />
                                                                     )}
                                                             </Collapse>
                                                             {endpointType.key === 'prototyped' ? <div />
                                                                 : (
                                                                     <div>
-                                                                        <FormControlLabel
-                                                                            control={(
-                                                                                <Checkbox
-                                                                                    id='sandbox-endpoint-checkbox'
-                                                                                    disabled={isRestricted(
-                                                                                        ['apim:api_create'], api)}
-                                                                                    checked={endpointCategory.sandbox}
-                                                                                    value='sandbox'
-                                                                                    color='primary'
-                                                                                    onChange={() => (
-                                                                                        handleOnChangeEndpointCategoryChange
-                                                                                        (
-                                                                                            'sandbox',
-                                                                                        ))}
-                                                                                />
-                                                                            )}
-                                                                            label={(
-                                                                                <FormattedMessage
-                                                                                    id={'Apis.Details.Endpoints.'
-                                                                                        + 'EndpointOverview.sandbox'
-                                                                                        + '.endpoint'}
-                                                                                    defaultMessage='Sandbox Endpoint'
-                                                                                />
-                                                                            )}
-                                                                        />
-                                                                        <Collapse in={endpointCategory.sandbox}>
-                                                                            {endpointType.key === 'default'
-                                                                                ? (
-                                                                                    <InlineMessage>
-                                                                                        <div className={classes.
-                                                                                            contentWrapper}>
-                                                                                            <Typography
-                                                                                                component='p'
-                                                                                                className={classes.content}
-                                                                                            >
-                                                                                                <FormattedMessage
-                                                                                                    id={'Apis.Details'
-                                                                                                        + '.Endpoints'
-                                                                                                        + '.Endpoint'
-                                                                                                        + 'Overview'
-                                                                                                        + '.upload'
-                                                                                                        + '.mediation'
-                                                                                                        + '.message'}
-                                                                                                    defaultMessage={
-                                                                                                        'Please upload '
-                                                                                                        + ' a mediation'
-                                                                                                        + ' sequence '
-                                                                                                        + 'file to'
-                                                                                                        + ' Message '
-                                                                                                        + '  Mediation'
-                                                                                                        + ' Policies,'
-                                                                                                        + ' which sets the'
-                                                                                                        + ' endpoints.'
-                                                                                                    }
-                                                                                                />
-                                                                                                <IconButton
-                                                                                                    onClick={
-                                                                                                        saveAndRedirect
-                                                                                                    }
-                                                                                                    size='large'>
-                                                                                                    <LaunchIcon
-                                                                                                        style={{
-                                                                                                            marginLeft:
-                                                                                                                '2px'
-                                                                                                        }}
-                                                                                                        fontSize='small'
-                                                                                                        color='primary'
-                                                                                                    />
-                                                                                                </IconButton>
-                                                                                            </Typography>
-                                                                                        </div>
-                                                                                        <Button
-                                                                                            className={classes.button}
-                                                                                            aria-label='Settings'
-                                                                                            onClick={() =>
-                                                                                                toggleAdvanceConfig(
-                                                                                                    0, '',
-                                                                                                    'sandbox_endpoints',
-                                                                                                )}
-                                                                                            disabled={
-                                                                                                (isRestricted(
-                                                                                                    ['apim:api_create'],
-                                                                                                    api,
-                                                                                                )
-                                                                                                )
-                                                                                            }
-                                                                                            variant='outlined'
-                                                                                        >
-                                                                                            <Icon
-                                                                                                className={
-                                                                                                    classes.buttonIcon}
-                                                                                            >
-                                                                                                settings
-                                                                                            </Icon>
-                                                                                            <Typography>
-                                                                                                <FormattedMessage
-                                                                                                    id={'Apis.Details.'
-                                                                                                    + 'Endpoints'
-                                                                                                    + '.EndpointOverview.'
-                                                                                                    + 'advance'
-                                                                                                    + '.endpoint.'
-                                                                                                    + 'configuration'}
-                                                                                                    defaultMessage={
-                                                                                                        'Advanced '
-                                                                                                        + 'Configurations'}
-                                                                                                />
-                                                                                            </Typography>
-                                                                                        </Button>
-                                                                                    </InlineMessage>
-                                                                                )
-                                                                                : (
-                                                                                   <GenericEndpoint
-                                                                                        autoFocus
-                                                                                        name={(
-                                                                                            <FormattedMessage
-                                                                                                id={'Apis.Details.'
-                                                                                                    + 'Endpoints.'
-                                                                                                    + 'EndpointOverview.'
-                                                                                                    + 'sandbox.'
-                                                                                                    + 'endpoint.sandbox.'
-                                                                                                    + 'header'}
-                                                                                                defaultMessage={
-                                                                                                    'Sandbox '
-                                                                                                    + 'Endpoint'}
-                                                                                            />
-                                                                                        )}
-                                                                                        className={classes.
-                                                                                            defaultEndpointWrapper}
-                                                                                        endpointURL={getEndpoints
-                                                                                        (
-                                                                                            'sandbox_endpoints'
-                                                                                        )}
-                                                                                        type=''
-                                                                                        index={0}
-                                                                                        category='sandbox_endpoints'
-                                                                                        editEndpoint={editEndpoint}
-                                                                                        esCategory='sandbox'
-                                                                                        setAdvancedConfigOpen=
-                                                                                            {toggleAdvanceConfig}
-                                                                                        setESConfigOpen=
-                                                                                            {toggleEndpointSecurityConfig}
-                                                                                        apiId={api.id}
+                                                                        {componentValidator.includes("typeSANDBOX") &&
+                                                                        <>
+                                                                            <FormControlLabel
+                                                                                control={(
+                                                                                    <Checkbox
+                                                                                        id='sandbox-endpoint-checkbox'
+                                                                                        disabled={isRestricted(
+                                                                                            ['apim:api_create'], api)}
+                                                                                        checked={endpointCategory.sandbox}
+                                                                                        value='sandbox'
+                                                                                        color='primary'
+                                                                                        onChange={() => (
+                                                                                            handleOnChangeEndpointCategoryChange
+                                                                                            (
+                                                                                                'sandbox',
+                                                                                            ))}
                                                                                     />
                                                                                 )}
-                                                                        </Collapse>
+                                                                                label={(
+                                                                                    <FormattedMessage
+                                                                                        id={'Apis.Details.Endpoints.'
+                                                                                            + 'EndpointOverview.sandbox'
+                                                                                            + '.endpoint'}
+                                                                                        defaultMessage='Sandbox Endpoint'
+                                                                                    />
+                                                                                )}
+                                                                            />
+                                                                            <Collapse in={endpointCategory.sandbox}>
+                                                                                {endpointType.key === 'default'
+                                                                                    ? (
+                                                                                        <InlineMessage>
+                                                                                            <div className={classes.
+                                                                                                contentWrapper}>
+                                                                                                <Typography
+                                                                                                    component='p'
+                                                                                                    className={classes.content}
+                                                                                                >
+                                                                                                    <FormattedMessage
+                                                                                                        id={'Apis.Details'
+                                                                                                            + '.Endpoints'
+                                                                                                            + '.Endpoint'
+                                                                                                            + 'Overview'
+                                                                                                            + '.upload'
+                                                                                                            + '.mediation'
+                                                                                                            + '.message'}
+                                                                                                        defaultMessage={
+                                                                                                            'Please upload '
+                                                                                                            + ' a mediation'
+                                                                                                            + ' sequence '
+                                                                                                            + 'file to'
+                                                                                                            + ' Message '
+                                                                                                            + '  Mediation'
+                                                                                                            + ' Policies,'
+                                                                                                            + ' which sets the'
+                                                                                                            + ' endpoints.'
+                                                                                                        }
+                                                                                                    />
+                                                                                                    <IconButton
+                                                                                                        onClick={
+                                                                                                            saveAndRedirect
+                                                                                                        }
+                                                                                                        size='large'>
+                                                                                                        <LaunchIcon
+                                                                                                            style={{
+                                                                                                                marginLeft:
+                                                                                                                    '2px'
+                                                                                                            }}
+                                                                                                            fontSize='small'
+                                                                                                            color='primary'
+                                                                                                        />
+                                                                                                    </IconButton>
+                                                                                                </Typography>
+                                                                                            </div>
+                                                                                            <Button
+                                                                                                className={classes.button}
+                                                                                                aria-label='Settings'
+                                                                                                onClick={() =>
+                                                                                                    toggleAdvanceConfig(
+                                                                                                        0, '',
+                                                                                                        'sandbox_endpoints',
+                                                                                                    )}
+                                                                                                disabled={
+                                                                                                    (isRestricted(
+                                                                                                        ['apim:api_create'],
+                                                                                                        api,
+                                                                                                    )
+                                                                                                    )
+                                                                                                }
+                                                                                                variant='outlined'
+                                                                                            >
+                                                                                                <Icon
+                                                                                                    className={
+                                                                                                        classes.buttonIcon}
+                                                                                                >
+                                                                                                    settings
+                                                                                                </Icon>
+                                                                                                <Typography>
+                                                                                                    <FormattedMessage
+                                                                                                        id={'Apis.Details.'
+                                                                                                        + 'Endpoints'
+                                                                                                        + '.EndpointOverview.'
+                                                                                                        + 'advance'
+                                                                                                        + '.endpoint.'
+                                                                                                        + 'configuration'}
+                                                                                                        defaultMessage={
+                                                                                                            'Advanced '
+                                                                                                            + 'Configurations'}
+                                                                                                    />
+                                                                                                </Typography>
+                                                                                            </Button>
+                                                                                        </InlineMessage>
+                                                                                    )
+                                                                                    : (
+                                                                                    <> <GenericEndpoint
+                                                                                            autoFocus
+                                                                                            name={(
+                                                                                                <FormattedMessage
+                                                                                                    id={'Apis.Details.'
+                                                                                                        + 'Endpoints.'
+                                                                                                        + 'EndpointOverview.'
+                                                                                                        + 'sandbox.'
+                                                                                                        + 'endpoint.sandbox.'
+                                                                                                        + 'header'}
+                                                                                                    defaultMessage={
+                                                                                                        'Sandbox '
+                                                                                                        + 'Endpoint'}
+                                                                                                />
+                                                                                            )}
+                                                                                            className={classes.
+                                                                                                defaultEndpointWrapper}
+                                                                                            endpointURL={getEndpoints
+                                                                                            (
+                                                                                                'sandbox_endpoints'
+                                                                                            )}
+                                                                                            type=''
+                                                                                            index={0}
+                                                                                            category='sandbox_endpoints'
+                                                                                            editEndpoint={editEndpoint}
+                                                                                            esCategory='sandbox'
+                                                                                            setAdvancedConfigOpen=
+                                                                                                {toggleAdvanceConfig}
+                                                                                            setESConfigOpen=
+                                                                                                {toggleEndpointSecurityConfig}
+                                                                                            apiId={api.id}
+                                                                                            componentValidator={componentValidator}
+                                                                                        />
+                                                                                        {endpointCategory.sandbox && // eslint-disable-line
+                                                                                            api.subtypeConfiguration?.subtype === 'AIAPI' && // eslint-disable-line
+                                                                                            (apiKeyParamConfig.authHeader || apiKeyParamConfig.authQueryParameter) && // eslint-disable-line
+                                                                                            (<AIEndpointAuth
+                                                                                                api={api}
+                                                                                                saveEndpointSecurityConfig={saveEndpointSecurityConfig} // eslint-disable-line
+                                                                                                apiKeyParamConfig={apiKeyParamConfig} // eslint-disable-line
+                                                                                        />)}</> // eslint-disable-line
+                                                                                    )}
+                                                                            </Collapse>
+                                                                        </>}
                                                                     </div>
                                                                 )}
                                                         </>
@@ -1289,8 +1313,8 @@ function EndpointOverview(props) {
                         || api.type === 'WS'
                         || endpointType.key === 'awslambda'
                         || endpointType.key === 'service'
-                        || api.gatewayType === 'wso2/apk'
                         || api.subtypeConfiguration?.subtype === 'AIAPI'
+                        || !componentValidator.includes('loadBalanceAndFailoverConfigurations')
                         ? <div />
                         : (
                             <Grid item xs={12}>
@@ -1316,12 +1340,13 @@ function EndpointOverview(props) {
                                     handleEndpointTypeSelect={handleEndpointTypeSelect}
                                     globalEpType={endpointType}
                                     apiType={api.type}
+                                    componentValidator={componentValidator}
                                 />
                             </Grid>
                         )
                 }
             </Grid>
-            {api.gatewayType !== 'wso2/apk' && (
+            {componentValidator.includes('advancedConfigurations') && (
                 <Dialog open={advanceConfigOptions.open}>
                     <DialogTitle>
                         <Typography className={classes.configDialogHeader}>
@@ -1341,77 +1366,84 @@ function EndpointOverview(props) {
                     </DialogContent>
                 </Dialog>
             )}
-            <Dialog open={endpointSecurityConfig.open}>
-                <DialogTitle>
-                    <Typography className={classes.configDialogHeader}>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.security.configuration'
-                            defaultMessage='Endpoint Security Configurations'
-                        />
-                    </Typography>
-                </DialogTitle>
-                <DialogContent>
-                    {endpointSecurityConfig.category === 'production' ? (
-                        <EndpointSecurity
-                            securityInfo={endpointSecurityInfo
-                                && (endpointSecurityInfo.production
-                                    ? endpointSecurityInfo.production : endpointSecurityInfo)}
-                            onChangeEndpointAuth={handleEndpointSecurityChange}
-                            saveEndpointSecurityConfig={saveEndpointSecurityConfig}
-                            closeEndpointSecurityConfig={closeEndpointSecurityConfig}
-                            isProduction
-                        />
-                    ) : (
-                        <EndpointSecurity
-                            securityInfo={endpointSecurityInfo
-                                && (endpointSecurityInfo.sandbox
-                                    ? endpointSecurityInfo.sandbox : endpointSecurityInfo)}
-                            onChangeEndpointAuth={handleEndpointSecurityChange}
-                            saveEndpointSecurityConfig={saveEndpointSecurityConfig}
-                            closeEndpointSecurityConfig={closeEndpointSecurityConfig}
-                        />
-                    )}
-                </DialogContent>
-            </Dialog>
-            <Dialog open={typeChangeConfirmation.openDialog}>
-                <DialogTitle>
-                    <Typography className={classes.configDialogHeader}>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation'
-                            defaultMessage='Change Endpoint Type'
-                        />
-                    </Typography>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography>
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation.message'
-                            defaultMessage='Your current endpoint configuration will be lost.'
-                        />
-                    </Typography>
-                </DialogContent>
-                <DialogActions>
-                    <Button
-                        onClick={() => { setTypeChangeConfirmation({ openDialog: false, serviceInfo: false }); }}
-                        color='primary'
-                    >
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints.EndpointOverview.change.type.cancel'
-                            defaultMessage='Cancel'
-                        />
-                    </Button>
-                    <Button
-                        onClick={() => { changeEndpointType(typeChangeConfirmation.type); }}
-                        color='primary'
-                        id='change-endpoint-type-btn'
-                    >
-                        <FormattedMessage
-                            id='Apis.Details.Endpoints..EndpointOverview.change.type.proceed'
-                            defaultMessage='Proceed'
-                        />
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            {endpointSecurityTypes && endpointSecurityTypes.length > 0 &&
+                <>
+                    <Dialog open={endpointSecurityConfig.open}>
+                        <DialogTitle>
+                            <Typography className={classes.configDialogHeader}>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.security.configuration'
+                                    defaultMessage='Endpoint Security Configurations'
+                                />
+                            </Typography>
+                        </DialogTitle>
+                        <DialogContent>
+                            {endpointSecurityConfig.category === 'production' ? (
+                                <EndpointSecurity
+                                    securityInfo={endpointSecurityInfo
+                                        && (endpointSecurityInfo.production
+                                            ? endpointSecurityInfo.production : endpointSecurityInfo)}
+                                    onChangeEndpointAuth={handleEndpointSecurityChange}
+                                    saveEndpointSecurityConfig={saveEndpointSecurityConfig}
+                                    closeEndpointSecurityConfig={closeEndpointSecurityConfig}
+                                    isProduction
+                                    endpointSecurityTypes={endpointSecurityTypes}
+                                />
+                            ) : (
+                                <EndpointSecurity
+                                    securityInfo={endpointSecurityInfo
+                                        && (endpointSecurityInfo.sandbox
+                                            ? endpointSecurityInfo.sandbox : endpointSecurityInfo)}
+                                    onChangeEndpointAuth={handleEndpointSecurityChange}
+                                    saveEndpointSecurityConfig={saveEndpointSecurityConfig}
+                                    closeEndpointSecurityConfig={closeEndpointSecurityConfig}
+                                />
+                            )}
+                        </DialogContent>
+                    </Dialog>
+                    <Dialog open={typeChangeConfirmation.openDialog}>
+                        <DialogTitle>
+                            <Typography className={classes.configDialogHeader}>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.type.change.confirmation'
+                                    defaultMessage='Change Endpoint Type'
+                                />
+                            </Typography>
+                        </DialogTitle>
+                        <DialogContent>
+                            <Typography>
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.endpoint.type
+                                        .change.confirmation.message'
+                                    defaultMessage='Your current endpoint configuration will be lost.'
+                                />
+                            </Typography>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button
+                                onClick={() =>
+                                    { setTypeChangeConfirmation({ openDialog: false, serviceInfo: false }); }}
+                                color='primary'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints.EndpointOverview.change.type.cancel'
+                                    defaultMessage='Cancel'
+                                />
+                            </Button>
+                            <Button
+                                onClick={() => { changeEndpointType(typeChangeConfirmation.type); }}
+                                color='primary'
+                                id='change-endpoint-type-btn'
+                            >
+                                <FormattedMessage
+                                    id='Apis.Details.Endpoints..EndpointOverview.change.type.proceed'
+                                    defaultMessage='Proceed'
+                                />
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+                </>
+            }
         </Root>
     );
 }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -23,15 +23,14 @@ import Typography from '@mui/material/Typography';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
-import { useAppContext } from 'AppComponents/Shared/AppContext';
+import { useAppContext, usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import { Link, withRouter } from 'react-router-dom';
 import CustomSplitButton from 'AppComponents/Shared/CustomSplitButton';
 import NewEndpointCreate from 'AppComponents/Apis/Details/Endpoints/NewEndpointCreate';
 import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import cloneDeep from 'lodash.clonedeep';
 import { isRestricted } from 'AppData/AuthManager';
-import { Alert } from 'AppComponents/Shared';
-
+import { Alert, Progress } from 'AppComponents/Shared';
 import API from 'AppData/api';
 import EndpointOverview from './EndpointOverview';
 import AIEndpoints from './AIEndpoints';
@@ -101,6 +100,7 @@ const defaultSwagger = { paths: {} };
  */
 function Endpoints(props) {
     const {  intl, history } = props;
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const { api, updateAPI } = useContext(APIContext);
     const { settings } = useAppContext();
     const [swagger, setSwagger] = useState(defaultSwagger);
@@ -114,6 +114,8 @@ function Endpoints(props) {
         authHeader: null,
         authQueryParameter: null
     });
+    const [componentValidator, setComponentValidator] = useState([]);
+    const [endpointSecurityTypes, setEndpointSecurityTypes] = useState([]);
 
     useEffect(() => {
         if (api.subtypeConfiguration?.subtype === 'AIAPI') {
@@ -126,6 +128,15 @@ function Endpoints(props) {
                 });
         }
     }, []);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(publisherSettings.gatewayFeatureCatalog
+                .gatewayFeatures[api.gatewayType].endpoints);
+            setEndpointSecurityTypes(publisherSettings.gatewayFeatureCatalog
+                .gatewayFeatures[api.gatewayType].endpointSecurity);
+        }
+    }, [isLoading]);
 
     const apiReducer = (initState, configAction) => {
         const tmpEndpointConfig = cloneDeep(initState.endpointConfig);
@@ -717,11 +728,17 @@ function Endpoints(props) {
         apiDispatcher({ action: 'endpointImplementationType', value: { endpointType, implementationType } });
     };
 
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
+
     return (
         (<Root>
             {/* Since the api is set to the state in component did mount, check both the api and the apiObject. */}
-            {(api.endpointConfig === null && apiObject.endpointConfig === null)
-                ? <NewEndpointCreate generateEndpointConfig={generateEndpointConfig} apiType={apiObject.type} />
+            {(api.endpointConfig === null && apiObject.endpointConfig === null) ?
+                <NewEndpointCreate generateEndpointConfig={generateEndpointConfig} apiType={apiObject.type}
+                    componentValidator={componentValidator}
+                />
                 : (
                     <div className={classes.root}>
                         <Typography
@@ -764,9 +781,11 @@ function Endpoints(props) {
                                             setProductionBackendList={setProductionBackendList}
                                             isValidSequenceBackend={isValidSequenceBackend}
                                             setIsValidSequenceBackend={setIsValidSequenceBackend}
-                                            isCustomBackendSelected={isCustomBackendSelected} 
+                                            isCustomBackendSelected={isCustomBackendSelected}
                                             setIsCustomBackendSelected={setIsCustomBackendSelected}
                                             apiKeyParamConfig={apiKeyParamConfig}
+                                            componentValidator={componentValidator}
+                                            endpointSecurityTypes={endpointSecurityTypes}
                                         />
                                     </Grid>
                                 </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -104,6 +104,7 @@ function EndpointSecurity(props) {
     const { settings } = useAppContext();
     const {
         intl, securityInfo, onChangeEndpointAuth, isProduction, saveEndpointSecurityConfig, closeEndpointSecurityConfig,
+        endpointSecurityTypes,
     } = props;
     const [endpointSecurityInfo, setEndpointSecurityInfo] = useState(CONSTS.DEFAULT_ENDPOINT_SECURITY);
 
@@ -127,30 +128,9 @@ function EndpointSecurity(props) {
     const endpointType = isProduction ? 'production' : 'sandbox';
 
     const authTypes = () => {
-        const { gatewayType } = api; // Access gatewayType directly from api
-
-        if (gatewayType === 'wso2/apk') {
-            return [
-                {
-                    key: 'NONE',
-                    value: intl.formatMessage({
-                        id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.none',
-                        defaultMessage: 'None',
-                    }),
-                },
-                {
-                    key: 'BASIC',
-                    value: intl.formatMessage({
-                        id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.basic',
-                        defaultMessage: 'Basic Auth',
-                    }),
-                },
-            ];
-        }
-
-        // Default authTypes for other gateway types
-        return [
+        const types = [
             {
+                id: 'none',
                 key: 'NONE',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.none',
@@ -158,6 +138,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'basicAuth',
                 key: 'BASIC',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.basic',
@@ -165,6 +146,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'digest',
                 key: 'DIGEST',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.digest.auth',
@@ -172,6 +154,7 @@ function EndpointSecurity(props) {
                 }),
             },
             {
+                id: 'oauth2',
                 key: 'OAUTH',
                 value: intl.formatMessage({
                     id: 'Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.oauth',
@@ -179,6 +162,10 @@ function EndpointSecurity(props) {
                 }),
             },
         ];
+
+        const selectedTypes = [types[0]];
+
+        return selectedTypes.concat(types.filter((type) => endpointSecurityTypes?.includes(type.id)));
     };
 
     const grantTypes = [

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GenericEndpoint.jsx
@@ -117,6 +117,7 @@ function GenericEndpoint(props) {
         name,
         id,
         apiId,
+        componentValidator,
     } = props;
     const [serviceUrl, setServiceUrl] = useState(endpointURL);
     const { api } = useContext(APIContext);
@@ -227,28 +228,30 @@ function GenericEndpoint(props) {
                                 ? <div />
                                 : (
                                     <>
-                                        <IconButton
-                                            className={classes.iconButton}
-                                            aria-label='Settings'
-                                            onClick={() => setAdvancedConfigOpen(index, type, category)}
-                                            disabled={(isRestricted(['apim:api_create'], api))}
-                                            id={category + '-endpoint-configuration-icon-btn'}
-                                            size='large'>
-                                            <Tooltip
-                                                placement='top-start'
-                                                interactive
-                                                title={(
-                                                    <FormattedMessage
-                                                        id='Apis.Details.Endpoints.GenericEndpoint.config.endpoint'
-                                                        defaultMessage='Endpoint configurations'
-                                                    />
-                                                )}
-                                            >
-                                                <Icon>
-                                                    settings
-                                                </Icon>
-                                            </Tooltip>
-                                        </IconButton>
+                                        {componentValidator.includes('advancedConfigurations') &&
+                                            <IconButton
+                                                className={classes.iconButton}
+                                                aria-label='Settings'
+                                                onClick={() => setAdvancedConfigOpen(index, type, category)}
+                                                disabled={(isRestricted(['apim:api_create'], api))}
+                                                id={category + '-endpoint-configuration-icon-btn'}
+                                                size='large'>
+                                                <Tooltip
+                                                    placement='top-start'
+                                                    interactive
+                                                    title={(
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Endpoints.GenericEndpoint.config.endpoint'
+                                                            defaultMessage='Endpoint configurations'
+                                                        />
+                                                    )}
+                                                >
+                                                    <Icon>
+                                                        settings
+                                                    </Icon>
+                                                </Tooltip>
+                                            </IconButton>
+                                        }
                                         {api.subtypeConfiguration?.subtype !== 'AIAPI' && (<IconButton
                                             className={classes.iconButton}
                                             aria-label='Security'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/LoadbalanceFailoverConfig.jsx
@@ -134,6 +134,7 @@ function LoadbalanceFailoverConfig(props) {
         toggleESConfig,
         globalEpType,
         handleEndpointCategorySelect,
+        componentValidator,
     } = props;
     const { api } = useContext(APIContext);
     const [isConfigExpanded, setConfigExpand] = useState(false);
@@ -377,6 +378,7 @@ function LoadbalanceFailoverConfig(props) {
                                                 setESConfigOpen={toggleESConfig}
                                                 category='production_endpoints'
                                                 apiId={api.id}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}
@@ -412,6 +414,7 @@ function LoadbalanceFailoverConfig(props) {
                                                 setESConfigOpen={toggleESConfig}
                                                 category='sandbox_endpoints'
                                                 apiId={api.id}
+                                                componentValidator={componentValidator}
                                             />
                                         </Grid>
                                     )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/NewEndpointCreate.jsx
@@ -95,6 +95,7 @@ function NewEndpointCreate(props) {
         intl,
         generateEndpointConfig,
         apiType,
+        componentValidator,
     } = props;
     const [endpointImplType, setImplType] = useState('mock');
     const endpointTypes = [
@@ -138,7 +139,7 @@ function NewEndpointCreate(props) {
             disabled: ['GRAPHQL', 'SSE'],
         },
         {
-            type: 'prototyped',
+            type: 'INLINE',
             name: intl.formatMessage({
                 id: 'Apis.Details.Endpoints.NewEndpointCreate.create.prototype.endpoint',
                 defaultMessage: 'Mock Implementation',
@@ -205,7 +206,7 @@ function NewEndpointCreate(props) {
                 />
             </Typography>
             <Grid container justifyContent='flex-start' spacing={2}>
-                {eligibleTypes.map(((type) => {
+                {(eligibleTypes.filter(ep => componentValidator.includes(ep.type)).map((type) => {
                     return (
                         <Grid item className={classes.inlineMessageContainer}>
                             <Card className={classes.endpointTypeCard}>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { FormattedMessage } from 'react-intl';
 import Typography from '@mui/material/Typography';
@@ -33,7 +33,7 @@ import AddIcon from '@mui/icons-material/Add';
 import CardHeader from '@mui/material/CardHeader';
 import PropTypes from 'prop-types';
 import { useAppContext } from 'AppComponents/Shared/AppContext';
-import { useTheme } from '@mui/material';
+import { CircularProgress, useTheme } from '@mui/material';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 import Checkbox from '@mui/material/Checkbox';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
@@ -142,71 +142,100 @@ export default function DeploymentOnboarding(props) {
         setDescription,
         gatewayVendor,
         advertiseInfo,
+        isDeploying,
     } = props;
 
     const [api] = useAPI();
     const theme = useTheme();
     const { maxCommentLength } = theme.custom;
-    const assignGateway = (api.gatewayType === "wso2/synapse" || api.apiType === "APIPRODUCT") ? "Regular" : "APK";
     const { settings: { environment: environments } } = useAppContext();
-    const internalGatewaysFiltered = environments.filter((p) => !p.provider.toLowerCase().includes('solace'));
-    const internalGateways = internalGatewaysFiltered &&
-        internalGatewaysFiltered.filter((p) => p.gatewayType.toLowerCase() === assignGateway.toLowerCase());
-    const externalGateways = environments.filter((p) => p.provider.toLowerCase().includes('solace'));
-    const hasOnlyOneEnvironment = internalGateways.length === 1;
+    const [internalGateways, setInternalGateways] = useState([]);
+    const [externalGateways, setExternalGateways] = useState([]);
+    const [selectedExternalGateway, setSelectedExternalGateway] = useState([]);
     const isEndpointAvailable = api.endpointConfig !== null;
 
     const isDeployButtonDisabled = (((api.type !== 'WEBSUB' && !isEndpointAvailable))
     || api.workflowStatus === 'CREATED');
 
-    const defaultVhosts = internalGateways.map((e) => {
-        if (e.vhosts && e.vhosts.length > 0) {
-            return {
-                env: e.name,
-                vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
-            };
-        } else {
-            return undefined;
-        }
-    });
-
     const [descriptionOpen, setDescriptionOpen] = useState(false);
-    const [selectedEnvironment, setSelectedEnvironment] = useState(hasOnlyOneEnvironment
-        ? [internalGateways[0].name] : []);
+    const [selectedEnvironment, setSelectedEnvironment] = useState([]);
+    const [selectedVhostDeploy, setVhostsDeploy] = useState(null);
 
-    /**
-     * Get Solace environments from the environments list
-     * @return String Solace gateway environment name
-     */
-    function getSolaceEnvironment(envs) {
-        const solaceEnv= []
-        envs.forEach((env) => {
-            if (env.provider === 'solace') {
-                solaceEnv.push(env.name);
+    useEffect(() => {
+        let gatewayType;
+        if (api.apiType === 'APIPRODUCT') {
+            gatewayType = 'Regular';
+        } else {
+            switch (api.gatewayType) {
+                case 'wso2/synapse':
+                    gatewayType = 'Regular';
+                    break;
+                case 'wso2/apk':
+                    gatewayType = 'APK';
+                    break;
+                case 'AWS':
+                    gatewayType = 'AWS';
+                    break;
+                default:
+                    gatewayType = 'Regular';
             }
-        });
-        return solaceEnv;
-    }
+        }
+        const internalGatewaysFiltered = environments.filter((p) => p.provider.toLowerCase().includes('wso2'));
+        const selectedInternalGateways = internalGatewaysFiltered.filter((p) => 
+            p.gatewayType.toLowerCase() === gatewayType.toLowerCase())
+        if (selectedInternalGateways.length > 0) {
+            setInternalGateways(selectedInternalGateways);
+            const defaultVhosts = selectedInternalGateways.map((e) => {
+                if (e.vhosts && e.vhosts.length > 0) {
+                    return {
+                        env: e.name,
+                        vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
+                    };
+                } else {
+                    return undefined;
+                }
+            });
+            setVhostsDeploy(defaultVhosts);
+            setSelectedEnvironment(selectedInternalGateways.length === 1 ? [selectedInternalGateways[0].name] : []);
+        } else {
+            const external = environments.filter((p) => !p.provider.toLowerCase().includes('wso2'));
+            const selectedExternalGateways = external.filter((p) =>
+                p.gatewayType.toLowerCase() === gatewayType.toLowerCase());
+            setExternalGateways(selectedExternalGateways);
+            setSelectedExternalGateway(selectedExternalGateways.map((env) => env.name));
 
-    /**
-     * Get Organization value of external gateways
-     * @param {Object} additionalProperties the additionalProperties list
-     * @return String organization name
-     */
-    function getOrganizationFromAdditionalProperties(additionalProperties) {
-        let organization;
-        additionalProperties.forEach((property) => {
-            if (property.key === 'Organization') {
-                organization = property.value;
+            if (selectedExternalGateways.length > 0) {
+                const defaultVhosts = selectedExternalGateways.map((e) => {
+                    if (e.vhosts && e.vhosts.length > 0) {
+                        return {
+                            env: e.name,
+                            vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
+                        };
+                    } else {
+                        return undefined;
+                    }
+                });
+                setVhostsDeploy(defaultVhosts);
             }
-        });
-        return organization;
-    }
+        }
+        
+    }, []);
 
-    const [selectedSolaceEnvironment, setSelectedSolaceEnvironment] = useState(
-        getSolaceEnvironment(externalGateways),
-    );
-    const [selectedVhostDeploy, setVhostsDeploy] = useState(defaultVhosts);
+
+    // /**
+    //  * Get Organization value of external gateways
+    //  * @param {Object} additionalProperties the additionalProperties list
+    //  * @return String organization name
+    //  */
+    // function getOrganizationFromAdditionalProperties(additionalProperties) {
+    //     let organization;
+    //     additionalProperties.forEach((property) => {
+    //         if (property.key === 'Organization') {
+    //             organization = property.value;
+    //         }
+    //     });
+    //     return organization;
+    // }
 
     /**
      * Handle Description
@@ -222,12 +251,12 @@ export default function DeploymentOnboarding(props) {
     };
 
     const handleChange = (event) => {
-        if (gatewayVendor === 'solace') {
+        if (gatewayVendor !== 'wso2') {
             if (event.target.checked) {
-                setSelectedSolaceEnvironment([...selectedSolaceEnvironment, event.target.value]);
+                setSelectedExternalGateway([...selectedExternalGateway, event.target.value]);
             } else {
-                setSelectedSolaceEnvironment(
-                    selectedSolaceEnvironment.filter((env) => env !== event.target.value),
+                setSelectedExternalGateway(
+                    selectedExternalGateway.filter((env) => env !== event.target.value),
                 );
             }
         } else {
@@ -543,7 +572,10 @@ export default function DeploymentOnboarding(props) {
                             <Paper fullWidth className={classes.root}>
                                 <Box p={5}>
                                     <Typography className={classes.textRevision}>
-                                        Solace Environments
+                                        <FormattedMessage 
+                                            id='Apis.Details.Environments.deploy.api.external.gateways.text'
+                                            defaultMessage='API Gateways'
+                                        />
                                     </Typography>
                                     <Box mt={4}>
                                         <Grid
@@ -553,20 +585,20 @@ export default function DeploymentOnboarding(props) {
                                             { externalGateways.map((row) => (
                                                 <Grid item xs={3}>
                                                     <Card
-                                                        className={clsx(selectedSolaceEnvironment
-                                                        && selectedSolaceEnvironment.includes(row.name)
+                                                        className={clsx(selectedExternalGateway
+                                                        && selectedExternalGateway.includes(row.name)
                                                             ? (classes.changeCard) : (classes.noChangeCard),
                                                         classes.cardHeight)}
                                                         variant='outlined'
                                                     >
                                                         <CardHeader
-                                                            data-testid='solace-api-name'
+                                                            data-testid='external-name'
                                                             action={(
                                                                 <Checkbox
                                                                     id={row.name.split(' ').join('')}
                                                                     value={row.name}
                                                                     checked=
-                                                                        {selectedSolaceEnvironment.includes(row.name)}
+                                                                        {selectedExternalGateway.includes(row.name)}
                                                                     disabled={isRestricted(['apim:api_publish',
                                                                         'apim:api_create'])}
                                                                     onChange={handleChange}
@@ -593,36 +625,55 @@ export default function DeploymentOnboarding(props) {
                                                             )}
                                                         />
                                                         <CardContent className={classes.cardContentHeight}>
-                                                            <Grid
-                                                                container
-                                                                direction='column'
-                                                                spacing={2}
-                                                            >
-                                                                <Grid item xs={12}>
+                                                            <Grid item xs={12} sx={{ width: '100%' }}>
+                                                                <Tooltip
+                                                                    title={(
+                                                                        <>
+                                                                            <Typography color='inherit'>
+                                                                                {getVhostHelperText(row.name,
+                                                                                    selectedVhostDeploy)}
+                                                                            </Typography>
+                                                                        </>
+                                                                    )}
+                                                                    placement='right'
+                                                                >
                                                                     <TextField
-                                                                        data-testid='api-env-name'
-                                                                        id='Api.Details.Third.party.environment.name'
-                                                                        label='Environment'
-                                                                        variant='outlined'
-                                                                        disabled
-                                                                        fullWidth
-                                                                        margin='dense'
-                                                                        value={row.name}
-                                                                    />
-                                                                    <TextField
-                                                                        data-testid='api-org-name'
-                                                                        id='Api.Details.
-                                                                            Third.party.environment.organization'
-                                                                        label='Organization'
-                                                                        variant='outlined'
-                                                                        disabled
-                                                                        fullWidth
-                                                                        margin='dense'
-                                                                        value={getOrganizationFromAdditionalProperties(
-                                                                            row.additionalProperties,
+                                                                        id='vhost-selector'
+                                                                        select
+                                                                        label={(
+                                                                            <FormattedMessage
+                                                                                id='Apis.Details.
+                                                                                Environments.deploy.vhost'
+                                                                                defaultMessage='VHost'
+                                                                            />
                                                                         )}
-                                                                    />
-                                                                </Grid>
+                                                                        SelectProps={{
+                                                                            MenuProps: {
+                                                                                getContentAnchorEl: null,
+                                                                            },
+                                                                        }}
+                                                                        name={row.name}
+                                                                        value={selectedVhostDeploy.find(
+                                                                            (v) => v.env === row.name,
+                                                                        ).vhost}
+                                                                        onChange={handleVhostDeploySelect}
+                                                                        margin='dense'
+                                                                        variant='outlined'
+                                                                        fullWidth
+                                                                        helperText={getVhostHelperText(row.name,
+                                                                            selectedVhostDeploy, true)}
+                                                                    >
+                                                                        {row.vhosts?.map(
+                                                                            (vhost) => (
+                                                                                <MenuItem value={api.isWebSocket()
+                                                                                    ? vhost.wsHost : vhost.host}>
+                                                                                    {api.isWebSocket()
+                                                                                        ? vhost.wsHost : vhost.host}
+                                                                                </MenuItem>
+                                                                            ),
+                                                                        )}
+                                                                    </TextField>
+                                                                </Tooltip>
                                                             </Grid>
                                                         </CardContent>
                                                     </Card>
@@ -671,22 +722,24 @@ export default function DeploymentOnboarding(props) {
                                     </Box>
                                     <Box mt={3}>
                                         <Button
-                                            id='deploy-btn-solace'
+                                            id='deploy-btn-external'
                                             type='submit'
                                             variant='contained'
                                             onClick={
                                                 () => 
-                                                    createDeployRevision(selectedSolaceEnvironment, selectedVhostDeploy)
+                                                    createDeployRevision(selectedExternalGateway, selectedVhostDeploy)
                                             }
                                             color='primary'
-                                            disabled={selectedSolaceEnvironment.length === 0
+                                            disabled={selectedExternalGateway.length === 0
                                                 || isRestricted(['apim:api_publish', 'apim:api_create'])
-                                                || isDeployButtonDisabled}
+                                                || isDeployButtonDisabled || isDeploying}
                                         >
                                             <FormattedMessage
                                                 id='Apis.Details.Environments.Environments.deploy.deploy'
                                                 defaultMessage='Deploy'
                                             />
+                                            {' '}
+                                            {isDeploying && <CircularProgress size={24} />}
                                         </Button>
                                     </Box>
                                 </Box>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -62,6 +62,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import CardHeader from '@mui/material/CardHeader';
 import Checkbox from '@mui/material/Checkbox';
 import InfoIcon from '@mui/icons-material/Info';
+import { CircularProgress } from '@mui/material';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import API from 'AppData/api';
@@ -69,7 +70,6 @@ import { ConfirmDialog } from 'AppComponents/Shared/index';
 import { useRevisionContext } from 'AppComponents/Shared/RevisionContext';
 import Utils from 'AppData/Utils';
 import { Parser } from '@asyncapi/parser';
-import { upperCaseString } from 'AppData/stringFormatter';
 import GovernanceViolations from 'AppComponents/Shared/Governance/GovernanceViolations';
 import DisplayDevportal from './DisplayDevportal';
 import DeploymentOnbording from './DeploymentOnbording';
@@ -508,33 +508,88 @@ export default function Environments() {
     const restApi = new API();
     const restProductApi = new APIProduct();
     const [selectedRevision, setRevision] = useState([]);
-    const assignGateway = (api.gatewayType === "wso2/synapse" || api.apiType === "APIPRODUCT") ? "Regular" : "APK";
-    const externalGateways = settings && settings.environment.filter((p) => !p.provider.toLowerCase().includes('wso2'));
-    const internalGatewaysFiltered = settings && settings.environment.filter((p) =>
-        p.provider.toLowerCase().includes('wso2'));
-    const internalGateways = internalGatewaysFiltered && internalGatewaysFiltered.filter((p) =>
-        p.gatewayType.toLowerCase() === assignGateway.toLowerCase()
-    );
+    const [internalGateways, setInternalGateways] = useState([]);
+    const [externalGateways, setExternalGateways] = useState([]);
     const [selectedVhosts, setVhosts] = useState(null);
     const [selectedVhostDeploy, setVhostsDeploy] = useState([]);
+    const [SelectedEnvironment, setSelectedEnvironment] = useState([]);
+    const [allExternalGateways, setAllExternalGateways] = useState([]);
+    const [noEnv, setNoEnv] = useState(false);
+    const [isUndeploying, setIsUndeploying] = useState(false);
+    const [isDeploying, setIsDeploying] = useState(false);
+
     useEffect(() => {
         if (settings) {
-            const defaultVhosts = internalGateways.map((e) => {
-                if (e.vhosts && e.vhosts.length > 0) {
-                    const env = e.name;
-                    const vhost = api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host;
-                    return { env, vhost };
-                } else {
-                    return undefined;
+            let gatewayType;
+            if (api.apiType === 'APIPRODUCT') {
+                gatewayType = 'Regular';
+            } else {
+                switch (api.gatewayType) {
+                    case 'wso2/synapse':
+                        gatewayType = 'Regular';
+                        break;
+                    case 'wso2/apk':
+                        gatewayType = 'APK';
+                        break;
+                    case 'AWS':
+                        gatewayType = 'AWS';
+                        break;
+                    default:
+                        gatewayType = 'Regular';
                 }
-            });
-            setVhosts(defaultVhosts);
-            setVhostsDeploy(defaultVhosts);
+            }
+            const internalGatewaysFiltered = settings.environment.filter((p) =>
+                p.provider.toLowerCase().includes('wso2'));
+            const selectedInternalGateways = internalGatewaysFiltered.filter((p) =>
+                p.gatewayType.toLowerCase() === gatewayType.toLowerCase())
+            if (selectedInternalGateways.length > 0) {
+                setInternalGateways(selectedInternalGateways);
+                const defaultVhosts = selectedInternalGateways.map((e) => {
+                    if (e.vhosts && e.vhosts.length > 0) {
+                        return {
+                            env: e.name,
+                            vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
+                        };
+                    } else {
+                        return undefined;
+                    }
+                });
+                setVhosts(defaultVhosts);
+                setVhostsDeploy(defaultVhosts);
+                setSelectedEnvironment(selectedInternalGateways.length === 1 ?
+                    [selectedInternalGateways[0].name] : []);
+            } else {
+                const external = settings.environment.filter((p) => !p.provider.toLowerCase().includes('wso2'));
+                const selectedExternalGateways = external.filter((p) =>
+                    p.gatewayType.toLowerCase() === gatewayType.toLowerCase());
+                setExternalGateways(selectedExternalGateways);
+                if (selectedExternalGateways.length > 0) {
+                    selectedExternalGateways.forEach((env) => {
+                        setAllExternalGateways((prev) => [...prev, env]);
+                    });
+                    const defaultVhosts = selectedExternalGateways.map((e) => {
+                        if (e.vhosts && e.vhosts.length > 0) {
+                            return {
+                                env: e.name,
+                                vhost: api.isWebSocket() ? e.vhosts[0].wsHost : e.vhosts[0].host
+                            };
+                        } else {
+                            return undefined;
+                        }
+                    });
+                    setVhosts(defaultVhosts);
+                    setVhostsDeploy(defaultVhosts);
+                    setSelectedEnvironment(selectedExternalGateways.length === 1 ?
+                        [selectedExternalGateways[0].name] : []);
+                } else {
+                    setNoEnv(true);
+                }
+            }
         }
-    }, [settings]);
+    }, [isLoading]);
+
     const [extraRevisionToDelete, setExtraRevisionToDelete] = useState(null);
     const [description, setDescription] = useState('');
-    const [SelectedEnvironment, setSelectedEnvironment] = useState([]);
     const [open, setOpen] = useState(false);
     const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
     const [revisionToDelete, setRevisionToDelete] = useState([]);
@@ -542,23 +597,8 @@ export default function Environments() {
     const [revisionToRestore, setRevisionToRestore] = useState([]);
     const [currentLength, setCurrentLength] = useState(0);
     const [openDeployPopup, setOpenDeployPopup] = useState(history.location.state === 'deploy');
-    const [externalEnvEndpoints, setExternalEnvEndpoints] = useState(null);
     const [isGovernanceViolation, setIsGovernanceViolation] = useState(false);
     const [governanceError, setGovernanceError] = useState('');
-
-    const allExternalGatewaysMap = [];
-    const allExternalGateways = [];
-    if (externalGateways) {
-        externalGateways.forEach((env) => {
-            const revision = allEnvRevision && allEnvRevision.find(
-                (r) => r.deploymentInfo.some((e) => e.name === env.name),
-            );
-            const envDetails = revision && revision.deploymentInfo.find((e) => e.name === env.name);
-            const disPlayDevportal = envDetails && envDetails.displayOnDevportal;
-            allExternalGatewaysMap[env.name] = { revision, disPlayDevportal };
-            allExternalGateways.push(env);
-        });
-    }
 
 
     const externalEnvWithEndpoints = [];
@@ -608,7 +648,6 @@ export default function Environments() {
                     });
                     externalEnvWithEndpoints[env.name] = endpoints;
                 });
-                setExternalEnvEndpoints(externalEnvWithEndpoints);
             }
         })
     }, [api.id]);
@@ -644,17 +683,6 @@ export default function Environments() {
     };
 
     const handleSelect = (event) => {
-        const revisions = selectedRevision.filter((r) => r.env !== event.target.name);
-        const oldRevision = selectedRevision.find((r) => r.env === event.target.name);
-        let displayOnDevPortal = true;
-        if (oldRevision) {
-            displayOnDevPortal = oldRevision.displayOnDevPortal;
-        }
-        revisions.push({ env: event.target.name, revision: event.target.value, displayOnDevPortal });
-        setRevision(revisions);
-    };
-
-    const handleSelectForBrokers = (event) => {
         const revisions = selectedRevision.filter((r) => r.env !== event.target.name);
         const oldRevision = selectedRevision.find((r) => r.env === event.target.name);
         let displayOnDevPortal = true;
@@ -929,6 +957,7 @@ export default function Environments() {
             displayOnDevportal: false,
         }];
         if (api.apiType !== API.CONSTS.APIProduct) {
+            setIsUndeploying(true);
             restApi.undeployRevision(api.id, revisionId, body)
                 .then(() => {
                     Alert.info(intl.formatMessage({
@@ -950,6 +979,7 @@ export default function Environments() {
                     getRevision();
                     getDeployedEnv();
                 });
+            setIsUndeploying(false);
         } else {
             restProductApi.undeployProductRevision(api.id, revisionId, body)
                 .then(() => {
@@ -1017,6 +1047,7 @@ export default function Environments() {
             vhost,
         }];
         if (api.apiType !== API.CONSTS.APIProduct) {
+            setIsDeploying(true);
             restApi.deployRevision(api.id, revisionId, body).then((response) => {
                 if (response && response.obj && response.obj.length > 0) {
                     if (response.obj[0]?.status === null || response.obj[0]?.status === 'APPROVED') {
@@ -1044,6 +1075,7 @@ export default function Environments() {
             }).finally(() => {
                 getRevision();
                 getDeployedEnv();
+                setIsDeploying(false);
             });
         } else {
             restProductApi.deployProductRevision(api.id, revisionId, body)
@@ -1089,10 +1121,11 @@ export default function Environments() {
                     for (const env of envList) {
                         body1.push({
                             name: env,
-                            vhost: api.gatewayVendor === 'wso2' ? vhostList.find((v) => v.env === env).vhost : ' ',
+                            vhost: vhostList.find((v) => v.env === env).vhost,
                             displayOnDevportal: true,
                         });
                     }
+                    setIsDeploying(true);
                     restApi.deployRevision(api.id, response.body.id, body1)
                         .then(() => {
                             Alert.info(intl.formatMessage({
@@ -1131,6 +1164,8 @@ export default function Environments() {
                             history.replace();
                             getRevision();
                             getDeployedEnv();
+                            setIsDeploying(false);
+                            setOpenDeployPopup(false);
                         });
                 })
                 .catch((error) => {
@@ -1159,7 +1194,6 @@ export default function Environments() {
                     }
                     console.error(error);
                 });
-            setOpenDeployPopup(false);
         } else {
             restProductApi.createProductRevision(api.id, body)
                 .then((response) => {
@@ -1265,21 +1299,6 @@ export default function Environments() {
             open={confirmDeleteOpen}
         />
     );
-
-    /**
-     * Get Organization value of external gateways
-     * @param {Object} additionalProperties the additionalProperties list
-     * @return String organization name
-     */
-    function getOrganizationFromAdditionalProperties(additionalProperties) {
-        let organization;
-        additionalProperties.forEach((property) => {
-            if (property.key === 'Organization') {
-                organization = property.value;
-            }
-        });
-        return organization;
-    }
 
     const confirmRestoreDialog = (
         <ConfirmDialog
@@ -1833,7 +1852,7 @@ export default function Environments() {
                             !selectedRevision.some((r) => r.env === row.name && r.revision) ||
                             !selectedVhosts.some((v) => v.env === row.name && v.vhost) ||
                             (api.advertiseInfo && api.advertiseInfo.advertised) ||
-                            isDeployButtonDisabled
+                            isDeployButtonDisabled || isDeploying
                         }
                         variant='outlined'
                         onClick={() =>
@@ -1849,6 +1868,8 @@ export default function Environments() {
                             id='Apis.Details.Environments.Environments.deploy.button'
                             defaultMessage='Deploy'
                         />
+                        {' '}
+                        {isDeploying && <CircularProgress size={24} />}
                     </Button>
                 </div>
             );
@@ -1943,7 +1964,7 @@ export default function Environments() {
                         !selectedRevision.some((r) => r.env === row.name && r.revision) ||
                         !selectedVhosts.some((v) => v.env === row.name && v.vhost) ||
                         (api.advertiseInfo && api.advertiseInfo.advertised) ||
-                        isDeployButtonDisabled
+                        isDeployButtonDisabled || isDeploying
                     }
                     variant='outlined'
                     onClick={() =>
@@ -2003,7 +2024,7 @@ export default function Environments() {
                     <Button
                         className={classes.button1}
                         variant='outlined'
-                        disabled={api.isRevision ||
+                        disabled={isUndeploying || api.isRevision ||
                             (settings && settings.portalConfigurationOnlyModeEnabled) ||
                             isRestricted(['apim:api_create', 'apim:api_publish'], api)}
                         onClick={() => undeployRevision(approvedDeployment.id, row.name)}
@@ -2039,12 +2060,13 @@ export default function Environments() {
         const selected = selectionList && selectionList.find((v) => v.env === env);
         if (selected) {
             let vhost;
-            if (api.isWebSocket()) {
-                vhost = internalGateways.find((e) => e.name === env).vhosts.find(
+            const gateways = internalGateways.length > 0 ? internalGateways: externalGateways;
+            if (api.isWebSocket() ) {
+                vhost = gateways.find((e) => e.name === env).vhosts.find(
                     (v) => v.wsHost === selected.vhost,
                 );
             } else {
-                vhost = internalGateways.find((e) => e.name === env).vhosts.find(
+                vhost = gateways.find((e) => e.name === env).vhosts.find(
                     (v) => v.host === selected.vhost,
                 );
             }
@@ -2065,9 +2087,26 @@ export default function Environments() {
         return '';
     }
 
-    if (isLoading || selectedVhosts === null) {
+    if (!noEnv && (isLoading || selectedVhosts === null)) {
         return <Progress per={80} message='Loading app settings ...' />;
     }
+
+    if (noEnv) {
+        return (
+            <Grid container>
+                <Grid item>
+                    <Typography variant='h5' gutterBottom>
+                        <FormattedMessage
+                            id='Apis.Details.Environments.Environments.no.env.heading'
+                            defaultMessage='No Gateway Environments Configured for the selected gateway type'
+
+                        />
+                    </Typography>
+                </Grid>
+            </Grid>
+        );
+    }
+
     // allEnvDeployments represents all deployments of the API with mapping
     // environment -> {revision deployed to env, vhost deployed to env with revision}
     const allEnvDeployments = allEnvRevision ?
@@ -2098,6 +2137,7 @@ export default function Environments() {
                     setDescription={setDescription}
                     gatewayVendor={api.gatewayVendor}
                     advertiseInfo={api.advertiseInfo}
+                    isDeploying={isDeploying}
                 />
             )}
             {allRevisions && allRevisions.length !== 0 && (
@@ -2485,12 +2525,12 @@ export default function Environments() {
                                 </Grid>
                             </Box>
                         )}
-                        {(api.gatewayVendor === 'solace') && (allExternalGateways.length > 0) && (
+                        {(api.gatewayVendor !== 'wso2') && (allExternalGateways.length > 0) && (
                             <Box mt={2}>
                                 <Typography variant='h6' align='left' className={classes.sectionTitle}>
                                     <FormattedMessage
-                                        id='Apis.Details.Environments.Environments.solace.platform.environments.heading'
-                                        defaultMessage='Solace Platform Environments'
+                                        id='Apis.Details.Environments.Environments.external.gateways.heading'
+                                        defaultMessage='API Gateways'
                                     />
                                 </Typography>
                                 <Grid
@@ -2541,28 +2581,55 @@ export default function Environments() {
                                                             direction='column'
                                                             spacing={2}
                                                         >
-                                                            <Grid item xs={12}>
-                                                                <TextField
-                                                                    id='Api.Details.Third.party.environment.name'
-                                                                    label='Environment'
-                                                                    variant='outlined'
-                                                                    disabled
-                                                                    fullWidth
-                                                                    margin='dense'
-                                                                    value={row.name}
-                                                                />
-                                                                <TextField
-                                                                    id='Api.Details.
-                                                                        Third.party.environment.organization'
-                                                                    label='Organization'
-                                                                    variant='outlined'
-                                                                    disabled
-                                                                    fullWidth
-                                                                    margin='dense'
-                                                                    value={getOrganizationFromAdditionalProperties(
-                                                                        row.additionalProperties,
+                                                            <Grid item xs={12} sx={{ width: '100%' }}>
+                                                                <Tooltip
+                                                                    title={(
+                                                                        <>
+                                                                            <Typography color='inherit'>
+                                                                                {getVhostHelperText(row.name,
+                                                                                    selectedVhostDeploy)}
+                                                                            </Typography>
+                                                                        </>
                                                                     )}
-                                                                />
+                                                                    placement='right'
+                                                                >
+                                                                    <TextField
+                                                                        id='vhost-selector'
+                                                                        select
+                                                                        label={(
+                                                                            <FormattedMessage
+                                                                                id='Apis.Details.
+                                                                                Environments.deploy.vhost'
+                                                                                defaultMessage='VHost'
+                                                                            />
+                                                                        )}
+                                                                        SelectProps={{
+                                                                            MenuProps: {
+                                                                                getContentAnchorEl: null,
+                                                                            },
+                                                                        }}
+                                                                        name={row.name}
+                                                                        value={selectedVhostDeploy.find(
+                                                                            (v) => v.env === row.name,
+                                                                        ).vhost}
+                                                                        onChange={handleVhostDeploySelect}
+                                                                        margin='dense'
+                                                                        variant='outlined'
+                                                                        fullWidth
+                                                                        helperText={getVhostHelperText(row.name,
+                                                                            selectedVhostDeploy, true)}
+                                                                    >
+                                                                        {row.vhosts?.map(
+                                                                            (vhost) => (
+                                                                                <MenuItem value={api.isWebSocket()
+                                                                                    ? vhost.wsHost : vhost.host}>
+                                                                                    {api.isWebSocket()
+                                                                                        ? vhost.wsHost : vhost.host}
+                                                                                </MenuItem>
+                                                                            ),
+                                                                        )}
+                                                                    </TextField>
+                                                                </Tooltip>
                                                             </Grid>
                                                         </Grid>
                                                     </CardContent>
@@ -2593,12 +2660,14 @@ export default function Environments() {
                                 || (allRevisions && allRevisions.length === revisionCount && !extraRevisionToDelete)
                                 || isRestricted(['apim:api_create', 'apim:api_publish'], api)
                                 || (api.advertiseInfo && api.advertiseInfo.advertised)
-                                || isDeployButtonDisabled}
+                                || isDeployButtonDisabled || isDeploying}
                         >
                             <FormattedMessage
                                 id='Apis.Details.Environments.Environments.deploy.deploy'
                                 defaultMessage='Deploy'
                             />
+                            {' '}
+                            {isDeploying && <CircularProgress size={24} />}
                         </Button>
                     </DialogActions>
                 </StyledDialog>
@@ -2956,7 +3025,7 @@ export default function Environments() {
                                                             fullWidth
                                                             disabled={
                                                                 api.isRevision
-                                                                || (settings 
+                                                                || (settings
                                                                     && settings.portalConfigurationOnlyModeEnabled)
                                                                 || !allRevisions || allRevisions.length === 0
                                                             }
@@ -3003,13 +3072,13 @@ export default function Environments() {
                     </TableContainer>
                 </Box>
             )}
-            {allRevisions && allRevisions.length !== 0 && (api.gatewayVendor === 'solace')
-                && (allExternalGateways.length > 0) && (
+            {allRevisions && allRevisions.length !== 0 && (api.gatewayVendor !== 'wso2')
+            && (allExternalGateways.length > 0) && (
                 <Box mx='auto' mt={5}>
                     <Typography variant='h6' className={classes.sectionTitle}>
                         <FormattedMessage
-                            id='Apis.Details.Solace.Platform.Environments'
-                            defaultMessage='Solace Platform Environments'
+                            id='Apis.Details.External.Gateways'
+                            defaultMessage='API Gateways'
                         />
                     </Typography>
                     <TableContainer component={Paper}>
@@ -3018,43 +3087,23 @@ export default function Environments() {
                                 <TableRow>
                                     <TableCell align='left'>
                                         <FormattedMessage
-                                            id='Apis.Details.Third.Party.Brokers.broker.displayName'
+                                            id='Apis.Details.Environments.Environments.api.gateways.name'
                                             defaultMessage='Name'
                                         />
                                     </TableCell>
-                                    {externalEnvEndpoints && (
-                                        <TableCell align='left'>
-                                            <FormattedMessage
-                                                id='Apis.Details.Third.Party.Brokers.broker.endpoints'
-                                                defaultMessage='Access Endpoints'
-                                            />
-                                        </TableCell>
-                                    )}
                                     <TableCell align='left'>
                                         <FormattedMessage
-                                            id='Apis.Details.Third.Party.Brokers.broker.environment'
-                                            defaultMessage='Environment'
-                                        />
-                                    </TableCell>
-                                    <TableCell align='left'>
-                                        <FormattedMessage
-                                            id='Apis.Details.Third.Party.Brokers.broker.type'
-                                            defaultMessage='Organization'
-                                        />
-                                    </TableCell>
-                                    <TableCell align='left'>
-                                        <FormattedMessage
-                                            id='Apis.Details.Third.Party.Brokers.broker.name'
-                                            defaultMessage='Provider'
+                                            id='Apis.Details.Environments.Environments.gateway.accessUrl'
+                                            defaultMessage='Gateway Access URL'
                                         />
                                     </TableCell>
                                     {api && api.isDefaultVersion !== true
                                         ? (
                                             <TableCell align='left'>
                                                 <FormattedMessage
-                                                    id='Apis.Details.Environments.
-                                                        Environments.gateway.deployed.revision'
-                                                    defaultMessage='Deployed Revision'
+                                                    id='Apis.Details.Environments.Environments.gateway
+                                                    .deployment.current.revision'
+                                                    defaultMessage='Current Revision'
                                                 />
                                             </TableCell>
                                         )
@@ -3068,9 +3117,49 @@ export default function Environments() {
                                         )}
                                     <TableCell align='left'>
                                         <FormattedMessage
-                                            id='Apis.Details.Environments.Environments.display.in.devportal'
-                                            defaultMessage='Display in Developer Portal'
+                                            id='Apis.Details.Environments.Environments.gateway.deployment.next.revision'
+                                            defaultMessage='Next Revision'
                                         />
+                                    </TableCell>
+                                    <TableCell align='left'>
+                                        <FormattedMessage
+                                            id='Apis.Details.Environments.Environments.visibility.in.devportal'
+                                            defaultMessage='Gateway URL Visibility'
+                                        />
+                                        <Tooltip
+                                            title={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Environments.Environments.display.devportal'
+                                                    defaultMessage='Display Gateway Access URLs in developer portal.'
+                                                />
+                                            )}
+                                            placement='top-end'
+                                            aria-label='New Deployment'
+                                        >
+                                            <IconButton size='small' aria-label='delete'>
+                                                <HelpOutlineIcon fontSize='small' />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </TableCell>
+                                    <TableCell>
+                                        <FormattedMessage
+                                            id='Apis.Details.Environments.Environments.visibility.permission'
+                                            defaultMessage='Visibility Permission'
+                                        />
+                                        <Tooltip
+                                            title={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Environments.Environments.visibility.permission'
+                                                    defaultMessage='Gateway Environment Visibility in Developer Portal.'
+                                                />
+                                            )}
+                                            placement='top-end'
+                                            aria-label='New Deployment'
+                                        >
+                                            <IconButton size='small' aria-label='delete'>
+                                                <HelpOutlineIcon fontSize='small' />
+                                            </IconButton>
+                                        </Tooltip>
                                     </TableCell>
                                 </TableRow>
                             </TableHead>
@@ -3080,83 +3169,65 @@ export default function Environments() {
                                         <TableCell component='th' scope='row'>
                                             {row.displayName}
                                         </TableCell>
-                                        {externalEnvEndpoints && (
-                                            <TableCell align='left'>
-                                                {externalEnvEndpoints[row.name] &&
-                                                        externalEnvEndpoints[row.name].map((e) => {
-                                                            return (
-                                                                <Grid container spacing={2}>
-                                                                    <Grid item>
-                                                                        <Chip
-                                                                            label={upperCaseString(e.protocol)}
-                                                                            size='small'
-                                                                            color='primary'
-                                                                            variant='outlined'
-                                                                        />
-                                                                    </Grid>
-                                                                    <Grid
-                                                                        item
-                                                                        style={{
-                                                                            display: 'flex',
-                                                                            alignItems: 'center',
-                                                                            justifyContent: 'center',
-                                                                        }}
-                                                                    >
-                                                                        {e.uri}
-                                                                    </Grid>
-                                                                </Grid>
-                                                            );
-                                                        })
-                                                }
-                                            </TableCell>
-                                        )}
-                                        <TableCell align='left'>
-                                            {row.name}
-                                        </TableCell>
-                                        <TableCell align='left'>
-                                            {getOrganizationFromAdditionalProperties(row.additionalProperties)}
-                                        </TableCell>
-                                        <TableCell align='left'>
-                                            {row.provider}
-                                        </TableCell>
-                                        <TableCell align='left' style={{ width: '300px' }}>
-                                            {allExternalGatewaysMap[row.name].revision != null
-                                                ? (
-                                                    <div>
-                                                        <Chip
-                                                            label={allExternalGatewaysMap[row.name]
-                                                                .revision.displayName}
-                                                            style={{ backgroundColor: '#15B8CF' }}
-                                                        />
-                                                        <Button
-                                                            className={classes.button1}
-                                                            variant='outlined'
-                                                            disabled={api.isRevision ||
-                                                                    (settings &&
-                                                                        settings.portalConfigurationOnlyModeEnabled
-                                                                    )}
-                                                            onClick={() => undeployRevision(
-                                                                allExternalGatewaysMap[row.name]
-                                                                    .revision.id, row.name,
-                                                            )}
-                                                            size='small'
-                                                        >
-                                                            <FormattedMessage
-                                                                id='Apis.Details.Environments.Environments.undeploy.btn'
-                                                                defaultMessage='Undeploy'
-                                                            />
-                                                        </Button>
+                                        {allEnvDeployments[row.name].revision != null ? (
+                                            <>
+                                                <TableCell align='left' id='gateway-access-url-cell'>
+                                                    <div className={classes.primaryEndpoint}>
+                                                        {api.isWebSocket()
+                                                            ? getGatewayAccessUrl(allEnvDeployments[row.name]
+                                                                .vhost, 'WS')
+                                                                .primary : getGatewayAccessUrl(
+                                                                allEnvDeployments[row.name].vhost, 'HTTP',
+                                                            ).primary}
                                                     </div>
-                                                ) : (
-                                                    <div style={{ display: 'flex', justifyContent: 'center' }}>
+                                                    <div className={classes.secondaryEndpoint}>
+                                                        {api.isWebSocket()
+                                                            ? getGatewayAccessUrl(allEnvDeployments[row.name]
+                                                                .vhost, 'WS')
+                                                                .secondary : getGatewayAccessUrl(
+                                                                allEnvDeployments[row.name].vhost, 'HTTP',
+                                                            ).secondary}
+                                                    </div>
+                                                    {api.isGraphql()
+                                                    && (
+                                                        <>
+                                                            <div className={classes.primaryEndpoint}>
+                                                                {getGatewayAccessUrl(allEnvDeployments[row.name]
+                                                                    .vhost, 'WS')
+                                                                    .primary}
+                                                            </div>
+                                                            <div className={classes.secondaryEndpoint}>
+                                                                {getGatewayAccessUrl(allEnvDeployments[row.name]
+                                                                    .vhost, 'WS')
+                                                                    .secondary}
+                                                            </div>
+                                                        </>
+
+                                                    )}
+                                                </TableCell>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <TableCell align='left' className={classes.tableCellVhostSelect}>
+                                                    <Tooltip
+                                                        title={(
+                                                            <>
+                                                                <Typography color='inherit'>
+                                                                    {getVhostHelperText(row.name,
+                                                                        selectedVhosts)}
+                                                                </Typography>
+                                                            </>
+                                                        )}
+                                                        placement='bottom'
+                                                    >
                                                         <TextField
-                                                            id='revision-selector'
+                                                            id='vhost-selector'
                                                             select
                                                             label={(
                                                                 <FormattedMessage
-                                                                    id='Apis.Details.Environments.
-                                                                            Environments.select.table'
-                                                                    defaultMessage='Select Revision'
+                                                                    id='Apis.Details.Environments.Environments
+                                                                    .select.vhost'
+                                                                    defaultMessage='Select Access URL'
                                                                 />
                                                             )}
                                                             SelectProps={{
@@ -3165,58 +3236,49 @@ export default function Environments() {
                                                                 },
                                                             }}
                                                             name={row.name}
-                                                            onChange={handleSelectForBrokers}
+                                                            value={selectedVhosts.find((v) => v.env === row.name).vhost}
+                                                            onChange={handleVhostSelect}
                                                             margin='dense'
                                                             variant='outlined'
-                                                            style={{ width: '50%' }}
-                                                            disabled={api.isRevision ||
-                                                                    (settings &&
-                                                                        settings.portalConfigurationOnlyModeEnabled
-                                                                    )
-                                                                    || !allRevisions || allRevisions.length === 0}
+                                                            className={classes.vhostSelect}
+                                                            fullWidth
+                                                            disabled={api.isRevision
+                                                            || (settings && settings.portalConfigurationOnlyModeEnabled)
+                                                            || !allRevisions || allRevisions.length === 0}
+                                                            helperText={getVhostHelperText(row.name, selectedVhosts,
+                                                                true, 100)}
                                                         >
-                                                            {allRevisions && allRevisions.length !== 0
-                                                                    && allRevisions.map(
-                                                                        (number) => (
-                                                                            <MenuItem value={number.id}>
-                                                                                {number.displayName}
-                                                                            </MenuItem>
-                                                                        ),
-                                                                    )}
+                                                            {row.vhosts.map(
+                                                                (vhost) => (
+                                                                    <MenuItem value={api.isWebSocket()
+                                                                        ? vhost.wsHost : vhost.host}>
+                                                                        {api.isWebSocket()
+                                                                            ? vhost.wsHost : vhost.host}
+                                                                    </MenuItem>
+                                                                ),
+                                                            )}
                                                         </TextField>
-                                                        <Button
-                                                            className={classes.button2}
-                                                            disabled={api.isRevision ||
-                                                                (settings &&
-                                                                    settings.portalConfigurationOnlyModeEnabled
-                                                                )
-                                                                || !selectedRevision.some(
-                                                                    (r) => r.env === row.name && r.revision,
-                                                                ) || (api.advertiseInfo && api.advertiseInfo.advertised)
-                                                                || isDeployButtonDisabled}
-                                                            variant='outlined'
-                                                            onClick={() => deployRevision(selectedRevision.find(
-                                                                (r) => r.env === row.name,
-                                                            ).revision, row.name,
-                                                            ' ', selectedRevision.find(
-                                                                (r) => r.env === row.name,
-                                                            ).displayOnDevPortal)}
-
-                                                        >
-                                                            <FormattedMessage
-                                                                id='Apis.Details.Environments.Environments
-                                                                .deploy.button'
-                                                                defaultMessage='Deploy'
-                                                            />
-                                                        </Button>
-                                                    </div>
-                                                )}
+                                                    </Tooltip>
+                                                </TableCell>
+                                            </>
+                                        )}
+                                        <TableCell component='th' scope='row'>
+                                            {getDeployedRevisionComponent(row, allEnvRevisionMapping)}
+                                        </TableCell>
+                                        <TableCell align='left' style={{ width: '300px' }}>
+                                            {getDeployedRevisionStatusComponent(row, allEnvRevisionMapping)}
                                         </TableCell>
                                         <TableCell align='left'>
                                             <DisplayDevportal
                                                 name={row.name}
                                                 api={api}
-                                                EnvDeployments={allExternalGatewaysMap[row.name]}
+                                                EnvDeployments={allEnvDeployments[row.name]}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Permission
+                                                type={row.permissions.permissionType}
+                                                roles={row.permissions.roles}
                                             />
                                         </TableCell>
                                     </TableRow>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Permission.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Permission.jsx
@@ -33,7 +33,7 @@ export default function SimplePopper(props) {
     } = props;
     const [anchorEl, setAnchorEl] = React.useState(null);
 
-    let msg = roles.toString();
+    let msg = roles?.toString();
     if (type === 'PUBLIC') {
         msg = 'No Visibility Restrictions!';
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/MetaData.jsx
@@ -145,7 +145,10 @@ function MetaData(props) {
                             </Grid>
                             <Grid item xs={12} md={6} lg={8}>
                                 <Typography component='p' variant='body1'>
-                                    {api.gatewayType === 'wso2/synapse' ? 'Regular' : 'APK'}
+                                    {api.gatewayType === 'wso2/synapse' && 'Regular'}
+                                    {api.gatewayType === 'wso2/apk' && 'APK'}
+                                    {api.gatewayType !== 'wso2/synapse' && api.gatewayType !== 'wso2/apk' 
+                                        && api.gatewayType}
                                 </Typography>
                             </Grid>
                         </>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operation.jsx
@@ -197,7 +197,7 @@ class Operation extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            isSecurity: false,
+            isSecurity: props.componentValidator.includes('operationSecurity'),
         };
         this.handleScopeChange = this.handleScopeChange.bind(this);
         this.handlePolicyChange = this.handlePolicyChange.bind(this);
@@ -255,7 +255,7 @@ class Operation extends React.Component {
      */
     render() {
         const {
-            operation, theme, apiPolicies, scopes, isOperationRateLimiting, sharedScopes, intl,
+            operation, theme, apiPolicies, scopes, isOperationRateLimiting, sharedScopes, intl, componentValidator,
         } = this.props;
         const dropdownScopes = [...scopes];
         const { isSecurity } = this.state;
@@ -288,127 +288,138 @@ class Operation extends React.Component {
                         className={classes.chipActive}
                     />
                 </TableCell>
-                <TableCell>
-                    <Select
-                        className={classes.dropDown}
-                        value={isOperationRateLimiting ? operation.throttlingPolicy : ''}
-                        disabled={(!isOperationRateLimiting || isRestricted(['apim:api_publish', 'apim:api_create']))}
-                        onChange={this.handlePolicyChange}
-                        fieldName='Throttling Policy'
-                    >
-                        {apiPolicies.map((policy) => (
-                            <MenuItem
-                                key={policy.name}
-                                value={policy.name}
-                            >
-                                {policy.displayName}
-                            </MenuItem>
-                        ))}
-                    </Select>
-                </TableCell>
-                <TableCell>
-                    <TextField
-                        id='operation_scope'
-                        select
-                        SelectProps={{
-                            multiple: true,
-                            renderValue: (selected) => (Array.isArray(selected) ? selected.join(', ') : selected),
-                        }}
-                        fullWidth
-                        label={dropdownScopes.length !== 0 || sharedScopes ? intl.formatMessage({
-                            id: 'Apis.Details.Operations.Operation.operation.scope.label.default',
-                            defaultMessage: 'Operation scope',
-                        }) : intl.formatMessage({
-                            id: 'Apis.Details.Operations.Operation.operation.scope.label.notAvailable',
-                            defaultMessage: 'No scope available',
-                        })}
-                        value={operation.scopes}
-                        onChange={({ target: { value } }) => this.handleScopeChange({
-                            data: { value: value ? [value] : [] },
-                        })}
-                        helperText={(
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.helperText'
-                                defaultMessage='Select a scope to control permissions to this operation'
-                            />
-                        )}
-                        margin='dense'
-                        variant='outlined'
-                        disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
-                    >
-                        <ListSubheader>
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.select.local'
-                                defaultMessage='API Scopes'
-                            />
-                        </ListSubheader>
-                        {filteredApiScopes.length !== 0 ? filteredApiScopes.map((apiScope) => (
-                            <MenuItem
-                                key={apiScope.scope.name}
-                                value={apiScope.scope.name}
-                                dense
-                            >
-                                <Checkbox checked={operation.scopes.includes(apiScope.scope.name)} color='primary' />
-                                {apiScope.scope.name}
-                            </MenuItem>
-                        )) : (
-                            <MenuItem
-                                value=''
-                                disabled
-                            >
-                                <em>
+                {componentValidator.includes('operationLevelRateLimiting') &&
+                    <TableCell>
+                        <Select
+                            className={classes.dropDown}
+                            value={isOperationRateLimiting ? operation.throttlingPolicy : ''}
+                            disabled={(!isOperationRateLimiting || 
+                                isRestricted(['apim:api_publish', 'apim:api_create']))}
+                            onChange={this.handlePolicyChange}
+                            fieldName='Throttling Policy'
+                        >
+                            {apiPolicies.map((policy) => (
+                                <MenuItem
+                                    key={policy.name}
+                                    value={policy.name}
+                                >
+                                    {policy.displayName}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </TableCell>
+                }
+                {componentValidator.includes('operationSecurity') &&
+                    <>
+                        <TableCell>
+                            <TextField
+                                id='operation_scope'
+                                select
+                                SelectProps={{
+                                    multiple: true,
+                                    renderValue: (selected) => 
+                                        (Array.isArray(selected) ? selected.join(', ') : selected),
+                                }}
+                                fullWidth
+                                label={dropdownScopes.length !== 0 || sharedScopes ? intl.formatMessage({
+                                    id: 'Apis.Details.Operations.Operation.operation.scope.label.default',
+                                    defaultMessage: 'Operation scope',
+                                }) : intl.formatMessage({
+                                    id: 'Apis.Details.Operations.Operation.operation.scope.label.notAvailable',
+                                    defaultMessage: 'No scope available',
+                                })}
+                                value={operation.scopes}
+                                onChange={({ target: { value } }) => this.handleScopeChange({
+                                    data: { value: value ? [value] : [] },
+                                })}
+                                helperText={(
                                     <FormattedMessage
-                                        id='Apis.Details.Operations.Operation.operation.no.api.scope.available'
-                                        defaultMessage='No API scopes available'
+                                        id='Apis.Details.Operations.Operation.operation.scope.helperText'
+                                        defaultMessage='Select a scope to control permissions to this operation'
                                     />
-                                </em>
-                            </MenuItem>
-                        )}
-                        <ListSubheader>
-                            <FormattedMessage
-                                id='Apis.Details.Operations.Operation.operation.scope.select.shared'
-                                defaultMessage='Shared Scopes'
-                            />
-                        </ListSubheader>
-                        {sharedScopes && sharedScopes.length !== 0 ? sharedScopes.map((sharedScope) => (
-                            <MenuItem
-                                key={sharedScope.scope.name}
-                                value={sharedScope.scope.name}
-                                dense
+                                )}
+                                margin='dense'
+                                variant='outlined'
+                                disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
                             >
-                                <Checkbox checked={operation.scopes.includes(sharedScope.scope.name)} color='primary' />
-                                {sharedScope.scope.name}
-                            </MenuItem>
-                        )) : (
-                            <MenuItem
-                                value=''
-                                disabled
-                            >
-                                <em>
+                                <ListSubheader>
                                     <FormattedMessage
-                                        id='Apis.Details.Operations.Operation.operation.no.sharedpi.scope.available'
-                                        defaultMessage='No shared scopes available'
+                                        id='Apis.Details.Operations.Operation.operation.scope.select.local'
+                                        defaultMessage='API Scopes'
                                     />
-                                </em>
-                            </MenuItem>
-                        )}
-                    </TextField>
-                </TableCell>
-                <TableCell>
-                    <Switch
-                        checked={(() => {
-                            if (operation.authType === 'None') {
-                                return false;
-                            }
-                            return true;
-                        })()}
-                        onChange={this.handleChange}
-                        value={isSecurity}
-                        color='primary'
-                        disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
-                        data-testid={operation.target + '-security-btn'}
-                    />
-                </TableCell>
+                                </ListSubheader>
+                                {filteredApiScopes.length !== 0 ? filteredApiScopes.map((apiScope) => (
+                                    <MenuItem
+                                        key={apiScope.scope.name}
+                                        value={apiScope.scope.name}
+                                        dense
+                                    >
+                                        <Checkbox checked={operation.scopes.includes(apiScope.scope.name)} 
+                                            color='primary' />
+                                        {apiScope.scope.name}
+                                    </MenuItem>
+                                )) : (
+                                    <MenuItem
+                                        value=''
+                                        disabled
+                                    >
+                                        <em>
+                                            <FormattedMessage
+                                                id='Apis.Details.Operations.Operation.operation.no.api.scope.available'
+                                                defaultMessage='No API scopes available'
+                                            />
+                                        </em>
+                                    </MenuItem>
+                                )}
+                                <ListSubheader>
+                                    <FormattedMessage
+                                        id='Apis.Details.Operations.Operation.operation.scope.select.shared'
+                                        defaultMessage='Shared Scopes'
+                                    />
+                                </ListSubheader>
+                                {sharedScopes && sharedScopes.length !== 0 ? sharedScopes.map((sharedScope) => (
+                                    <MenuItem
+                                        key={sharedScope.scope.name}
+                                        value={sharedScope.scope.name}
+                                        dense
+                                    >
+                                        <Checkbox checked={operation.scopes.includes(sharedScope.scope.name)} 
+                                            color='primary' />
+                                        {sharedScope.scope.name}
+                                    </MenuItem>
+                                )) : (
+                                    <MenuItem
+                                        value=''
+                                        disabled
+                                    >
+                                        <em>
+                                            <FormattedMessage
+                                                id='Apis.Details.Operations
+                                                    .Operation.operation.no.sharedpi.scope.available'
+                                                defaultMessage='No shared scopes available'
+                                            />
+                                        </em>
+                                    </MenuItem>
+                                )}
+                            </TextField>
+                        </TableCell>
+                        <TableCell>
+                            <Switch
+                                checked={(() => {
+                                    if (operation.authType === 'None') {
+                                        return false;
+                                    }
+                                    return true;
+                                })()}
+                                onChange={this.handleChange}
+                                value={isSecurity}
+                                color='primary'
+                                disabled={isRestricted(['apim:api_publish', 'apim:api_create'])}
+                                data-testid={operation.target + '-security-btn'}
+                            />
+                        </TableCell>
+                    </>
+                }
             </StyledTableRow>
         );
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Operations/Operations.jsx
@@ -351,7 +351,7 @@ class Operations extends React.Component {
      * @inheritdoc
      */
     render() {
-        const { api, resourceNotFoundMessage, intl} = this.props;
+        const { api, resourceNotFoundMessage, intl, componentValidator} = this.props;
         const {
             operations, apiPolicies, apiThrottlingPolicy, isSaving,
             filterKeyWord, notFound, sharedScopes, enableReadOnly,
@@ -429,30 +429,37 @@ class Operations extends React.Component {
                                                 />
                                             </Typography>
                                         </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.throttling.policy'
-                                                    defaultMessage='Rate Limiting'
-                                                />
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.scopes'
-                                                    defaultMessage='Scope'
-                                                />
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant='subtitle2'>
-                                                <FormattedMessage
-                                                    id='Apis.Details.Operations.Operation.authType'
-                                                    defaultMessage='Security Enabled'
-                                                />
-                                            </Typography>
-                                        </TableCell>
+                                        {componentValidator.includes("operationLevelRateLimiting") &&
+                                            <TableCell>
+                                                <Typography variant='subtitle2'>
+                                                    <FormattedMessage
+                                                        id='Apis.Details.Operations.Operation
+                                                            .throttling.policy'
+                                                        defaultMessage='Rate Limiting'
+                                                    />
+                                                </Typography>
+                                            </TableCell>
+                                        }
+                                        {componentValidator.includes("operationSecurity") &&
+                                            <>
+                                                <TableCell>
+                                                    <Typography variant='subtitle2'>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Operations.Operation.scopes'
+                                                            defaultMessage='Scope'
+                                                        />
+                                                    </Typography>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Typography variant='subtitle2'>
+                                                        <FormattedMessage
+                                                            id='Apis.Details.Operations.Operation.authType'
+                                                            defaultMessage='Security Enabled'
+                                                        />
+                                                    </Typography>
+                                                </TableCell>
+                                            </>
+                                        }
                                     </TableRow>
                                     {operations.filter(
                                         (operation) => operation.target.toLowerCase().includes(filterKeyWord),
@@ -465,6 +472,7 @@ class Operations extends React.Component {
                                                 sharedScopes={sharedScopes}
                                                 isOperationRateLimiting={!apiThrottlingPolicy}
                                                 apiPolicies={apiPolicies}
+                                                componentValidator={componentValidator}
                                             />
                                         );
                                     })}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -96,7 +96,7 @@ const Policies: React.FC = () => {
     const [policies, setPolicies] = useState<Policy[]>([]);
     const [allPolicies, setAllPolicies] = useState<PolicySpec[] | null>(null);
     const [expandedResource, setExpandedResource] = useState<string | null>(null);
-    const [isChoreoConnectEnabled, setIsChoreoConnectEnabled] = useState(api.gatewayType === 'wso2/apk');
+    const [isChoreoConnectEnabled, setIsChoreoConnectEnabled] = useState(api.gatewayType !== 'wso2/synapse');
     const { showMultiVersionPolicies } = Configurations.apis;
     const [selectedTab, setSelectedTab] = useState((api.apiPolicies != null) ? 0 : 1);
 
@@ -203,10 +203,21 @@ const Policies: React.FC = () => {
             commonPolicyByPolicyDisplayName.sort(
                 (a: Policy, b: Policy) => a.name.localeCompare(b.name))
 
+            let gatewayType;
+            if (api.gatewayType === "wso2/apk") {
+                // Get CC gateway supported policies
+                gatewayType = 'ChoreoConnect';
+            } else if (api.gatewayType === "AWS") {
+                // Get AWS gateway supported policies
+                gatewayType = 'AWS';
+            } else {
+                // Get synpase gateway supported policies
+                gatewayType = 'Synapse';
+            }
+
             let filteredApiPolicyByGatewayTypeList = null;
             let filteredCommonPolicyByGatewayTypeList = null;
             
-            let gatewayType = isChoreoConnectEnabled ? 'ChoreoConnect' : 'Synapse';
             // Get relevant gateway supported policies
             filteredApiPolicyByGatewayTypeList = apiPolicyByPolicyDisplayName.filter(
                 (policy: Policy) => policy.supportedGateways.includes(gatewayType));
@@ -460,8 +471,6 @@ const Policies: React.FC = () => {
         setUpdating(true);
         const newApiOperations: any = cloneDeep(apiOperations);
         const newApiLevelPolicies: any = cloneDeep(apiLevelPolicies);
-        let getewayTypeForPolicies = "wso2/synapse";
-        const getewayVendorForPolicies = "wso2";
 
         deletePolicyUuid(newApiLevelPolicies);
         // Set operation policies to the API object
@@ -472,16 +481,11 @@ const Policies: React.FC = () => {
             }
         });
 
-        // Handles normal policy savings for choreo connect gateway type.
-        if(isChoreoConnectEnabled) {
-            getewayTypeForPolicies = "wso2/apk";
-        }
-
         const updatePromise = updateAPI({
             operations: newApiOperations,
             apiPolicies: newApiLevelPolicies,
-            gatewayVendor: getewayVendorForPolicies,
-            gatewayType: getewayTypeForPolicies
+            gatewayVendor: api.gatewayVendor,
+            gatewayType: api.gatewayType,
         });
         updatePromise
             .catch((error: any) => {
@@ -625,6 +629,7 @@ const Policies: React.FC = () => {
                             commonPolicyList={commonPolicies}
                             fetchPolicies={fetchPolicies}
                             isChoreoConnectEnabled={isChoreoConnectEnabled}
+                            gatewayType={api.gatewayType}
                         />
                     </Box>
                 </Box>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyList.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyList.tsx
@@ -72,6 +72,7 @@ interface PolicyListPorps {
     commonPolicyList: Policy[];
     fetchPolicies: () => void;
     isChoreoConnectEnabled: boolean;
+    gatewayType: string;
 }
 
 /**
@@ -79,11 +80,11 @@ interface PolicyListPorps {
  * @param {JSON} props Input props from parent components.
  * @returns {TSX} List of policies local to the API segment.
  */
-const PolicyList: FC<PolicyListPorps> = ({apiPolicyList, commonPolicyList, fetchPolicies, isChoreoConnectEnabled}) => {
+const PolicyList: FC<PolicyListPorps> = ({apiPolicyList, commonPolicyList, fetchPolicies, isChoreoConnectEnabled, 
+    gatewayType}) => {
 
     const [selectedTab, setSelectedTab] = useState(0); // Request flow related tab is active by default
     const [dialogOpen, setDialogOpen] = React.useState(false);
-    let gatewayType = CONSTS.GATEWAY_TYPE.synapse;
 
     const handleAddPolicy = () => {
         setDialogOpen(true);
@@ -92,10 +93,6 @@ const PolicyList: FC<PolicyListPorps> = ({apiPolicyList, commonPolicyList, fetch
     const handleAddPolicyClose = () => {
         setDialogOpen(false);
     };
-
-    if (isChoreoConnectEnabled) {
-        gatewayType = CONSTS.GATEWAY_TYPE.choreoConnect;
-    }
 
     return (
         <StyledPaper className={classes.paperPosition}>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -34,16 +34,19 @@ import SwaggerClient from 'swagger-client';
 import { isRestricted } from 'AppData/AuthManager';
 import CONSTS from 'AppData/Constants';
 import Configurations from 'Config';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
+import APIRateLimiting from './components/APIRateLimiting';
 import Operation from './components/Operation';
 import GroupOfOperations from './components/GroupOfOperations';
 import AddOperation from './components/AddOperation';
 import GoToDefinitionLink from './components/GoToDefinitionLink';
-import APIRateLimiting from './components/APIRateLimiting';
 import {
     extractPathParameters, isSelectAll, mapAPIOperations, getVersion, VERSIONS,
 } from './operationUtils';
 import OperationsSelector from './components/OperationsSelector';
 import SaveOperations from './components/SaveOperations';
+
 
 /**
  * This component handles the Resource page in API details though it's written in a sharable way
@@ -62,6 +65,7 @@ export default function Resources(props) {
         disableAddOperation,
     } = props;
 
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const [api, updateAPI] = useAPI();
     const [pageError, setPageError] = useState(false);
     const [operationRateLimits, setOperationRateLimits] = useState([]);
@@ -75,6 +79,7 @@ export default function Resources(props) {
     const [resolvedSpec, setResolvedSpec] = useState({ spec: {}, errors: [] });
     const [focusOperationLevel, setFocusOperationLevel] = useState(false);
     const [expandedResource, setExpandedResource] = useState(false);
+    const [componentValidator, setComponentValidator] = useState([]);
 
     const intl = useIntl();
     /**
@@ -516,6 +521,13 @@ export default function Resources(props) {
     }, []);
 
     useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(publisherSettings.gatewayFeatureCatalog
+                .gatewayFeatures[api.gatewayType].resources);
+        }
+    }, [isLoading]);
+
+    useEffect(() => {
         setApiThrottlingPolicy(api.apiThrottlingPolicy);
     }, [api.apiThrottlingPolicy]);
 
@@ -611,6 +623,9 @@ export default function Resources(props) {
             </Grid>
         );
     }
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     return (
         <Grid container direction='row' justifyContent='flex-start' spacing={2} alignItems='stretch'>
             {pageError && (
@@ -621,6 +636,7 @@ export default function Resources(props) {
             {!disableRateLimiting && (
                 <Grid item md={12}>
                     <APIRateLimiting
+                        api={api}
                         operationRateLimits={operationRateLimits}
                         value={apiThrottlingPolicy}
                         onChange={setApiThrottlingPolicy}
@@ -644,6 +660,7 @@ export default function Resources(props) {
                             setSelectedOperation={setSelectedOperation}
                             enableSecurity={enableSecurity}
                             disableSecurity={disableSecurity}
+                            componentValidator={componentValidator}
                         />
                     )}
                     {Object.entries(operations).map(([target, verbObject]) => (
@@ -688,6 +705,7 @@ export default function Resources(props) {
                                                     setFocusOperationLevel={setFocusOperationLevel}
                                                     expandedResource={expandedResource}
                                                     setExpandedResource={setExpandedResource}
+                                                    componentValidator={componentValidator}
                                                 />
                                             </Grid>
                                         ) : null;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/APIRateLimiting.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/APIRateLimiting.jsx
@@ -38,6 +38,8 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { isRestricted } from 'AppData/AuthManager';
 import { useAPI } from 'AppComponents/Apis/Details/components/ApiContext';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+import { Progress } from 'AppComponents/Shared';
 
 const PREFIX = 'APIRateLimiting';
 
@@ -70,15 +72,16 @@ const RateLimitingLevels = {
  */
 function APIRateLimiting(props) {
     const {
-        updateAPI, operationRateLimits, onChange, value: currentApiThrottlingPolicy, isAPIProduct,
+        api, updateAPI, operationRateLimits, onChange, value: currentApiThrottlingPolicy, isAPIProduct,
         setFocusOperationLevel, focusOperationLevel,
     } = props;
     const intl = useIntl();
+    const { data: publisherSettings, isLoading } = usePublisherSettings();
     const [apiThrottlingPolicy, setApiThrottlingPolicy] = useState(currentApiThrottlingPolicy);
     const [isSaving, setIsSaving] = useState(false);
-
-    const isResourceLevel = apiThrottlingPolicy === null;
-    const rateLimitingLevel = isResourceLevel ? RateLimitingLevels.RESOURCE : RateLimitingLevels.API;
+    const [componentValidator, setComponentValidator] = useState([]);
+    const [isResourceLevel, setIsResourceLevel] = useState(false);
+    const [rateLimitingLevel, setRateLimitingLevel] = useState(RateLimitingLevels.API);
     const [apiFromContext] = useAPI();
 
     // Following effect is used to handle the controlled component case, If user provide onChange handler to
@@ -92,6 +95,18 @@ function APIRateLimiting(props) {
             }
         }
     }, [onChange, currentApiThrottlingPolicy]); // Do not expect to change the onChange during the runtime
+
+    useEffect(() => {
+        setIsResourceLevel(apiThrottlingPolicy === null || !componentValidator.includes('apiLevelRateLimiting'));
+        setRateLimitingLevel(isResourceLevel ? RateLimitingLevels.RESOURCE : RateLimitingLevels.API);
+    }, [apiThrottlingPolicy, isResourceLevel]);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setComponentValidator(publisherSettings.gatewayFeatureCatalog
+                .gatewayFeatures[api.gatewayType].resources);
+        }
+    }, [isLoading]);
 
     /**
      *
@@ -108,7 +123,7 @@ function APIRateLimiting(props) {
         } else {
             setApiThrottlingPolicy(userSelection);
         }
-        if (event.target.value === RateLimitingLevels.RESOURCE) {
+        if (event.target.value === RateLimitingLevels.RESOURCE && setFocusOperationLevel) {
             setFocusOperationLevel(false);
         }
     }
@@ -160,154 +175,163 @@ function APIRateLimiting(props) {
             </Typography>
         );
     }
+    if (isLoading) {
+        return <Progress per={80} message='Loading app settings ...' />;
+    }
     return (
-        <StyledPaper>
-            <Grid container direction='row' justifyContent='flex-start' alignItems='flex-start'>
-                <Grid item md={12} xs={12} sx={{ p: 1 }}>
-                    <Box>
-                        <Typography variant='subtitle1' component='h3' gutterBottom>
-                            <FormattedMessage
-                                id='Apis.Details.Rate.Limiting.operations.configuration'
-                                defaultMessage='Operations Configuration'
-                            />
-                            <Tooltip
-                                fontSize='small'
-                                title={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.operations.configuration.tooltip',
-                                    defaultMessage: 'Configurations that affects on all the resources',
-                                })}
-                                placement='right-end'
-                                interactive
-                            >
-                                <IconButton aria-label='Operations Configuration help text' size='large'>
-                                    <HelpOutline />
-                                </IconButton>
-                            </Tooltip>
-                        </Typography>
-                    </Box>
-                    <Divider variant='middle' />
-                </Grid>
-                <Grid item md={6} xs={12} sx={{ p: 1 }}>
-                    <FormControl component='fieldset'>
-                        <FormLabel component='legend'>
-                            <FormattedMessage
-                                id='Apis.Details.Resources.components.APIRateLimiting.rate.limiting.level'
-                                defaultMessage='Rate limiting level'
-                            />
-                        </FormLabel>
-                        <RadioGroup
-                            aria-label='Apply rate limiting in'
-                            value={rateLimitingLevel}
-                            onChange={updateRateLimitingPolicy}
-                            row
-                        >
-                            <FormControlLabel
-                                value={RateLimitingLevels.API}
-                                control={(
-                                    <Radio
-                                        color='primary'
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    />
-                                )}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.level.api.level',
-                                    defaultMessage: 'API Level',
-                                })}
-                                labelPlacement='end'
-                                id='api-rate-limiting-api-level'
-                            />
-                            <FormControlLabel
-                                value={RateLimitingLevels.RESOURCE}
-                                control={(
-                                    <Radio
-                                        color='primary'
-                                        disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                    />
-                                )}
-                                className={focusOperationLevel && classes.focusLabel}
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.level.operation.level',
-                                    defaultMessage: 'Operation Level',
-                                })}
-                                labelPlacement='end'
-                                id='api-rate-limiting-operation-level'
-                            />
-                        </RadioGroup>
-                    </FormControl>
-                </Grid>
-                <Grid item md={6} xs={12} sx={{ p: 1 }}>
-                    <Box minHeight={70} pl={10} sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.2)' }}>
-                        {isResourceLevel ? (
-                            operationRateLimitMessage
-                        ) : (
-                            <TextField
-                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
-                                id='operation_throttling_policy'
-                                select
-                                label={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.policies',
-                                    defaultMessage: 'Rate limiting policies',
-                                })}
-                                value={apiThrottlingPolicy}
-                                onChange={({ target: { value } }) => (
-                                    onChange ? onChange(value) : setApiThrottlingPolicy(value))}
-                                helperText={intl.formatMessage({
-                                    id: 'Apis.Details.Rate.Limiting.rate.limiting.policies.helper.text',
-                                    defaultMessage: 'Selected rate limiting policy will be applied to whole API',
-                                })}
-                                margin='dense'
-                                variant='outlined'
-                            >
-                                {operationRateLimits.map((rateLimit) => (
-                                    <MenuItem
-                                        key={rateLimit.name}
-                                        value={rateLimit.name}
-                                        id={'api-rate-limiting-api-level-' + rateLimit.name}
-                                    >
-                                        {rateLimit.displayName}
-                                    </MenuItem>
-                                ))}
-                            </TextField>
-                        )}
-                    </Box>
-                </Grid>
-                {/* If onChange handler is provided we assume that component is getting controlled by its parent
-                so that, hide the save cancel action */}
-                {!onChange && (
-                    <>
-                        <Grid item md={12}>
-                            <Divider />
-                        </Grid>
-                        <Grid item>
-                            <Box ml={1}>
-                                <Button
-                                    onClick={saveChanges}
-                                    disabled={false}
-                                    variant='outlined'
-                                    size='small'
-                                    color='primary'
+        ["apiLevelRateLimiting", "operationLevelRateLimiting"]
+            .some(type => componentValidator.includes(type)) &&
+            <StyledPaper>
+                <Grid container direction='row' justifyContent='flex-start' alignItems='flex-start'>
+                    <Grid item md={12} xs={12} sx={{ p: 1 }}>
+                        <Box>
+                            <Typography variant='subtitle1' component='h3' gutterBottom>
+                                <FormattedMessage
+                                    id='Apis.Details.Rate.Limiting.operations.configuration'
+                                    defaultMessage='Operations Configuration'
+                                />
+                                <Tooltip
+                                    fontSize='small'
+                                    title={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.operations.configuration.tooltip',
+                                        defaultMessage: 'Configurations that affects on all the resources',
+                                    })}
+                                    placement='right-end'
+                                    interactive
                                 >
-                                    <FormattedMessage
-                                        id='Apis.Details.Rate.Limiting.operations.save.btn'
-                                        defaultMessage='Save'
+                                    <IconButton aria-label='Operations Configuration help text' size='large'>
+                                        <HelpOutline />
+                                    </IconButton>
+                                </Tooltip>
+                            </Typography>
+                        </Box>
+                        <Divider variant='middle' />
+                    </Grid>
+                    <Grid item md={6} xs={12} sx={{ p: 1 }}>
+                        <FormControl component='fieldset'>
+                            <FormLabel component='legend'>
+                                <FormattedMessage
+                                    id='Apis.Details.Resources.components.APIRateLimiting.rate.limiting.level'
+                                    defaultMessage='Rate limiting level'
+                                />
+                            </FormLabel>
+                            <RadioGroup
+                                aria-label='Apply rate limiting in'
+                                value={rateLimitingLevel}
+                                onChange={updateRateLimitingPolicy}
+                                row
+                            >
+                                {componentValidator.includes('apiLevelRateLimiting') &&
+                                    <FormControlLabel
+                                        value={RateLimitingLevels.API}
+                                        control={(
+                                            <Radio
+                                                color='primary'
+                                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            />
+                                        )}
+                                        label={intl.formatMessage({
+                                            id: 'Apis.Details.Rate.Limiting.rate.limiting.level.api.level',
+                                            defaultMessage: 'API Level',
+                                        })}
+                                        labelPlacement='end'
+                                        id='api-rate-limiting-api-level'
                                     />
-                                    
-                                    {isSaving && <CircularProgress size={24} />}
-                                </Button>
-                                <Box display='inline' ml={1}>
-                                    <Button size='small' onClick={resetChanges}>
+                                }
+                                {componentValidator.includes('operationLevelRateLimiting') &&
+                                    <FormControlLabel
+                                        value={RateLimitingLevels.RESOURCE}
+                                        control={(
+                                            <Radio
+                                                color='primary'
+                                                disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                            />
+                                        )}
+                                        className={focusOperationLevel && classes.focusLabel}
+                                        label={intl.formatMessage({
+                                            id: 'Apis.Details.Rate.Limiting.rate.limiting.level.operation.level',
+                                            defaultMessage: 'Operation Level',
+                                        })}
+                                        labelPlacement='end'
+                                        id='api-rate-limiting-operation-level'
+                                    />
+                                }
+                            </RadioGroup>
+                        </FormControl>
+                    </Grid>
+                    <Grid item md={6} xs={12} sx={{ p: 1 }}>
+                        <Box minHeight={70} pl={10} sx={{ borderLeft: '1px solid rgba(0, 0, 0, 0.2)' }}>
+                            {isResourceLevel ? (
+                                operationRateLimitMessage
+                            ) : (
+                                <TextField
+                                    disabled={isRestricted(['apim:api_create'], apiFromContext)}
+                                    id='operation_throttling_policy'
+                                    select
+                                    label={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.rate.limiting.policies',
+                                        defaultMessage: 'Rate limiting policies',
+                                    })}
+                                    value={apiThrottlingPolicy}
+                                    onChange={({ target: { value } }) => (
+                                        onChange ? onChange(value) : setApiThrottlingPolicy(value))}
+                                    helperText={intl.formatMessage({
+                                        id: 'Apis.Details.Rate.Limiting.rate.limiting.policies.helper.text',
+                                        defaultMessage: 'Selected rate limiting policy will be applied to whole API',
+                                    })}
+                                    margin='dense'
+                                    variant='outlined'
+                                >
+                                    {operationRateLimits.map((rateLimit) => (
+                                        <MenuItem
+                                            key={rateLimit.name}
+                                            value={rateLimit.name}
+                                            id={'api-rate-limiting-api-level-' + rateLimit.name}
+                                        >
+                                            {rateLimit.displayName}
+                                        </MenuItem>
+                                    ))}
+                                </TextField>
+                            )}
+                        </Box>
+                    </Grid>
+                    {/* If onChange handler is provided we assume that component is getting controlled by its parent
+                    so that, hide the save cancel action */}
+                    {!onChange && (
+                        <>
+                            <Grid item md={12}>
+                                <Divider />
+                            </Grid>
+                            <Grid item>
+                                <Box ml={1}>
+                                    <Button
+                                        onClick={saveChanges}
+                                        disabled={false}
+                                        variant='outlined'
+                                        size='small'
+                                        color='primary'
+                                    >
                                         <FormattedMessage
-                                            id='Apis.Details.Rate.Limiting.operations.reset.btn'
-                                            defaultMessage='Reset'
+                                            id='Apis.Details.Rate.Limiting.operations.save.btn'
+                                            defaultMessage='Save'
                                         />
+                                        
+                                        {isSaving && <CircularProgress size={24} />}
                                     </Button>
+                                    <Box display='inline' ml={1}>
+                                        <Button size='small' onClick={resetChanges}>
+                                            <FormattedMessage
+                                                id='Apis.Details.Rate.Limiting.operations.reset.btn'
+                                                defaultMessage='Reset'
+                                            />
+                                        </Button>
+                                    </Box>
                                 </Box>
-                            </Box>
-                        </Grid>
-                    </>
-                )}
-            </Grid>
-        </StyledPaper>
+                            </Grid>
+                        </>
+                    )}
+                </Grid>
+            </StyledPaper>
     );
 }
 APIRateLimiting.defaultProps = {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AsyncOperation.jsx
@@ -94,6 +94,7 @@ function AsyncOperation(props) {
         target,
         verb,
         sharedScopes,
+        componentValidator
     } = props;
 
     const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
@@ -253,6 +254,7 @@ function AsyncOperation(props) {
                                     target={target}
                                     verb={verb}
                                     sharedScopes={sharedScopes}
+                                    componentValidator={componentValidator}
                                 />
                                 {(api.type === 'WS' || api.type === 'WEBSUB') && (
                                     <Runtime

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/Operation.jsx
@@ -132,6 +132,7 @@ function Operation(props) {
         setFocusOperationLevel,
         expandedResource,
         setExpandedResource,
+        componentValidator,
     } = props;
     const apiOperation = api.operations[target] && api.operations[target][verb.toUpperCase()];
     const isUsedInAPIProduct = apiOperation && Array.isArray(
@@ -342,6 +343,7 @@ function Operation(props) {
                             verb={verb}
                             sharedScopes={sharedScopes}
                             setFocusOperationLevel={setFocusOperationLevel}
+                            componentValidator={componentValidator}
                         />
                         {!hideParameters && (
                             <Parameters

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
@@ -39,7 +39,7 @@ import { useIntl } from 'react-intl';
  */
 export default function OperationsSelector(props) {
     const {
-        selectedOperations, setSelectedOperation, operations, enableSecurity, disableSecurity,
+        selectedOperations, setSelectedOperation, operations, enableSecurity, disableSecurity, componentValidator,
     } = props;
     const [apiFromContext] = useAPI();
     const intl = useIntl();
@@ -92,7 +92,8 @@ export default function OperationsSelector(props) {
                             </div>
                         </Tooltip>
                     )}
-                    { (operationWithSecurityCount === operationCount)
+                    { (componentValidator.includes('operationSecurity') && 
+                    (operationWithSecurityCount === operationCount))
                     && (
                         <Tooltip
                             title={intl.formatMessage({
@@ -112,7 +113,8 @@ export default function OperationsSelector(props) {
                             </div>
                         </Tooltip>
                     )}
-                    { (operationWithSecurityCount !== 0 && operationWithSecurityCount !== operationCount)
+                    { (componentValidator.includes('operationSecurity') && 
+                    operationWithSecurityCount !== 0 && operationWithSecurityCount !== operationCount)
                     && (
                         <Tooltip
                             title={intl.formatMessage({

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/OperationGovernance.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/OperationGovernance.jsx
@@ -54,10 +54,11 @@ const checkedIcon = <CheckBoxIcon fontSize='small' />;
 export default function OperationGovernance(props) {
     const {
         operation, operationsDispatcher, operationRateLimits, api, disableUpdate, spec, target, verb, sharedScopes,
-        setFocusOperationLevel,
+        setFocusOperationLevel, componentValidator
     } = props;
     const operationScopes = getOperationScopes(operation, spec);
-    const isOperationRateLimiting = api.apiThrottlingPolicy === null;
+    const isOperationRateLimiting = api.apiThrottlingPolicy === null || 
+        !componentValidator.includes('apiLevelRateLimiting');
     const filteredApiScopes = api.scopes.filter((sharedScope) => !sharedScope.shared);
     const intl = useIntl();
     const scrollToTop = () => {
@@ -82,251 +83,262 @@ export default function OperationGovernance(props) {
                 </Typography>
             </Grid>
             <Grid item xs={1} />
-            <Grid item xs={11}>
-                <FormControl disabled={disableUpdate} component='fieldset'>
-                    <FormControlLabel
-                        control={(
-                            <Switch
-                                data-testid={'security-' + verb + target}
-                                checked={operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none'}
-                                onChange={({ target: { checked } }) => operationsDispatcher({
-                                    action: 'authType',
-                                    data: { target, verb, value: checked },
-                                })}
-                                size='small'
-                                color='primary'
-                            />
-                        )}
-                        label={intl.formatMessage({
-                            id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                + 'security.switch',
-                            defaultMessage: 'Security',
-                        })}
-                        labelPlacement='start'
-                    />
-                </FormControl>
-                <sup style={{ marginLeft: '10px' }}>
-                    <Tooltip
-                        title={(
-                            <FormattedMessage
-                                id={'Apis.Details.Resources.components.operationComponents.OperationGovernance.Security'
-                                + '.tooltip'}
-                                defaultMessage='This will enable/disable Application Level securities defined in the
-                                Runtime Configurations page.'
-                            />
-                        )}
-                        fontSize='small'
-                        placement='right-end'
-                        interactive
-                    >
-                        <HelpOutline />
-                    </Tooltip>
-                </sup>
-            </Grid>
+            {componentValidator.includes('operationSecurity') &&
+                <Grid item xs={11}>
+                    <FormControl disabled={disableUpdate} component='fieldset'>
+                        <FormControlLabel
+                            control={(
+                                <Switch
+                                    data-testid={'security-' + verb + target}
+                                    checked={operation['x-auth-type'] && 
+                                        operation['x-auth-type'].toLowerCase() !== 'none'}
+                                    onChange={({ target: { checked } }) => operationsDispatcher({
+                                        action: 'authType',
+                                        data: { target, verb, value: checked },
+                                    })}
+                                    size='small'
+                                    color='primary'
+                                />
+                            )}
+                            label={intl.formatMessage({
+                                id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
+                                    + 'security.switch',
+                                defaultMessage: 'Security',
+                            })}
+                            labelPlacement='start'
+                        />
+                    </FormControl>
+                    <sup style={{ marginLeft: '10px' }}>
+                        <Tooltip
+                            title={(
+                                <FormattedMessage
+                                    id={'Apis.Details.Resources.components'
+                                       + '.operationComponents.OperationGovernance.Security.tooltip'}
+                                    defaultMessage='This will enable/disable Application Level securities defined in the
+                                    Runtime Configurations page.'
+                                />
+                            )}
+                            fontSize='small'
+                            placement='right-end'
+                            interactive
+                        >
+                            <HelpOutline />
+                        </Tooltip>
+                    </sup>
+                </Grid>
+            }
             <Grid item md={1} />
             <Grid item md={5}>
-                <Box display='flex' flexDirection='row' alignItems='flex-start'>
-                    <TextField
-                        select
-                        fullWidth={!isOperationRateLimiting}
-                        SelectProps={{
-                            autoWidth: true,
-                            IconComponent: isOperationRateLimiting ? ArrowDropDownIcon : 'span',
-                        }}
-                        disabled={disableUpdate || !isOperationRateLimiting}
-                        label={
-                            isOperationRateLimiting
-                                ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.rate.limiting.policy',
-                                    defaultMessage: 'Rate limiting policy',
-                                })
-                                : (
-                                    <div>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.governed.by'}
-                                            defaultMessage='Rate limiting is governed by '
-                                        />
-                                        <Box
-                                            fontWeight='fontWeightBold'
-                                            display='inline'
-                                            color='primary.main'
-                                            cursor='pointer'
-                                        >
+                {componentValidator.includes('operationLevelRateLimiting') &&
+                    <Box display='flex' flexDirection='row' alignItems='flex-start'>
+                        <TextField
+                            select
+                            fullWidth={!isOperationRateLimiting}
+                            SelectProps={{
+                                autoWidth: true,
+                                IconComponent: isOperationRateLimiting ? ArrowDropDownIcon : 'span',
+                            }}
+                            disabled={disableUpdate || !isOperationRateLimiting}
+                            label={
+                                isOperationRateLimiting
+                                    ? intl.formatMessage({
+                                        id: 'Apis.Details.Resources.components.operationComponents.'
+                                    + 'OperationGovernance.rate.limiting.policy',
+                                        defaultMessage: 'Rate limiting policy',
+                                    })
+                                    : (
+                                        <div>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.API.level'}
-                                                defaultMessage='API Level'
+                                + 'OperationGovernance.rate.limiting.governed.by'}
+                                                defaultMessage='Rate limiting is governed by '
                                             />
-                                        </Box>
-                                    </div>
-                                )
-                        }
-                        value={
-                            isOperationRateLimiting
-                            && operation['x-throttling-tier']
-                                ? operation['x-throttling-tier']
-                                : ''
-                        }
-                        onChange={({ target: { value } }) => operationsDispatcher({
-                            action: 'throttlingPolicy',
-                            data: { target, verb, value },
-                        })}
-                        helperText={
-                            isOperationRateLimiting
-                                ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.rate.limiting.policy.select',
-                                    defaultMessage: 'Select a rate limit policy for this operation',
-                                })
-                                : (
-                                    <span>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section1'}
-                                            defaultMessage='Use '
-                                        />
-                                        <Box fontWeight='fontWeightBold' display='inline' color='primary.main'>
+                                            <Box
+                                                fontWeight='fontWeightBold'
+                                                display='inline'
+                                                color='primary.main'
+                                                cursor='pointer'
+                                            >
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.API.level'}
+                                                    defaultMessage='API Level'
+                                                />
+                                            </Box>
+                                        </div>
+                                    )
+                            }
+                            value={
+                                isOperationRateLimiting
+                                && operation['x-throttling-tier']
+                                    ? operation['x-throttling-tier']
+                                    : ''
+                            }
+                            onChange={({ target: { value } }) => operationsDispatcher({
+                                action: 'throttlingPolicy',
+                                data: { target, verb, value },
+                            })}
+                            helperText={
+                                isOperationRateLimiting
+                                    ? intl.formatMessage({
+                                        id: 'Apis.Details.Resources.components.operationComponents.'
+                                    + 'OperationGovernance.rate.limiting.policy.select',
+                                        defaultMessage: 'Select a rate limit policy for this operation',
+                                    })
+                                    : (
+                                        <span>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section2'}
-                                                defaultMessage='Operation Level'
+                                + 'OperationGovernance.rate.limiting.helperText.section1'}
+                                                defaultMessage='Use '
                                             />
-                                        </Box>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section3'}
-                                            defaultMessage=' rate limiting to '
-                                        />
-                                        <b>
+                                            <Box fontWeight='fontWeightBold' display='inline' color='primary.main'>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section2'}
+                                                    defaultMessage='Operation Level'
+                                                />
+                                            </Box>
                                             <FormattedMessage
                                                 id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section4'}
-                                                defaultMessage='enable'
+                                + 'OperationGovernance.rate.limiting.helperText.section3'}
+                                                defaultMessage=' rate limiting to '
                                             />
-                                        </b>
-                                        <FormattedMessage
-                                            id={'Apis.Details.Resources.components.operationComponents.'
-                            + 'OperationGovernance.rate.limiting.helperText.section5'}
-                                            defaultMessage=' rate limiting per operation'
-                                        />
-                                    </span>
-                                )
-                        }
-                        margin='dense'
-                        variant='outlined'
-                        id={verb + target + '-operation_throttling_policy'}
-                    >
-                        {operationRateLimits.map((rateLimit) => (
-                            <MenuItem
-                                key={rateLimit.name}
-                                value={rateLimit.name}
-                                id={verb + target + '-operation_throttling_policy-' + rateLimit.name}
-                            >
-                                {rateLimit.displayName}
-                            </MenuItem>
-                        ))}
-                    </TextField>
-                    {!isOperationRateLimiting && (
-                        <Button onClick={scrollToTop}>
-                            <FormattedMessage
-                                id={
-                                    'Apis.Details.Resources.components.operationComponents.'
-                                    + 'OperationGovernance.rate.limiting.button.text'
-                                }
-                                defaultMessage='Change rate limiting level'
-                            />
-                            <ExpandLessIcon />
-                        </Button>
-                    )}
-                </Box>
+                                            <b>
+                                                <FormattedMessage
+                                                    id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section4'}
+                                                    defaultMessage='enable'
+                                                />
+                                            </b>
+                                            <FormattedMessage
+                                                id={'Apis.Details.Resources.components.operationComponents.'
+                                + 'OperationGovernance.rate.limiting.helperText.section5'}
+                                                defaultMessage=' rate limiting per operation'
+                                            />
+                                        </span>
+                                    )
+                            }
+                            margin='dense'
+                            variant='outlined'
+                            id={verb + target + '-operation_throttling_policy'}
+                        >
+                            {operationRateLimits.map((rateLimit) => (
+                                <MenuItem
+                                    key={rateLimit.name}
+                                    value={rateLimit.name}
+                                    id={verb + target + '-operation_throttling_policy-' + rateLimit.name}
+                                >
+                                    {rateLimit.displayName}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                        {!isOperationRateLimiting && (
+                            <Button onClick={scrollToTop}>
+                                <FormattedMessage
+                                    id={
+                                        'Apis.Details.Resources.components.operationComponents.'
+                                        + 'OperationGovernance.rate.limiting.button.text'
+                                    }
+                                    defaultMessage='Change rate limiting level'
+                                />
+                                <ExpandLessIcon />
+                            </Button>
+                        )}
+                    </Box>
+                }
             </Grid>
             <Grid item md={6} />
             <Grid item md={1} />
-            <Grid item md={7}>
-                {operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? (
-                    <Autocomplete
-                        multiple
-                        limitTags={5}
-                        id={verb + target + '-operation-scope-autocomplete'}
-                        options={[...filteredApiScopes, ...sharedScopes]}
-                        groupBy={(option) => option.shared ? 'Shared Scopes' : 'API Scopes'}
-                        noOptionsText={intl.formatMessage({
-                            id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                + 'no.scopes.available',
-                            defaultMessage: 'No scopes available',
-                        })}
-                        disableCloseOnSelect
-                        value={operationScopes.map((scope) => ({ scope: { name: scope } }))}
-                        getOptionLabel={(option) => option.scope.name}
-                        isOptionEqualToValue={(option, value) => option.scope.name === value.scope.name}
-                        onChange={(event, newValue) => {
-                            const selectedScopes = newValue.map((val) => val.scope.name);
-                            operationsDispatcher({
-                                action: 'scopes',
-                                data: { target, verb, value: selectedScopes ? [selectedScopes] : [] },
-                            });
-                        }}
-                        renderOption={(listOfOptions, option, { selected }) => (
-                            <li {...listOfOptions}>
-                                <Checkbox
-                                    id={verb + target + '-operation-scope-' + option.scope.name}
-                                    icon={icon}
-                                    checkedIcon={checkedIcon}
-                                    style={{ marginRight: 8 }}
-                                    checked={selected}
-                                />
-                                {option.scope.name}
-                            </li>
-                        )}
-                        style={{ width: 500 }}
-                        renderInput={(params) => (
-                            <TextField {...params}
-                                disabled={disableUpdate}
-                                fullWidth
-                                label={api.scopes.length !== 0 || sharedScopes ? intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                        + 'OperationGovernance.operation.scope.label.default',
-                                    defaultMessage: 'Operation scope',
-                                }) : intl.formatMessage({
-                                    id: 'Apis.Details.Resources.components.operationComponents.'
-                                        + 'OperationGovernance.operation.scope.label.notAvailable',
-                                    defaultMessage: 'No scope available',
-                                })}
-                                placeholder={intl.formatMessage({
+            {componentValidator.includes('operationSecurity') &&
+                <>
+                    <Grid item md={7}>
+                        {operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? (
+                            <Autocomplete
+                                multiple
+                                limitTags={5}
+                                id={verb + target + '-operation-scope-autocomplete'}
+                                options={[...filteredApiScopes, ...sharedScopes]}
+                                groupBy={(option) => option.shared ? 'Shared Scopes' : 'API Scopes'}
+                                noOptionsText={intl.formatMessage({
                                     id: 'Apis.Details.Topics.components.operationComponents.OperationGovernance.'
-                                        + 'search.scopes.placeholder',
-                                    defaultMessage: 'Search scopes',
+                                        + 'no.scopes.available',
+                                    defaultMessage: 'No scopes available',
                                 })}
-                                helperText={(
-                                    <FormattedMessage
-                                        id={'Apis.Details.Resources.components.operationComponents.'
-                                            + 'OperationGovernance.operation.scope.helperText'}
-                                        defaultMessage='Select a scope to control permissions to this operation'
-                                    />
+                                disableCloseOnSelect
+                                value={operationScopes.map((scope) => ({ scope: { name: scope } }))}
+                                getOptionLabel={(option) => option.scope.name}
+                                isOptionEqualToValue={(option, value) => option.scope.name === value.scope.name}
+                                onChange={(event, newValue) => {
+                                    const selectedScopes = newValue.map((val) => val.scope.name);
+                                    operationsDispatcher({
+                                        action: 'scopes',
+                                        data: { target, verb, value: selectedScopes ? [selectedScopes] : [] },
+                                    });
+                                }}
+                                renderOption={(listOfOptions, option, { selected }) => (
+                                    <li {...listOfOptions}>
+                                        <Checkbox
+                                            id={verb + target + '-operation-scope-' + option.scope.name}
+                                            icon={icon}
+                                            checkedIcon={checkedIcon}
+                                            style={{ marginRight: 8 }}
+                                            checked={selected}
+                                        />
+                                        {option.scope.name}
+                                    </li>
                                 )}
-                                margin='dense'
-                                variant='outlined'
-                                id={verb + target + '-operation-scope-select'} />
-                        )}
-                    />
-                ) : null}
-            </Grid>
-            <Grid item md={3} style={{ marginTop: '14px' }}>
-                { operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' ? !disableUpdate && (
-                    <Link to={`/apis/${api.id}/scopes/create`} target='_blank'>
-                        <Typography style={{ marginLeft: '10px' }} color='primary' display='inline' variant='caption'>
-                            <FormattedMessage
-                                id={'Apis.Details.Resources.components.operationComponents.'
-                                + 'OperationGovernance.operation.scope.create.new.scope'}
-                                defaultMessage='Create New Scope'
+                                style={{ width: 500 }}
+                                renderInput={(params) => (
+                                    <TextField {...params}
+                                        disabled={disableUpdate}
+                                        fullWidth
+                                        label={api.scopes.length !== 0 || sharedScopes ? intl.formatMessage({
+                                            id: 'Apis.Details.Resources.components.operationComponents.'
+                                                + 'OperationGovernance.operation.scope.label.default',
+                                            defaultMessage: 'Operation scope',
+                                        }) : intl.formatMessage({
+                                            id: 'Apis.Details.Resources.components.operationComponents.'
+                                                + 'OperationGovernance.operation.scope.label.notAvailable',
+                                            defaultMessage: 'No scope available',
+                                        })}
+                                        placeholder={intl.formatMessage({
+                                            id: 'Apis.Details.Topics.components.operationComponents'
+                                                + '.OperationGovernance.search.scopes.placeholder',
+                                            defaultMessage: 'Search scopes',
+                                        })}
+                                        helperText={(
+                                            <FormattedMessage
+                                                id={'Apis.Details.Resources.components.operationComponents.'
+                                                    + 'OperationGovernance.operation.scope.helperText'}
+                                                defaultMessage='Select a scope to control permissions to this operation'
+                                            />
+                                        )}
+                                        margin='dense'
+                                        variant='outlined'
+                                        id={verb + target + '-operation-scope-select'} />
+                                )}
                             />
-                            <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
-                        </Typography>
-                    </Link>
-                ) : null}
-            </Grid>
+                        ) : null}
+                    </Grid>
+                    <Grid item md={3} style={{ marginTop: '14px' }}>
+                        { operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none' 
+                            ? !disableUpdate && (
+                                <Link to={`/apis/${api.id}/scopes/create`} target='_blank'>
+                                    <Typography style={{ marginLeft: '10px' }} color='primary' 
+                                        display='inline' variant='caption'>
+                                        <FormattedMessage
+                                            id={'Apis.Details.Resources.components.operationComponents.'
+                                            + 'OperationGovernance.operation.scope.create.new.scope'}
+                                            defaultMessage='Create New Scope'
+                                        />
+                                        <LaunchIcon style={{ marginLeft: '2px' }} fontSize='small' />
+                                    </Typography>
+                                </Link>
+                            ) : null}
+                    </Grid>
+                </>
+            }
             <Grid item md={1} />
         </>
     );

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/leftMenu/DevelopSectionMenu.jsx
@@ -114,7 +114,8 @@ const AccordionDetails = MuiAccordionDetails;
  */
 export default function DevelopSectionMenu(props) {
     const {
-        pathPrefix, isAPIProduct, api, getLeftMenuItemForResourcesByType, getLeftMenuItemForDefinitionByType,
+        pathPrefix, isAPIProduct, api, getLeftMenuItemForResourcesByType, getLeftMenuItemForDefinitionByType, 
+        componentValidator,
     } = props;
     const user = useUser();
     const [portalConfigsExpanded, setPortalConfigsExpanded] = useState(user
@@ -175,7 +176,7 @@ export default function DevelopSectionMenu(props) {
                             id='left-menu-itembusinessinfo'
                             route='business-info'
                         />
-                        {!isAPIProduct && (
+                        {(componentValidator.subscriptions.includes("subscriptions") && !isAPIProduct) && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.subscriptions',
@@ -258,7 +259,7 @@ export default function DevelopSectionMenu(props) {
                         root: classes.root2
                     }}>
                     <div>
-                        {!isAPIProduct && !api.isWebSocket() && (api.gatewayVendor === 'wso2') && (
+                        {!isAPIProduct && !api.isWebSocket() && (
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.runtime.configs',
@@ -308,7 +309,8 @@ export default function DevelopSectionMenu(props) {
                                 id='left-menu-itemendpoints'
                             />
                         )}
-                        {!isAPIProduct && (api.gatewayVendor === 'wso2') && (
+                        {(componentValidator.localScopes.includes("localScopes") 
+                            && (!isAPIProduct)) && 
                             <LeftMenuItem
                                 text={intl.formatMessage({
                                     id: 'Apis.Details.index.left.menu.scope',
@@ -319,7 +321,7 @@ export default function DevelopSectionMenu(props) {
                                 Icon={<ScopesIcon />}
                                 id='left-menu-itemLocalScopes'
                             />
-                        )}
+                        }
                         {api.advertiseInfo && !api.advertiseInfo.advertised && !isAPIProduct
                             && (api.type === 'HTTP' || api.type === 'SOAP' || api.type === 'SOAPTOREST') && (
                             <LeftMenuItem
@@ -345,9 +347,10 @@ export default function DevelopSectionMenu(props) {
                             id='left-menu-itemproperties'
                         />
 
-                        {!api.isWebSocket() && !isRestricted(['apim:api_publish'], api) && (
+                        {(componentValidator.monetization.includes("monetization") && 
+                            (!api.isWebSocket() && !isRestricted(['apim:api_publish'], api))) && (
                             <>
-                                {!isAPIProduct && (api.gatewayVendor === 'wso2') && (
+                                {!isAPIProduct && (
                                     <LeftMenuItem
                                         text={intl.formatMessage({
                                             id: 'Apis.Details.index.monetization',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -767,7 +767,8 @@ class Details extends Component {
                 >
                     <Box className={classes.LeftMenu}>
                         <nav name='secondaryNavigation' aria-label='secondary navigation'>
-                            <Link to={'/' + (isAPIProduct ? 'api-products' : 'apis') + '/'} aria-label='ALL APIs'>
+                            <Link to={'/' + (isAPIProduct ? 'api-products' : 'apis') + '/'}
+                                aria-label='ALL APIs'>
                                 <div className={classes.leftLInkMain}>
                                     <CustomIcon
                                         className={classes.customIcon}
@@ -798,7 +799,8 @@ class Details extends Component {
                                 id='left-menu-compliance'
                             />
                             <Typography className={classes.headingText}>
-                                <FormattedMessage id='Apis.Details.index.develop.title' defaultMessage='Develop' />
+                                <FormattedMessage id='Apis.Details.index.develop.title'
+                                    defaultMessage='Develop' />
                             </Typography>
                             <DevelopSectionMenu
                                 pathPrefix={pathPrefix}
@@ -806,6 +808,9 @@ class Details extends Component {
                                 api={api}
                                 getLeftMenuItemForResourcesByType={this.getLeftMenuItemForResourcesByType}
                                 getLeftMenuItemForDefinitionByType={this.getLeftMenuItemForDefinitionByType}
+                                componentValidator=
+                                    {settings && settings.gatewayFeatureCatalog
+                                        .gatewayFeatures[api.gatewayType]}
                             />
                             <Divider />
                             {!isAPIProduct && (
@@ -848,8 +853,10 @@ class Details extends Component {
                                     />
                                 </>
                             )}
-                            {!readOnlyUser && (isAPIProduct || (!isAPIProduct && !api.isWebSocket() && !api.isGraphql()
-                                && !isAsyncAPI)) && (
+                            {!readOnlyUser && (isAPIProduct || (!isAPIProduct && !api.isWebSocket()
+                                && !api.isGraphql() && !isAsyncAPI)) &&
+                            (settings && settings.gatewayFeatureCatalog.gatewayFeatures[api.gatewayType]
+                                .tryout.includes('tryout')) && (
                                 <div>
                                     <Divider />
                                     <Typography className={classes.headingText}>
@@ -949,7 +956,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.API_DEFINITION}
-                                        component={() => <APIDefinition api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <APIDefinition api={api}
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.WSDL}
@@ -965,7 +973,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.ASYNCAPI_DEFINITION}
-                                        component={() => <APIDefinition api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <APIDefinition api={api}
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.LIFE_CYCLE}
@@ -977,7 +986,8 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.CONFIGURATION}
-                                        component={() => <DesignConfigurations api={api} updateAPI={this.updateAPI}/>}
+                                        component={() => <DesignConfigurations api={api}
+                                            updateAPI={this.updateAPI}/>}
                                     />
                                     <Route
                                         path={Details.subPaths.RUNTIME_CONFIGURATION}
@@ -989,11 +999,13 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.TOPICS}
-                                        component={() => <Topics api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Topics api={api}
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         path={Details.subPaths.CONFIGURATION_PRODUCT}
-                                        component={() => <DesignConfigurations api={api} updateAPI={this.updateAPI}/>}
+                                        component={() => <DesignConfigurations api={api}
+                                            updateAPI={this.updateAPI}/>}
                                     />
                                     <Route
                                         path={Details.subPaths.RUNTIME_CONFIGURATION_PRODUCT}
@@ -1013,7 +1025,11 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.OPERATIONS}
-                                        component={() => <Operations api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Operations api={api}
+                                            componentValidator={settings &&
+                                                settings.gatewayFeatureCatalog
+                                                    .gatewayFeatures[api.gatewayType].resources}
+                                            updateAPI={this.updateAPI} />}
                                     />
                                     <Route
                                         exact
@@ -1030,8 +1046,12 @@ class Details extends Component {
                                         key={Details.subPaths.RESOURCES}
                                         component={APIOperations}
                                     />
-
-                                    <Route path={Details.subPaths.SCOPES} component={() => <Scope api={api} />} />
+                                    {settings && settings.gatewayFeatureCatalog
+                                        .gatewayFeatures[api.gatewayType]
+                                        .localScopes.includes("operationScopes") &&
+                                        <Route path={Details.subPaths.SCOPES} component={() =>
+                                            <Scope api={api} />} />
+                                    }
                                     <Route
                                         path={Details.subPaths.DOCUMENTS}
                                         component={() => <Documents api={api} />}
@@ -1040,16 +1060,24 @@ class Details extends Component {
                                         path={Details.subPaths.DOCUMENTS_PRODUCT}
                                         component={() => <Documents api={api} />}
                                     />
-                                    <Route
-                                        path={Details.subPaths.SUBSCRIPTIONS}
-                                        component={() => <Subscriptions api={api} updateAPI={this.updateAPI} />}
-                                    />
+                                    {settings && settings.gatewayFeatureCatalog
+                                        .gatewayFeatures[api.gatewayType]
+                                        .subscriptions.includes("subscriptions") &&
+                                        <Route
+                                            path={Details.subPaths.SUBSCRIPTIONS}
+                                            component={() => <Subscriptions api={api}
+                                                updateAPI={this.updateAPI} />}
+                                        />
+                                    }
                                     <Route
                                         path={Details.subPaths.SUBSCRIPTIONS_PRODUCT}
-                                        component={() => <Subscriptions api={api} updateAPI={this.updateAPI} />}
+                                        component={() => <Subscriptions api={api}
+                                            updateAPI={this.updateAPI} />}
                                     />
-                                    <Route path={Details.subPaths.SECURITY} component={() => <Security api={api} />} />
-                                    <Route path={Details.subPaths.COMMENTS} component={() => <Comments api={api} />} />
+                                    <Route path={Details.subPaths.SECURITY} component={() =>
+                                        <Security api={api} />} />
+                                    <Route path={Details.subPaths.COMMENTS} component={() =>
+                                        <Comments api={api} />} />
                                     <Route
                                         path={Details.subPaths.BUSINESS_INFO}
                                         component={() => <BusinessInformation api={api} />}
@@ -1066,18 +1094,23 @@ class Details extends Component {
                                         path={Details.subPaths.PROPERTIES_PRODUCT}
                                         component={() => <Properties api={api} />}
                                     />
-                                    <Route path={Details.subPaths.SHARE} component={() => <ShareAPI 
+                                    <Route path={Details.subPaths.SHARE} component={() => <ShareAPI
                                         api={api} updateAPI={this.updateAPI} />} />
                                     <Route path={Details.subPaths.NEW_VERSION} component={() => <CreateNewVersion />} />
                                     <Route
                                         path={Details.subPaths.NEW_VERSION_PRODUCT}
                                         component={() => <CreateNewVersion />} />
 
-                                    <Route path={Details.subPaths.SUBSCRIPTIONS} component={() => <Subscriptions />} />
-                                    <Route
-                                        path={Details.subPaths.MONETIZATION}
-                                        component={() => <Monetization api={api} />}
-                                    />
+                                    <Route path={Details.subPaths.SUBSCRIPTIONS} component={() =>
+                                        <Subscriptions />} />
+                                    {settings && settings.gatewayFeatureCatalog
+                                        .gatewayFeatures[api.gatewayType]
+                                        .monetization.includes("monetization") &&
+                                        <Route
+                                            path={Details.subPaths.MONETIZATION}
+                                            component={() => <Monetization api={api} />}
+                                        />
+                                    }
                                     <Route
                                         path={Details.subPaths.MONETIZATION_PRODUCT}
                                         component={() => <Monetization api={api} />}
@@ -1090,7 +1123,8 @@ class Details extends Component {
                                         path={Details.subPaths.TRYOUT_PRODUCT}
                                         component={() => <TryOutConsole apiObj={api} />}
                                     />
-                                    <Route path={Details.subPaths.EXTERNAL_STORES} component={ExternalStores} />
+                                    <Route path={Details.subPaths.EXTERNAL_STORES}
+                                        component={ExternalStores} />
                                     <Route
                                         path={Details.subPaths.COMMENTS}
                                         component={() => <Comments apiObj={api} />}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/RestAPIMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/Menus/RestAPIMenu.jsx
@@ -32,7 +32,7 @@ import API from 'AppData/api';
 const RestAPIMenu = (props) => {
     const { icon, isCreateMenu } = props;
     const { data: settings } = usePublisherSettings();
-    const apkGatewayType = settings && settings.gatewayTypes.length === 1 && settings.gatewayTypes.includes('APK');
+    const noRegularGw = settings && !settings.gatewayTypes.includes('Regular');
     const Component = isCreateMenu ? APICreateMenuSection : LandingMenu;
     const dense = isCreateMenu;
     const { alwaysShowDeploySampleButton } = Configurations.apis;
@@ -99,7 +99,7 @@ const RestAPIMenu = (props) => {
             </LandingMenuItem>
 
             {(!isCreateMenu || (isCreateMenu && alwaysShowDeploySampleButton)) && showSampleDeploy &&
-                !apkGatewayType && (
+                !noRegularGw && (
                 <>
                     <Box width={1} sx={{ pt: 2, pr: 2, pl: 2, ml: 2 }}>
                         <Divider variant='middle' />

--- a/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
@@ -79,6 +79,7 @@ const CONSTS = {
     GATEWAY_TYPE: {
         synapse: 'Synapse',
         choreoConnect: 'ChoreoConnect',
+        AWS: 'AWS',
     },
     PATH_TEMPLATES: {
         COMMON_POLICIES: '/policies',


### PR DESCRIPTION
### Description
This PR introduced a filtering mechanism to render publisher features in a controlled manner for federated gateways. Also the deployment flow is optimised for the federated gateways. Operation Policy filtering mechanism is improved to show AWS related common policies only for the AWS type APIs. Devportal UI is restricted for federated gateways.

### Fixes
- [x] Use the gateway feature catalog to filter out components in the publisher UI.
- [x] Add restrictions to the Devportal for external gateway deployed APIs.