### PR TITLE
Fix orgname being null in devportal

### DIFF
--- a/portals/devportal/src/main/webapp/services/login/login_callback.jsp
+++ b/portals/devportal/src/main/webapp/services/login/login_callback.jsp
@@ -269,7 +269,7 @@
         if (encodedOrg != null) {
             encodedOrg = URLEncoder.encode(organization, "UTF-8");
         }
-        cookie = new Cookie("ORGANIZATION_DEFAULT", encodedOrg);
+        cookie = new Cookie("ORGANIZATION_Default", encodedOrg);
         cookie.setPath(context + "/");
         cookie.setSecure(true);
         cookie.setMaxAge((int) expiresIn);

--- a/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
+++ b/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
@@ -78,7 +78,7 @@
     cookie.setMaxAge(2);
     response.addCookie(cookie);
 
-    cookie = new Cookie("ORGANIZATION_DEFAULT", "");
+    cookie = new Cookie("ORGANIZATION_Default", "");
     cookie.setPath(context + "/");
     cookie.setSecure(true);
     cookie.setMaxAge(2);


### PR DESCRIPTION
Can't fully capitalize the cookie name ORGANIZATION_Default because '_Default' part is being set internally when retrieving the cookie.