### PR TITLE
Radio button selection to assign orgs for a Key Manager in admin portal

### DIFF
--- a/portals/admin/src/main/webapp/site/public/locales/en.json
+++ b/portals/admin/src/main/webapp/site/public/locales/en.json
@@ -651,6 +651,7 @@
   "KeyManagers.AddEditKeyManager.form.issuer.help": "E.g.,: https://localhost:9443/oauth2/token",
   "KeyManagers.AddEditKeyManager.form.name": "Name",
   "KeyManagers.AddEditKeyManager.form.name.help": "Name of the Key Manager.",
+  "KeyManagers.AddEditKeyManager.form.orgs.error": "At least one organization should be selected.",
   "KeyManagers.AddEditKeyManager.form.revokeEndpoint": "Revoke Endpoint",
   "KeyManagers.AddEditKeyManager.form.revokeEndpoint.help": "E.g., https://localhost:9443/oauth2/revoke",
   "KeyManagers.AddEditKeyManager.form.scopeManagementEndpoint": "Scope Management Endpoint",

--- a/portals/admin/src/main/webapp/site/public/locales/fr.json
+++ b/portals/admin/src/main/webapp/site/public/locales/fr.json
@@ -651,6 +651,7 @@
   "KeyManagers.AddEditKeyManager.form.issuer.help": "E.g.,: https://localhost:9443/oauth2/token",
   "KeyManagers.AddEditKeyManager.form.name": "Name",
   "KeyManagers.AddEditKeyManager.form.name.help": "Name of the Key Manager.",
+  "KeyManagers.AddEditKeyManager.form.orgs.error": "At least one organization should be selected.",
   "KeyManagers.AddEditKeyManager.form.revokeEndpoint": "Revoke Endpoint",
   "KeyManagers.AddEditKeyManager.form.revokeEndpoint.help": "E.g., https://localhost:9443/oauth2/revoke",
   "KeyManagers.AddEditKeyManager.form.scopeManagementEndpoint": "Scope Management Endpoint",

--- a/portals/admin/src/main/webapp/source/src/app/components/Base/Navigator.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/Base/Navigator.jsx
@@ -117,6 +117,7 @@ function Navigator(props) {
     const iskeyManagers = hasPermission(CONSTS.Roles.KEY_MANAGER);
     const isAPICategory = hasPermission(CONSTS.Roles.CATEGORY_MANAGER);
     const isGatewayManager = hasPermission(CONSTS.Roles.GATEWAY_MANAGER);
+    const isOrganizationManager = hasPermission(CONSTS.Roles.ORGANIZATION_MANAGER);
 
     const entireArray = [];
     const checkRouteMenuMapping = routeMenuMapping;
@@ -148,6 +149,12 @@ function Navigator(props) {
             const apiCatObj = checkRouteMenuMapping[i];
             if (isAPICategory) {
                 entireArray.push(apiCatObj);
+            }
+        }
+        if (checkRouteMenuMapping[i].id === 'Organizations') {
+            const organizationObj = checkRouteMenuMapping[i];
+            if (isOrganizationManager) {
+                entireArray.push(organizationObj);
             }
         }
         if (checkRouteMenuMapping[i].id === 'Gateways') {

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -167,6 +167,7 @@ function AddEditKeyManager(props) {
     const { isGlobal } = (location && location.state) || false;
     const isSuperAdmin = isSuperTenant && _scopes.includes('apim:admin_settings');
     const [validOrgs, setValidOrgs] = useState([]);
+    const [orgSelectionType, setOrgSelectionType] = useState(null);
 
     const defaultKMType = (settings.keyManagerConfiguration
         && settings.keyManagerConfiguration.length > 0)
@@ -335,18 +336,25 @@ function AddEditKeyManager(props) {
                     }
                 }
                 setValidOrgs(result.body.allowedOrganizations);
+                if (result.body.allowedOrganizations.includes('ALL') || result.body.allowedOrganizations.length === 0) {
+                    setOrgSelectionType('ALL');
+                } else if (result.body.allowedOrganizations.includes('NONE')) {
+                    setOrgSelectionType('NONE');
+                } else {
+                    setOrgSelectionType('SELECT');
+                }
                 setValidRoles(result.body.permissions
                     && result.body.permissions.roles
                     ? result.body.permissions.roles
                     : []);
                 dispatch({ field: 'all', value: editState });
                 updateKeyManagerConnectorConfiguration(editState.type);
-                getOrganizations();
             });
         } else {
             updateKeyManagerConnectorConfiguration(defaultKMType);
-            getOrganizations();
+            setOrgSelectionType('ALL'); // by default all KMs are allowed for all orgs
         }
+        getOrganizations();
     }, []);
 
     const hasErrors = (fieldName, fieldValue, validatingActive) => {
@@ -381,6 +389,14 @@ function AddEditKeyManager(props) {
                     error = intl.formatMessage({
                         id: 'KeyManagers.AddEditKeyManager.is.empty.error.key.config',
                         defaultMessage: 'Required field is empty.',
+                    });
+                }
+                break;
+            case 'selectOrgs':
+                if (orgSelectionType === 'SELECT' && validOrgs.length === 0) {
+                    error = intl.formatMessage({
+                        id: 'KeyManagers.AddEditKeyManager.form.orgs.error',
+                        defaultMessage: 'At least one organization should be selected.',
                     });
                 }
                 break;
@@ -445,7 +461,8 @@ function AddEditKeyManager(props) {
                 || hasErrors('revokeEndpoint', revokeEndpoint, validatingActive)
                 || hasErrors('enableDirectToken', enableDirectToken, validatingActive)
                 || hasErrors('userInfoEndpoint', userInfoEndpoint, validatingActive)
-                || hasErrors('scopeManagementEndpoint', scopeManagementEndpoint, validatingActive);
+                || hasErrors('scopeManagementEndpoint', scopeManagementEndpoint, validatingActive)
+                || hasErrors('selectOrgs', validOrgs, validatingActive);
         } else {
             return hasErrors('name', name, validatingActive)
                 || hasErrors('displayName', displayName, validatingActive)
@@ -617,8 +634,28 @@ function AddEditKeyManager(props) {
         });
     }
 
+    useEffect(() => {
+        setValidOrgs((prevValidOrgs) => {
+            if (orgSelectionType === 'ALL') return ['ALL'];
+            if (orgSelectionType === 'NONE') return ['NONE'];
+            if (validOrgs.length > 0 && !validOrgs.includes('ALL') && !validOrgs.includes('NONE')) {
+                return prevValidOrgs;
+            }
+            return [];
+        });
+    }, [orgSelectionType]);
+
     const handleOrganizationAddition = (event, newValue) => {
-        setValidOrgs(newValue.map((org) => org.organizationId));
+        const selectedOrgs = newValue.map((org) => org.organizationId);
+        if (selectedOrgs.length === 0) {
+            setOrgSelectionType('NONE');
+        } else {
+            setValidOrgs(selectedOrgs);
+        }
+    };
+
+    const handleOrgSelectionChange = (event) => {
+        setOrgSelectionType(event.target.value);
     };
 
     return (
@@ -1904,100 +1941,136 @@ function AddEditKeyManager(props) {
                             </>
                         )
                     }
-                    {
-                        settings.orgAccessControlEnabled && (
-                            <>
-                                <Grid item xs={12} md={12} lg={3}>
-                                    <Typography
-                                        color='inherit'
-                                        variant='subtitle2'
-                                        component='div'
-                                        id='KeyManagers.AddEditKeyManager.certificate.header'
-                                    >
-                                        <FormattedMessage
-                                            id='KeyManagers.AddEditKeyManager.orgs'
-                                            defaultMessage='Available Organizations'
-                                        />
-                                    </Typography>
-                                    <Typography
-                                        color='inherit'
-                                        variant='caption'
-                                        component='p'
-                                        id='KeyManagers.AddEditKeyManager.certificate.body'
-                                    >
-                                        <FormattedMessage
-                                            id='KeyManagers.AddEditKeyManager.org.description'
-                                            defaultMessage='Make this key manager available to selected organizations.'
-                                        />
-                                    </Typography>
-                                </Grid>
-                                <Grid item xs={12} md={12} lg={9}>
-                                    <Box display='flex' flexDirection='row' alignItems='center'>
-                                        <Autocomplete
-                                            disabled={organizations.length === 0}
-                                            multiple
-                                            fullWidth
-                                            limitTags={5}
-                                            options={organizations}
-                                            getOptionLabel={(option) => option.displayName}
-                                            noOptionsText='No registered organizations'
-                                            disableCloseOnSelect
-                                            value={
-                                                organizations.filter((org) => validOrgs.includes(org.organizationId))
-                                            }
-                                            onChange={handleOrganizationAddition}
-                                            renderOption={(options, organization, { selected }) => (
-                                                <div>
-                                                    <li {...options}>
-                                                        <Checkbox
-                                                            id={organization.organizationId}
-                                                            key={organization.organizationId}
-                                                            icon={icon}
-                                                            checkedIcon={checkedIcon}
-                                                            style={{ marginRight: 8 }}
-                                                            checked={selected}
-                                                        />
-                                                        {organization.displayName}
-                                                    </li>
-                                                </div>
-                                            )}
-                                            renderInput={(params) => (
-                                                <TextField
-                                                    {...params}
-                                                    disabled={organizations.length === 0}
-                                                    fullWidth
-                                                    label={organizations.length !== 0 ? (
-                                                        <FormattedMessage
-                                                            id='Apis.Details.Configurations.organizations'
-                                                            defaultMessage='Organizations'
-                                                        />
-                                                    ) : (
-                                                        <FormattedMessage
-                                                            id='Apis.Details.Configurations.organizations.empty'
-                                                            defaultMessage='No Organizations Registered.'
-                                                        />
-                                                    )}
-                                                    placeholder={intl.formatMessage({
-                                                        id:
-                                                        'Apis.Details.Configurations.organizations.placeholder.text',
-                                                        defaultMessage: 'Search Organizations',
-                                                    })}
-                                                    margin='normal'
-                                                    variant='outlined'
-                                                    id='Organizations'
-                                                />
-                                            )}
-                                        />
-                                    </Box>
-                                </Grid>
-                                <Grid item xs={12}>
-                                    <Box marginTop={2} marginBottom={2}>
-                                        <StyledHr />
-                                    </Box>
-                                </Grid>
-                            </>
-                        )
-                    }
+                    {settings.orgAccessControlEnabled && organizations.length !== 0 && (
+                        <>
+                            <Grid item xs={12} md={12} lg={3}>
+                                <Typography
+                                    color='inherit'
+                                    variant='subtitle2'
+                                    component='div'
+                                    id='KeyManagers.AddEditKeyManager.certificate.header'
+                                >
+                                    <FormattedMessage
+                                        id='KeyManagers.AddEditKeyManager.orgs'
+                                        defaultMessage='Available Organizations'
+                                    />
+                                </Typography>
+                                <Typography
+                                    color='inherit'
+                                    variant='caption'
+                                    component='p'
+                                    id='KeyManagers.AddEditKeyManager.certificate.body'
+                                >
+                                    <FormattedMessage
+                                        id='KeyManagers.AddEditKeyManager.org.description'
+                                        defaultMessage='Make this key manager available to selected organizations.'
+                                    />
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={12} md={12} lg={9}>
+                                <Box component='div' m={1}>
+                                    <FormControl variant='standard' component='fieldset'>
+                                        <RadioGroup
+                                            style={{ flexDirection: 'row' }}
+                                            aria-label='organization'
+                                            name='selection'
+                                            value={orgSelectionType}
+                                            onChange={handleOrgSelectionChange}
+                                        >
+                                            <FormControlLabel
+                                                id='none'
+                                                value='NONE'
+                                                control={<Radio />}
+                                                label='None'
+                                            />
+                                            <FormControlLabel
+                                                id='select'
+                                                value='SELECT'
+                                                control={<Radio />}
+                                                label='Select'
+                                            />
+                                            <FormControlLabel
+                                                id='all'
+                                                value='ALL'
+                                                control={<Radio />}
+                                                label='All'
+                                            />
+                                        </RadioGroup>
+                                    </FormControl>
+                                    {orgSelectionType === 'SELECT' && (
+                                        <Box display='flex' flexDirection='row' alignItems='center'>
+                                            <Autocomplete
+                                                disabled={organizations.length === 0}
+                                                multiple
+                                                fullWidth
+                                                limitTags={5}
+                                                options={organizations}
+                                                getOptionLabel={(option) => option.displayName}
+                                                noOptionsText='No registered organizations'
+                                                disableCloseOnSelect
+                                                value={
+                                                    organizations.filter(
+                                                        (org) => validOrgs.includes(org.organizationId),
+                                                    )
+                                                }
+                                                onChange={handleOrganizationAddition}
+                                                renderOption={(options, organization, { selected }) => (
+                                                    <div>
+                                                        <li {...options}>
+                                                            <Checkbox
+                                                                id={organization.organizationId}
+                                                                key={organization.organizationId}
+                                                                icon={icon}
+                                                                checkedIcon={checkedIcon}
+                                                                style={{ marginRight: 8 }}
+                                                                checked={selected}
+                                                            />
+                                                            {organization.displayName}
+                                                        </li>
+                                                    </div>
+                                                )}
+                                                renderInput={(params) => (
+                                                    <TextField
+                                                        {...params}
+                                                        name='selectOrgs'
+                                                        disabled={organizations.length === 0}
+                                                        fullWidth
+                                                        label={organizations.length !== 0 ? (
+                                                            <FormattedMessage
+                                                                id='Apis.Details.Configurations.organizations'
+                                                                defaultMessage='Organizations'
+                                                            />
+                                                        ) : (
+                                                            <FormattedMessage
+                                                                id='Apis.Details.Configurations.organizations.empty'
+                                                                defaultMessage='No Organizations Registered.'
+                                                            />
+                                                        )}
+                                                        placeholder={intl.formatMessage({
+                                                            id:
+                                                            'Apis.Details.Configurations.organizations.placeholder.'
+                                                            + 'text',
+                                                            defaultMessage: 'Search Organizations',
+                                                        })}
+                                                        margin='normal'
+                                                        variant='outlined'
+                                                        id='Organizations'
+                                                        error={hasErrors('selectOrgs', validOrgs, validating)}
+                                                        helperText={hasErrors('selectOrgs', validOrgs, validating)}
+                                                    />
+                                                )}
+                                            />
+                                        </Box>
+                                    )}
+                                </Box>
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Box marginTop={2} marginBottom={2}>
+                                    <StyledHr />
+                                </Box>
+                            </Grid>
+                        </>
+                    )}
                     <Grid item xs={12} md={12} lg={3}>
                         <Typography
                             color='inherit'

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -2000,7 +2000,6 @@ function AddEditKeyManager(props) {
                                     {orgSelectionType === 'SELECT' && (
                                         <Box display='flex' flexDirection='row' alignItems='center'>
                                             <Autocomplete
-                                                disabled={organizations.length === 0}
                                                 multiple
                                                 fullWidth
                                                 limitTags={5}
@@ -2033,17 +2032,11 @@ function AddEditKeyManager(props) {
                                                     <TextField
                                                         {...params}
                                                         name='selectOrgs'
-                                                        disabled={organizations.length === 0}
                                                         fullWidth
-                                                        label={organizations.length !== 0 ? (
+                                                        label={(
                                                             <FormattedMessage
                                                                 id='Apis.Details.Configurations.organizations'
                                                                 defaultMessage='Organizations'
-                                                            />
-                                                        ) : (
-                                                            <FormattedMessage
-                                                                id='Apis.Details.Configurations.organizations.empty'
-                                                                defaultMessage='No Organizations Registered.'
                                                             />
                                                         )}
                                                         placeholder={intl.formatMessage({

--- a/portals/admin/src/main/webapp/source/src/app/components/Organizations/AddEditOrganization.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/Organizations/AddEditOrganization.jsx
@@ -253,6 +253,7 @@ function AddEditOrganization(props) {
         >
             <Box style={{ paddingRight: '20px' }}>
                 <TextField
+                    autoFocus
                     margin='dense'
                     name='displayName'
                     value={displayName}
@@ -276,7 +277,6 @@ function AddEditOrganization(props) {
                     }}
                 >
                     <TextField
-                        autoFocus
                         margin='dense'
                         name='referenceId'
                         value={referenceId}

--- a/portals/admin/src/main/webapp/source/src/app/components/Organizations/ListOrganizations.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/Organizations/ListOrganizations.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import API from 'AppData/api';
 import { useIntl, FormattedMessage } from 'react-intl';
 import Typography from '@mui/material/Typography';
@@ -45,6 +45,18 @@ function apiCall() {
  */
 export default function ListOrganizations() {
     const intl = useIntl();
+    const [userOrg, setUserOrg] = useState(null);
+
+    useEffect(() => {
+        new API()
+            .getUserOrganizationInfo()
+            .then((result) => {
+                setUserOrg(result.body.organizationId);
+            })
+            .catch((error) => {
+                throw error;
+            });
+    }, []);
 
     const columProps = [
         { name: 'id', options: { display: false } },
@@ -116,12 +128,33 @@ export default function ListOrganizations() {
         ),
     };
 
+    const emptyBoxPropsForNoOrgUser = {
+        content: (
+            <Typography variant='body2' color='textSecondary' component='p'>
+                <FormattedMessage
+                    id='AdminPages.Organizations.List.empty.content.organization.no.orguser'
+                    defaultMessage={'Users who belong to an organization can manage their '
+                    + 'organizations by registering new organizations '
+                    + 'or updating existing entries.'}
+                />
+            </Typography>
+        ),
+        title: (
+            <Typography gutterBottom variant='h5' component='h2'>
+                <FormattedMessage
+                    id='AdminPages.Organizations.List.empty.title.organization'
+                    defaultMessage='Organizations'
+                />
+            </Typography>
+        ),
+    };
+
     return (
         <ListBase
             columProps={columProps}
             pageProps={pageProps}
             searchProps={searchProps}
-            emptyBoxProps={emptyBoxProps}
+            emptyBoxProps={userOrg ? emptyBoxProps : emptyBoxPropsForNoOrgUser}
             apiCall={apiCall}
             EditComponent={AddEditOrganization}
             editComponentProps={{
@@ -129,7 +162,7 @@ export default function ListOrganizations() {
                 title: 'Edit Organization',
             }}
             DeleteComponent={Delete}
-            addButtonProps={addButtonProps}
+            addButtonProps={userOrg ? addButtonProps : null}
         />
     );
 }

--- a/portals/admin/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/admin/src/main/webapp/source/src/app/data/Constants.js
@@ -41,6 +41,8 @@ const CONSTS = {
         SETTINGS_MANAGER: ['apim:app_owner_change', 'apim:admin_application_view',
             'apim:scope_manage', 'openid', 'apim:admin_settings', 'apim:tenantInfo', 'apim:api_provider_change',
         ],
+        ORGANIZATION_MANAGER: ['apim:organization_manage', 'apim:organization_read', 'openid',
+            'apim:tenantInfo', 'apim:admin_settings'],
     },
     DEFAULT_SUBSCRIPTIONLESS_PLAN: 'DefaultSubscriptionless',
     DEFAULT_ASYNC_SUBSCRIPTIONLESS_PLAN: 'AsyncDefaultSubscriptionless',

--- a/portals/admin/src/main/webapp/source/src/app/data/api.js
+++ b/portals/admin/src/main/webapp/source/src/app/data/api.js
@@ -1305,6 +1305,15 @@ class API extends Resource {
             );
         });
     }
+
+    /**
+     * Get user organization information
+     */
+    getUserOrganizationInfo() {
+        return this.client.then((client) => {
+            return client.apis['Users'].organizationInformation(this._requestMetaData());
+        });
+    }
 }
 
 API.CONSTS = {

--- a/portals/devportal/src/main/webapp/services/login/login_callback.jsp
+++ b/portals/devportal/src/main/webapp/services/login/login_callback.jsp
@@ -172,23 +172,6 @@
 
         String idToken = (String) tokenResponse.get("id_token");
 
-        String organization = "";
-        String[] idTokenParts = idToken.split("\\.");
-        if (idTokenParts.length == 3) {
-            String encodedBody = idTokenParts[1];
-            byte[] decodedBytes = Base64.getDecoder().decode(encodedBody);
-            String body = new String(decodedBytes);
-            Map idTokeBody;
-            try {
-                idTokeBody = gson.fromJson(body, Map.class);
-                String orgClaim = "org_name"; // get from settings
-                organization = (String) idTokeBody.get(orgClaim);
-
-            } catch (Exception e) {
-                log.error("Error while parsing id token", e);
-            }
-        }
-
         int idTokenLength = idToken.length();
 
         String idTokenPart1 = idToken.substring(0, idTokenLength / 2);
@@ -263,16 +246,6 @@
         cookie.setPath(context + "/");
         cookie.setSecure(true);
         cookie.setMaxAge(-1);
-        response.addCookie(cookie);
-
-        String encodedOrg = organization;
-        if (encodedOrg != null) {
-            encodedOrg = URLEncoder.encode(organization, "UTF-8");
-        }
-        cookie = new Cookie("ORGANIZATION_Default", encodedOrg);
-        cookie.setPath(context + "/");
-        cookie.setSecure(true);
-        cookie.setMaxAge((int) expiresIn);
         response.addCookie(cookie);
 
         String reqState = request.getParameter("state");

--- a/portals/devportal/src/main/webapp/source/src/app/components/Base/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Base/index.jsx
@@ -44,6 +44,7 @@ import Settings, { useSettingsContext } from 'AppComponents/Shared/SettingsConte
 import { app } from 'Settings';
 import HTMLRender from 'AppComponents/Shared/HTMLRender';
 import Box from '@mui/material/Box';
+import API from 'AppData/api';
 import AuthManager from '../../data/AuthManager';
 import LanguageSelector from './Header/LanuageSelector';
 import GlobalNavBar from './Header/GlobalNavbar';
@@ -275,6 +276,7 @@ class LayoutLegacy extends React.Component {
             selected: 'home',
             anchorEl: null,
             bannerHeight: 0,
+            userOrganization: null,
         };
         this.toggleGlobalNavBar = this.toggleGlobalNavBar.bind(this);
         const { history } = props;
@@ -288,6 +290,7 @@ class LayoutLegacy extends React.Component {
      * @returns {void}
      */
     componentDidMount() {
+        const restApi = new API();
         const { history: { location }, theme } = this.props;
         document.body.style.backgroundColor = theme.custom.page.emptyAreadBackground || '#ffffff';
         this.detectCurrentMenu(location);
@@ -302,6 +305,14 @@ class LayoutLegacy extends React.Component {
                 this.setState({ bannerHeight: bannerElement.clientHeight });
             }
         }
+        restApi
+            .getUserOrganizationInfo()
+            .then((res) => {
+                this.setState({ userOrganization: res.body.name });
+            })
+            .catch((error) => {
+                throw error;
+            });
     }
 
     detectCurrentMenu = (location) => {
@@ -414,11 +425,9 @@ class LayoutLegacy extends React.Component {
         const user = AuthManager.getUser();
         // TODO: Refer to fix: https://github.com/mui-org/material-ui/issues/10076#issuecomment-361232810 ~tmkb
         let username = null;
-        let organization = null;
 
         if (user) {
             username = user.name;
-            organization = user.getOrganizationName();
             const count = (username.match(/@/g) || []).length;
             if (user.name.endsWith('@carbon.super') && count <= 1) {
                 username = user.name.replace('@carbon.super', '');
@@ -610,7 +619,16 @@ class LayoutLegacy extends React.Component {
                                                 aria-label='user menu'
                                             >
                                                 <Icon className={classes.icons}>person</Icon>
-                                                {username}
+                                                <span
+                                                    style={{
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap',
+                                                        maxWidth: '200px',
+                                                    }}
+                                                >
+                                                    {username}
+                                                </span>
                                             </Button>
                                             <Popper
                                                 id='userPopup'
@@ -626,7 +644,7 @@ class LayoutLegacy extends React.Component {
                                                     vertical: 'top',
                                                     horizontal: 'center',
                                                 }}
-                                                placement='bottom-end'
+                                                placement='bottom-start'
                                             >
                                                 {({ TransitionProps, placement }) => (
                                                     <Grow
@@ -640,7 +658,7 @@ class LayoutLegacy extends React.Component {
                                                         <Paper>
                                                             <ClickAwayListener onClickAway={this.handleCloseUserMenu}>
                                                                 <MenuList>
-                                                                    {organization && (
+                                                                    {this.state.userOrganization && (
                                                                         <MenuItem style={{ pointerEvents: 'none' }}>
                                                                             <>
                                                                                 <Icon
@@ -659,9 +677,13 @@ class LayoutLegacy extends React.Component {
                                                                                         textTransform: 'uppercase',
                                                                                         fontWeight: 'bold',
                                                                                         fontSize: '12px',
+                                                                                        whiteSpace: 'nowrap',
+                                                                                        overflow: 'hidden',
+                                                                                        textOverflow: 'ellipsis',
+                                                                                        maxWidth: '200px',
                                                                                     }}
                                                                                 >
-                                                                                    {organization}
+                                                                                    {this.state.userOrganization}
                                                                                 </Typography>
                                                                             </>
                                                                         </MenuItem>

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -973,4 +973,12 @@ export default class API extends Resource {
             );
         });
     }
+    /**
+     * Get the Organization information to which the user belongs to
+     */
+    getUserOrganizationInfo() {
+        return this.client.then((client) => {
+            return client.apis.Users.organizationInformation(this._requestMetaData());
+        });
+    }
 }


### PR DESCRIPTION
### Purpose

Updated the UI with 3 radio buttons None, All and Select to assign organizations to a specific key manager.
For al already existing key manager or a newly added key manager, 'All' will be set by default, if not updated.

<img width="1001" alt="UI_update2" src="https://github.com/user-attachments/assets/10315abf-f68c-4c1d-b759-da71ca8a5ae7" />

### Approach:

When selected,
- ALL, an array including the keywork 'ALL' 
- NONE, an array including the keywork 'NONE'
- SELECT, an array with the UUIDs of selected orgs
will be passed in allowedOrganizations for the specific keymanager.

At the rest API level, these will be handled appropriately by assigning user's current organization if NONE, allowing any organization if ALL, and allowing only selected orgs if SELECT.

For already exisitng Key Managers, allowedOrganizations will be an empty list, which will also be handled from the rest API level.