### PR TITLE
Fix logout redirection issue when home page is enabled

### DIFF
--- a/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
+++ b/portals/devportal/src/main/webapp/services/logout/logout_callback.jsp
@@ -25,6 +25,7 @@
     Log log = LogFactory.getLog(this.getClass());
     log.debug("Logout Callback Function");
     Map settings = Util.readJsonFile("site/public/theme/settings.json", request.getServletContext());
+    Map userTheme = Util.readJsonFile("/site/public/theme/userTheme.json", request.getServletContext());
     String context = Util.getTenantBaseStoreContext(request, (String) Util.readJsonObj(settings, "app.context"));
 
     Cookie cookie = new Cookie("AM_ACC_TOKEN_DEFAULT_P2", "");
@@ -87,7 +88,17 @@
     log.debug("redirecting to logout");
     String referrer = request.getParameter("referrer");
     if (referrer == null) {
-        referrer = "/apis";
-    }
+      Map configurations = (Map) Util.readJsonObj(userTheme, "custom");
+      Map landingPage = (Map) Util.readJsonObj(userTheme, "custom.landingPage");
+      Object landingPageActiveObj = Util.readJsonObj(userTheme, "custom.landingPage.active");
+      boolean landingPageActive = (landingPageActiveObj != null) ? (boolean) landingPageActiveObj : false;
+      if (configurations != null && landingPage != null && landingPageActive) {
+          log.debug("Setting referrer to home");
+          referrer = "/home";
+      } else {
+          referrer = "/apis";
+      }
+      
+  }
     response.sendRedirect(context + "/logout?referrer=" + referrer);
 %>


### PR DESCRIPTION
## Purpose
This PR fixes an issue where logging out from devportal when the home page has been enabled redirects the user to /apis instead of /home.

## Approach
Check whether the home page has been enabled and redirect the post logout flow accordingly.

Fixes: https://github.com/wso2/api-manager/issues/3567
