### PR TITLE
Handling undefined username in the introspect response.

### DIFF
--- a/portals/devportal/src/main/webapp/services/login/introspect.jsp
+++ b/portals/devportal/src/main/webapp/services/login/introspect.jsp
@@ -77,14 +77,18 @@
         boolean isEnableEmailUserName = Util.isEnableEmailUserName();
         Map introspect = gson.fromJson(introspectResult.body(), Map.class);
         String username = (String) introspect.get("username");
-        Pattern regPattern = Pattern.compile("(@)");
-        boolean found = regPattern.matcher(username).find();
-        int count = !found ? 0 : (int) username.chars().filter(ch -> ch == '@').count();
-        if (isEnableEmailUserName || (username.indexOf("@carbon.super") > 0 && count <= 1)) {
-            introspect.put("username", username.replace("@carbon.super", ""));
-        }
-        response.setContentType("application/json");
-        out.println(gson.toJson(introspect));
+         if (username != null && !username.isEmpty()) {
+             Pattern regPattern = Pattern.compile("(@)");
+             boolean found = regPattern.matcher(username).find();
+             int count = !found ? 0 : (int) username.chars().filter(ch -> ch == '@').count();
+             if (isEnableEmailUserName || (username.indexOf("@carbon.super") > 0 && count <= 1)) {
+                 introspect.put("username", username.replace("@carbon.super", ""));
+             }
+             response.setContentType("application/json");
+             out.println(gson.toJson(introspect));
+         } else {
+             log.warn("Username is undefined in the introspect response.");
+         }
     } else {
         log.warn("Something went wrong while introspecting the token " + tokenP1 + tokenP2);
         log.error(introspectResult.body());


### PR DESCRIPTION
## Purpose
- When user authentication token is revoking if the username is not defined a TypeError thrown
- This change will handle this error when user authentication token is revoking with undefined username
- Related issue - https://github.com/wso2-enterprise/wso2-iam-internal/issues/2436
- Related PR - https://github.com/wso2/carbon-identity-framework/pull/6495

## Approach
- warning is logged when username is not defined. 