### PR TITLE
Remove visibleOrganizations field when updating API Products

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -46,13 +46,13 @@ const Root = styled('div')({
 const gatewayDetails = {
     'wso2/synapse': { 
         value: 'wso2/synapse',
-        name: 'Regular Gateway', 
+        name: 'Universal Gateway',
         description: 'API gateway embedded in APIM runtime.', 
         isNew: false 
     },
     'wso2/apk': { 
         value: 'wso2/apk',
-        name: 'APK Gateway', 
+        name: 'Kubernetes Gateway',
         description: 'API gateway running on Kubernetes.', 
         isNew: false 
     },

--- a/portals/publisher/src/main/webapp/source/src/app/data/APIProduct.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/APIProduct.js
@@ -251,12 +251,17 @@ class APIProduct extends Resource {
      */
     update(updatedProperties) {
         const updatedAPI = { ...this.toJSON(), ...this.toJSON(updatedProperties) };
+
+        // Create a copy and remove visibleOrganizations
+        const apiWithoutVisibleOrgs = { ...updatedAPI };
+        delete apiWithoutVisibleOrgs.visibleOrganizations;
+
         const promisedUpdate = this.client.then(client => {
             const payload = {
                 apiProductId: updatedAPI.id,
             };
             const requestBody = {
-                requestBody: updatedAPI,
+                requestBody: apiWithoutVisibleOrgs,
             }
             return client.apis['API Products'].updateAPIProduct(payload, requestBody);
         });


### PR DESCRIPTION
### Purpose
- Remove visibleOrganizations field when updating API Products
- Modify the following gateway names
  - `Regular Gateway` -> `Universal Gateway`
  - `APK Gateway` -> `Kubernetes Gateway`

- Fixes: https://github.com/wso2/api-manager/issues/3665 
