### PR TITLE
Hide Share with Organization button for non-org scenarios

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ApplicationCreateForm.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/ApplicationCreateForm.jsx
@@ -250,7 +250,7 @@ const ApplicationCreate = (props) => {
 
             />
             {
-                isOrgAccessControlEnabled && (
+                isOrgAccessControlEnabled && sessionStorage.getItem('userOrganization') && (
                     <Box display='flex' flexDirection='row' sx={{ pt: 1 }}>
                         <Typography sx={{ fontSize: 14 }}>
                             <FormattedMessage


### PR DESCRIPTION
### Purpose:
Hide the 'Share with the Organization' button in Application creation form for users who dont belong to an organization.

### Approach:
The logged-in user's organization name is stored in the sessionStorage at user login. Retrieve this item and hide the button if it is null.

Fix: https://github.com/wso2/api-manager/issues/3676