### PR TITLE
Improvement to Policies page in Publisher Portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -98,8 +98,29 @@ const Policies: React.FC = () => {
     const [expandedResource, setExpandedResource] = useState<string | null>(null);
     const [isChoreoConnectEnabled, setIsChoreoConnectEnabled] = useState(api.gatewayType !== 'wso2/synapse');
     const { showMultiVersionPolicies } = Configurations.apis;
-    const [selectedTab, setSelectedTab] = useState((api.apiPolicies != null) ? 0 : 1);
+    const [selectedTab, setSelectedTab] = useState(1);
     const [gateway, setGateway] = useState<string>("");
+
+    const operationPoliciesExist = (): boolean => {
+        for (const operation of api.operations) {
+            const { operationPolicies } = operation;
+            for (const category in operationPolicies){
+                const categoryArray = operationPolicies[category];
+                if (categoryArray.length > 0){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    useEffect(() => {
+        if((api.apiPolicies == null) && operationPoliciesExist()){
+            setSelectedTab(1);
+        } else {
+            setSelectedTab(0);
+        }
+    }, [])
 
     // If Choreo Connect radio button is selected in GatewaySelector, it will pass 
     // value as true to render other UI changes specific to the Choreo Connect.

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/TabPanel.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/TabPanel.tsx
@@ -77,7 +77,7 @@ const TabPanelShared: FC<TabPanelSharedProps> = ({
                 id={`${currentFlow}-tabpanel`}
                 aria-labelledby={`${currentFlow}-tab`}
             >
-                <Accordion id='tabPanel-common-policies'>
+                <Accordion id='tabPanel-common-policies' defaultExpanded>
                     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                         <Typography variant='subtitle1'>
                             <FormattedMessage


### PR DESCRIPTION
1. Made API Level Policies Selected by default except when there are Operation Level Policies added and there are no API Level Policies added.
2. Made Common Policies expanded by default

Partial fix for [api-manager#3683](https://github.com/wso2/api-manager/issues/3683)