### PR TITLE
Fixes multiple issues in Gateway Environments UI

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/AdminPages/Addons/ListBase.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/AdminPages/Addons/ListBase.jsx
@@ -173,9 +173,26 @@ function ListBase(props) {
                                                 state: { isAI },
                                             }}
                                         >
-                                            <IconButton color='primary' component='span' size='large'>
-                                                <EditIcon aria-label={`edit-policies+${artifactId}`} />
-                                            </IconButton>
+
+                                            {(dataRow.isReadOnly)
+                                                ? (
+                                                    <IconButton
+                                                        color='primary'
+                                                        component='span'
+                                                        size='large'
+                                                        disabled
+                                                    >
+                                                        <EditIcon aria-label={`edit-policies+${artifactId}`} />
+                                                    </IconButton>
+                                                ) : (
+                                                    <IconButton
+                                                        color='primary'
+                                                        component='span'
+                                                        size='large'
+                                                    >
+                                                        <EditIcon aria-label={`edit-policies+${artifactId}`} />
+                                                    </IconButton>
+                                                )}
                                         </RouterLink>
                                         {DeleteComponent && (
                                             <DeleteComponent

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -502,6 +502,16 @@ function AddEditGWEnvironment(props) {
         defaultMessage: 'Gateway Environment - Create new',
     });
 
+    const getDisplayName = (value) => {
+        if (value === 'Regular') {
+            return 'Universal Gateway';
+        } else if (value === 'APK') {
+            return 'Kubernetes Gateway';
+        } else {
+            return value + ' Gateway';
+        }
+    };
+
     return (
         <StyledContentBase
             pageStyle='half'
@@ -687,16 +697,11 @@ function AddEditGWEnvironment(props) {
                                     onChange={onChange}
                                     data-testid='gateway-environment-type-select'
                                 >
-                                    {settings.gatewayConfiguration
-                                        .sort((a, b) => a.displayName.localeCompare(b.displayName))
-                                        .map((gateway) => (
-                                            <MenuItem key={gateway.type} value={gateway.type}>
-                                                {gateway.displayName || gateway.type}
-                                            </MenuItem>
-                                        ))}
-                                    <MenuItem key='other' value='other' id='Admin.GatewayEnvironment.form.type.menu'>
-                                        {'Other' || 'other'}
-                                    </MenuItem>
+                                    {settings.gatewayTypes.map((item) => (
+                                        <MenuItem key={item} value={item}>
+                                            {getDisplayName(item)}
+                                        </MenuItem>
+                                    ))}
                                 </Select>
                                 <FormHelperText>
                                     {hasErrors('gatewayType', type, validating) || (

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
@@ -156,6 +156,9 @@ function AddEditVhost(props) {
                         const keyedVhost = vhost;
                         keyedVhost.key = '' + i++;
                         keyedVhost.host = defaultHostnameTemplate;
+                        if (defaultHostnameTemplate !== '') {
+                            keyedVhost.isNew = false;
+                        }
                         return keyedVhost;
                     }));
                 } else {
@@ -172,6 +175,9 @@ function AddEditVhost(props) {
                 vhost.key = '' + id;
                 if (config && config.defaultHostnameTemplate) {
                     vhost.host = config.defaultHostnameTemplate;
+                    if (config.defaultHostnameTemplate !== '') {
+                        vhost.isNew = false;
+                    }
                 }
                 setUserVhosts([vhost]);
             }
@@ -431,19 +437,22 @@ function AddEditVhost(props) {
                     </Grid>
                 ))}
                 {/* Add new VHost */}
-                <Grid item xs={12}>
-                    <Button
-                        name='newVhost'
-                        variant='outlined'
-                        color='primary'
-                        onClick={handleNewVhost}
-                    >
-                        <FormattedMessage
-                            id='GatewayEnvironments.AddEditVhost.add.vhost.btn'
-                            defaultMessage='New VHost'
-                        />
-                    </Button>
-                </Grid>
+                {(gatewayType === 'Regular' || gatewayType === 'APK' || gatewayType === 'other')
+                    && (
+                        <Grid item xs={12}>
+                            <Button
+                                name='newVhost'
+                                variant='outlined'
+                                color='primary'
+                                onClick={handleNewVhost}
+                            >
+                                <FormattedMessage
+                                    id='GatewayEnvironments.AddEditVhost.add.vhost.btn'
+                                    defaultMessage='New VHost'
+                                />
+                            </Button>
+                        </Grid>
+                    )}
             </Grid>
         </FormGroup>
     );


### PR DESCRIPTION
This PR,

- Disables update option for readOnly gateway environments

- Updates gateway type display names to align with new naming convention.
 
<img width="1026" alt="Screenshot 2025-02-27 at 15 52 55" src="https://github.com/user-attachments/assets/22a8ff97-7f2e-48e8-8c4e-cf67f107c953" />


- Fixes https://github.com/wso2/api-manager/issues/3726 by disabling multi vhost support for AWS gateways.