### PR TITLE
Improve error handling in governance blocking scenarios

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
@@ -419,10 +419,20 @@ function APICreateDefault(props) {
                                     });
                                 }
                             },
-                            error: () => intl.formatMessage({
-                                id: 'Apis.Create.Default.APICreateDefault.error.otherStatus',
-                                defaultMessage: 'Error while publishing the API',
-                            }),
+
+                            error: (error) => {
+                                if (error.response.body.code === complianceErrorCode) {
+                                    return intl.formatMessage({
+                                        id: 'Apis.Create.Default.APICreateDefault.error.governance.violation',
+                                        defaultMessage: 'Revision creation failed due to governance violations',
+                                    });
+                                } else {
+                                    return intl.formatMessage({
+                                        id: 'Apis.Create.Default.APICreateDefault.error.otherStatus',
+                                        defaultMessage: 'Error while publishing the API',
+                                    })
+                                }
+                            },
                         });
                         promisedPublish.then(() => history.push(`/apis/${api.id}/overview`))
                             .finally(() => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
@@ -36,6 +36,7 @@ import DefaultAPIForm from 'AppComponents/Apis/Create/Components/DefaultAPIForm'
 import APIProduct from 'AppData/APIProduct';
 import AuthManager from 'AppData/AuthManager';
 import Progress from 'AppComponents/Shared/Progress';
+import Utils from 'AppData/Utils';
 
 const gatewayTypeMap = {
     'Regular': 'wso2/synapse',
@@ -293,14 +294,45 @@ function APICreateDefault(props) {
                 error: (error) => {
                     console.error(error);
                     if (error.response) {
-                        // TODO: Use the code to check for the governance error
                         if (error.response.body.code === complianceErrorCode) {
-                            // TODO: Check whether we need to display the violations table
-                            // TODO: Improve the error alert
-                            return intl.formatMessage({
-                                id: 'Apis.Create.Default.APICreateDefault.error.governance.violation',
-                                defaultMessage: 'Revision creation failed due to governance violations',
-                            });
+                            const violations = JSON.parse(error.response.body.description).blockingViolations;
+                            return (
+                                <Box sx={{ width: '100%' }}>
+                                    <Typography>
+                                        <FormattedMessage
+                                            id='Apis.Create.Default.APICreateDefault.error.governance.violation'
+                                            defaultMessage={'Failed to create the API Revision due to '
+                                                + 'governance violations'}
+                                        />
+                                    </Typography>
+                                    <Box sx={{
+                                        display: 'flex',
+                                        justifyContent: 'flex-end',
+                                        mt: 1
+                                    }}>
+                                        <Button
+                                            onClick={() => Utils.downloadAsJSON(violations, 'governance-violations')}
+                                            sx={{
+                                                color: 'inherit',
+                                                fontWeight: 600,
+                                                textDecoration: 'none',
+                                                transition: 'all 0.3s',
+                                                '&:hover': {
+                                                    backgroundColor: 'inherit',
+                                                    transform: 'translateY(-2px)',
+                                                    textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                },
+                                            }}
+                                        >
+                                            <FormattedMessage
+                                                id={'Apis.Create.Default.APICreateDefault.error.'
+                                                    + 'governance.violation.download'}
+                                                defaultMessage='Download Violations'
+                                            />
+                                        </Button>
+                                    </Box>
+                                </Box>
+                            )
                         } else {
                             setPageError(error.response.body);
                             return error.response.body.description;
@@ -369,14 +401,45 @@ function APICreateDefault(props) {
                     error: (error) => {
                         console.error(error);
                         if (error.response) {
-                            // TODO: Use the code to check for the governance error
                             if (error.response.body.code === complianceErrorCode) {
-                                // TODO: Check whether we need to display the violations list
-                                // TODO: Improve the error alert
-                                return intl.formatMessage({
-                                    id: 'Apis.Create.Default.APICreateDefault.error.governance.violation',
-                                    defaultMessage: 'Deployment failed due to governance violations',
-                                });
+                                const violations = JSON.parse(error.response.body.description).blockingViolations;
+                                return (
+                                    <Box sx={{ width: '100%' }}>
+                                        <Typography>
+                                            <FormattedMessage
+                                                id='Apis.Create.Default.APICreateDefault.error.governance.violation'
+                                                defaultMessage='Deployment failed due to governance violations'
+                                            />
+                                        </Typography>
+                                        <Box sx={{
+                                            display: 'flex',
+                                            justifyContent: 'flex-end',
+                                            mt: 1
+                                        }}>
+                                            <Button
+                                                onClick={() =>
+                                                    Utils.downloadAsJSON(violations, 'governance-violations')}
+                                                sx={{
+                                                    color: 'inherit',
+                                                    fontWeight: 600,
+                                                    textDecoration: 'none',
+                                                    transition: 'all 0.3s',
+                                                    '&:hover': {
+                                                        backgroundColor: 'inherit',
+                                                        transform: 'translateY(-2px)',
+                                                        textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                    },
+                                                }}
+                                            >
+                                                <FormattedMessage
+                                                    id={'Apis.Create.Default.APICreateDefault.error.'
+                                                        + 'governance.violation.download'}
+                                                    defaultMessage='Download Violations'
+                                                />
+                                            </Button>
+                                        </Box>
+                                    </Box>
+                                )
                             } else {
                                 setPageError(error.response.body);
                                 return error.response.body.description;
@@ -419,13 +482,48 @@ function APICreateDefault(props) {
                                     });
                                 }
                             },
-
                             error: (error) => {
                                 if (error.response.body.code === complianceErrorCode) {
-                                    return intl.formatMessage({
-                                        id: 'Apis.Create.Default.APICreateDefault.error.governance.violation',
-                                        defaultMessage: 'Revision creation failed due to governance violations',
-                                    });
+                                    const violations = JSON.parse(error.response.body.description).blockingViolations;
+                                    return (
+                                        <Box sx={{ width: '100%' }}>
+                                            <Typography>
+                                                <FormattedMessage
+                                                    id={'Apis.Create.Default.APICreateDefault.error.'
+                                                        + 'governance.violation'}
+                                                    defaultMessage={'Failed to publish the API due to '
+                                                        + 'governance violations'}
+                                                />
+                                            </Typography>
+                                            <Box sx={{
+                                                display: 'flex',
+                                                justifyContent: 'flex-end',
+                                                mt: 1
+                                            }}>
+                                                <Button
+                                                    onClick={() =>
+                                                        Utils.downloadAsJSON(violations, 'governance-violations')}
+                                                    sx={{
+                                                        color: 'inherit',
+                                                        fontWeight: 600,
+                                                        textDecoration: 'none',
+                                                        transition: 'all 0.3s',
+                                                        '&:hover': {
+                                                            backgroundColor: 'inherit',
+                                                            transform: 'translateY(-2px)',
+                                                            textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                        },
+                                                    }}
+                                                >
+                                                    <FormattedMessage
+                                                        id={'Apis.Create.Default.APICreateDefault.error.'
+                                                            + 'governance.violation.download'}
+                                                        defaultMessage='Download Violations'
+                                                    />
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    )
                                 } else {
                                     return intl.formatMessage({
                                         id: 'Apis.Create.Default.APICreateDefault.error.otherStatus',

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/StreamingAPI/APICreateStreamingAPI.jsx
@@ -34,6 +34,7 @@ import Banner from 'AppComponents/Shared/Banner';
 import DefaultAPIForm from 'AppComponents/Apis/Create/Components/DefaultAPIForm';
 import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import AuthManager from 'AppData/AuthManager';
+import Utils from 'AppData/Utils';
 
 const PREFIX = 'APICreateStreamingAPI';
 
@@ -324,8 +325,54 @@ const APICreateStreamingAPI = (props) => {
                                 })
                                 .catch((error) => {
                                     if (error.response) {
-                                        Alert.error(error.response.body.description);
-                                        setPageError(error.response.body);
+                                        if (error.response.body.code === complianceErrorCode) {
+                                            const violations =
+                                                JSON.parse(error.response.body.description).blockingViolations;
+                                            Alert.error(
+                                                <Box sx={{ width: '100%' }}>
+                                                    <Typography>
+                                                        <FormattedMessage
+                                                            id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.'
+                                                                + 'error.governance.violation'}
+                                                            defaultMessage={'Failed to publish the API due to '
+                                                                + 'governance violations'}
+                                                        />
+                                                    </Typography>
+                                                    <Box sx={{
+                                                        display: 'flex',
+                                                        justifyContent: 'flex-end',
+                                                        mt: 1
+                                                    }}>
+                                                        <Button
+                                                            onClick={() =>
+                                                                Utils.downloadAsJSON(
+                                                                    violations, 'governance-violations'
+                                                                )}
+                                                            sx={{
+                                                                color: 'inherit',
+                                                                fontWeight: 600,
+                                                                textDecoration: 'none',
+                                                                transition: 'all 0.3s',
+                                                                '&:hover': {
+                                                                    backgroundColor: 'inherit',
+                                                                    transform: 'translateY(-2px)',
+                                                                    textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                                },
+                                                            }}
+                                                        >
+                                                            <FormattedMessage
+                                                                id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.'
+                                                                    + 'error.governance.violation.download'}
+                                                                defaultMessage='Download Violations'
+                                                            />
+                                                        </Button>
+                                                    </Box>
+                                                </Box>
+                                            )
+                                        } else {
+                                            Alert.error(error.response.body.description);
+                                            setPageError(error.response.body);
+                                        }
                                     } else {
                                         Alert.error(intl.formatMessage({
                                             id: 'Apis.Create.Default.APICreateDefault.error.errorMessage.publish',
@@ -342,8 +389,50 @@ const APICreateStreamingAPI = (props) => {
                         })
                         .catch((error) => {
                             if (error.response) {
-                                Alert.error(error.response.body.description);
-                                setPageError(error.response.body);
+                                if (error.response.body.code === complianceErrorCode) {
+                                    const violations = JSON.parse(error.response.body.description).blockingViolations;
+                                    Alert.error(
+                                        <Box sx={{ width: '100%' }}>
+                                            <Typography>
+                                                <FormattedMessage
+                                                    id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.error.'
+                                                        + 'governance.violation'}
+                                                    defaultMessage='Deployment failed due to governance violations'
+                                                />
+                                            </Typography>
+                                            <Box sx={{
+                                                display: 'flex',
+                                                justifyContent: 'flex-end',
+                                                mt: 1
+                                            }}>
+                                                <Button
+                                                    onClick={() =>
+                                                        Utils.downloadAsJSON(violations, 'governance-violations')}
+                                                    sx={{
+                                                        color: 'inherit',
+                                                        fontWeight: 600,
+                                                        textDecoration: 'none',
+                                                        transition: 'all 0.3s',
+                                                        '&:hover': {
+                                                            backgroundColor: 'inherit',
+                                                            transform: 'translateY(-2px)',
+                                                            textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                        },
+                                                    }}
+                                                >
+                                                    <FormattedMessage
+                                                        id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.error.'
+                                                            + 'governance.violation.download'}
+                                                        defaultMessage='Download Violations'
+                                                    />
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    )
+                                } else {
+                                    Alert.error(error.response.body.description);
+                                    setPageError(error.response.body);
+                                }
                             } else {
                                 Alert.error(intl.formatMessage({
                                     id: 'Apis.Create.Default.APICreateDefault.error.errorMessage.deploy.revision',
@@ -359,15 +448,46 @@ const APICreateStreamingAPI = (props) => {
                 })
                 .catch((error) => {
                     if (error.response) {
-                        // TODO: Use the code to check for the governance error
                         if (error.response.body.code === complianceErrorCode) {
-                            // TODO: Check whether we need to display the violations list
-                            // TODO: Improve the error alert
-                            Alert.error(intl.formatMessage({
-                                id: 'Apis.Create.Default.APICreateDefault.error.errorMessage.'
-                                    + 'create.revision.governance',
-                                defaultMessage: 'Action failed due to governance violations',
-                            }));
+                            const violations = JSON.parse(error.response.body.description).blockingViolations;
+                            Alert.error(
+                                <Box sx={{ width: '100%' }}>
+                                    <Typography>
+                                        <FormattedMessage
+                                            id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.error.'
+                                                + 'governance.violation'}
+                                            defaultMessage={'Failed to create the API Revision due to '
+                                                + 'governance violations'}
+                                        />
+                                    </Typography>
+                                    <Box sx={{
+                                        display: 'flex',
+                                        justifyContent: 'flex-end',
+                                        mt: 1
+                                    }}>
+                                        <Button
+                                            onClick={() => Utils.downloadAsJSON(violations, 'governance-violations')}
+                                            sx={{
+                                                color: 'inherit',
+                                                fontWeight: 600,
+                                                textDecoration: 'none',
+                                                transition: 'all 0.3s',
+                                                '&:hover': {
+                                                    backgroundColor: 'inherit',
+                                                    transform: 'translateY(-2px)',
+                                                    textShadow: '0px 1px 2px rgba(0,0,0,0.2)',
+                                                },
+                                            }}
+                                        >
+                                            <FormattedMessage
+                                                id={'Apis.Create.StreamingAPI.APICreateStreamingAPI.error.'
+                                                    + 'governance.violation.download'}
+                                                defaultMessage='Download Violations'
+                                            />
+                                        </Button>
+                                    </Box>
+                                </Box>
+                            )
                         } else {
                             Alert.error(error.response.body.description);
                             setPageError(error.response.body);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -830,7 +830,6 @@ export default function Environments() {
                 })
                 .catch((error) => {
                     if (error.response) {
-                        // TODO: Use the error code to identify the errors thrown by governance violation
                         if (error.response.body.code === complianceErrorCode) {
                             const violations = JSON.parse(error.response.body.description).blockingViolations;
                             setGovernanceError(violations);
@@ -852,7 +851,7 @@ export default function Environments() {
                                     }}>
                                         <Link
                                             component='button'
-                                            onClick={() => 
+                                            onClick={() =>
                                                 Utils.downloadAsJSON(violations, 'governance-violations')
                                             }
                                             sx={{
@@ -1080,6 +1079,7 @@ export default function Environments() {
             displayOnDevportal,
             vhost,
         }];
+        let isBlockedByGovernanceViolation = false;
         if (api.apiType !== API.CONSTS.APIProduct) {
             setIsDeploying(true);
             restApi.deployRevision(api.id, revisionId, body).then((response) => {
@@ -1098,8 +1098,8 @@ export default function Environments() {
                 }
             }).catch((error) => {
                 if (error.response) {
-                    // TODO: Use the error code to identify the errors thrown by governance violation
                     if (error.response.body.code === complianceErrorCode) {
+                        isBlockedByGovernanceViolation = true;
                         const violations = JSON.parse(error.response.body.description).blockingViolations;
                         setGovernanceError(violations);
                         setIsGovernanceViolation(true);
@@ -1151,8 +1151,11 @@ export default function Environments() {
                 }
                 console.error(error);
             }).finally(() => {
-                getRevision();
-                getDeployedEnv();
+                // Only refresh the page if there's no governance violation
+                if (!isBlockedByGovernanceViolation) {
+                    getRevision();
+                    getDeployedEnv();
+                }
                 setIsDeploying(false);
             });
         } else {
@@ -1213,7 +1216,6 @@ export default function Environments() {
                         })
                         .catch((error) => {
                             if (error.response) {
-                                // TODO: Use the error code to identify the errors thrown by governance violation
                                 if (error.response.body.code === complianceErrorCode) {
                                     const violations = JSON.parse(error.response.body.description).blockingViolations;
                                     setGovernanceError(violations);
@@ -1235,7 +1237,7 @@ export default function Environments() {
                                             }}>
                                                 <Link
                                                     component='button'
-                                                    onClick={() => 
+                                                    onClick={() =>
                                                         Utils.downloadAsJSON(violations, 'governance-violations')
                                                     }
                                                     sx={{
@@ -1279,7 +1281,6 @@ export default function Environments() {
                 })
                 .catch((error) => {
                     if (error.response) {
-                        // TODO: Use the error code to identify the errors thrown by governance violation
                         if (error.response.body.code === complianceErrorCode) {
                             const violations = JSON.parse(error.response.body.description).blockingViolations;
                             setGovernanceError(violations);
@@ -1322,6 +1323,7 @@ export default function Environments() {
                                     </Box>
                                 </Box>
                             );
+                            setOpenDeployPopup(false);
                             return;
                         } else {
                             Alert.error(error.response.body.description);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/SampleAPI/components/TaskState.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/SampleAPI/components/TaskState.jsx
@@ -12,6 +12,7 @@ import CircularProgress from '@mui/material/CircularProgress';
  * @return {*}
  */
 export default function TaskState(props) {
+    const complianceErrorCode = 903300;
     const {
         pending, completed, errors, inProgress, children, pendingMessage, completedMessage, inProgressMessage,
     } = props;
@@ -39,8 +40,7 @@ export default function TaskState(props) {
         severity = 'error';
         if (errors.response) {
             const { body } = errors.response;
-            if (body.description && body.description.includes('violatedPath')) { 
-                // TODO: Use the code for governance violations
+            if (body.code === complianceErrorCode) {
                 message = (
                     <>
                         <b>Governance Policy Violation</b>
@@ -48,7 +48,7 @@ export default function TaskState(props) {
                         <FormattedMessage
                             id='Apis.Listing.TaskState.governance.violation'
                             defaultMessage={'One or more governance polices have been violated.'
-                            + ' Please check the configurations.'}
+                                + ' Please check the configurations.'}
                         />
                     </>
                 );


### PR DESCRIPTION
### Purpose
$subject

### Approach
- Update the error handling logic in deployment page in governance blocking scenarios to prevent resetting the deployment page in governance blocking scenarios [1]
- Improved the error handling of Create & Publish operations in Publisher [2]
   - Handled the errors in async API creation/publish
   - Added the download violations button to the error alert

### Preview

[1] 

https://github.com/user-attachments/assets/ec9b3c81-9cef-4395-9b00-beb92e1df69e


[2] 

https://github.com/user-attachments/assets/3a724c65-49e1-4f67-b0ba-a8ae2ba8c487

