### PR TITLE
[API Design Assistant] Add UI fixes to individual components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.50-SNAPSHOT</version>
+    <version>9.2.50</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.50</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.51-SNAPSHOT</version>
+    <version>9.2.51</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>HEAD</tag>
+        <tag>v9.2.51</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.51</version>
+    <version>9.2.52-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.51</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.wso2.carbon.apimgt.ui</groupId>
     <artifactId>apim.ui.apps</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.50</version>
+    <version>9.2.51-SNAPSHOT</version>
     <name>WSO2 API Manager UI - Parent</name>
     <url>https://wso2.org</url>
 
@@ -21,7 +21,7 @@
         <url>https://github.com/wso2/apim-apps.git</url>
         <developerConnection>scm:git:https://github.com/wso2/apim-apps.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/apim-apps.git</connection>
-        <tag>v9.2.50</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51</version>
+        <version>9.2.52-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50-SNAPSHOT</version>
+        <version>9.2.50</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51-SNAPSHOT</version>
+        <version>9.2.51</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/admin/pom.xml
+++ b/portals/admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50</version>
+        <version>9.2.51-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51</version>
+        <version>9.2.52-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50-SNAPSHOT</version>
+        <version>9.2.50</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51-SNAPSHOT</version>
+        <version>9.2.51</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/devportal/pom.xml
+++ b/portals/devportal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50</version>
+        <version>9.2.51-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51-SNAPSHOT</version>
+        <version>9.2.51</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.51-SNAPSHOT</version>
+    <version>9.2.51</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50-SNAPSHOT</version>
+        <version>9.2.50</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.50-SNAPSHOT</version>
+    <version>9.2.50</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50</version>
+        <version>9.2.51-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.50</version>
+    <version>9.2.51-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/pom.xml
+++ b/portals/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51</version>
+        <version>9.2.52-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apim.ui.apps.portals</artifactId>
     <packaging>pom</packaging>
-    <version>9.2.51</version>
+    <version>9.2.52-SNAPSHOT</version>
     <name>WSO2 API Manager UI Portals - Parent</name>
     <url>https://wso2.org</url>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51</version>
+        <version>9.2.52-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50-SNAPSHOT</version>
+        <version>9.2.50</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.51-SNAPSHOT</version>
+        <version>9.2.51</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/pom.xml
+++ b/portals/publisher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.apimgt.ui</groupId>
         <artifactId>apim.ui.apps</artifactId>
-        <version>9.2.50</version>
+        <version>9.2.51-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
@@ -441,10 +441,8 @@ const ApiCreateWithAI = () => {
                                 backgroundColor: '#fff',
                                 marginRight: '20px',
                                 minwidth:'50%',
-                                overflowY: 'auto',
+                                overflowY: 'hidden',
                                 overflowX: 'hidden'
-
-
                             }}
                         >
                             {lastRenderedComponent}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
@@ -337,23 +337,33 @@ const ApiCreateWithAI = () => {
                                     <Box>
                                         <WelcomeMessage/>
                                         <Stack 
-                                            direction='row' 
-                                            spacing={7} 
-                                            justifyContent='center'
-                                            marginTop= '40px'
+                                            direction="column" 
+                                            spacing={2} 
+                                            justifyContent="center"
+                                            sx={{ 
+                                                width: '420px', 
+                                                display: 'flex', 
+                                                marginTop: '40px', 
+                                                marginLeft: 'auto', 
+                                                marginRight: 'auto', 
+                                                marginBottom: '0' 
+                                            }}
                                         >
                                             <SampleQueryCard 
                                                 onExecuteClick={handleExecuteSampleQuery} 
-                                                queryHeading='Create a REST API' 
-                                                queryData='Create an API for a banking transaction' 
+                                                queryHeading='Create an API for a banking transaction' 
                                                 sx={{ textAlign: 'left' }} 
                                             />
                                             <SampleQueryCard 
                                                 onExecuteClick={handleExecuteSampleQuery} 
-                                                queryHeading='Create a SSE API' 
-                                                queryData='Create an API for live sports scores' 
+                                                queryHeading='Create a GraphQL schema to query patient data' 
                                                 sx={{ textAlign: 'left' }} 
-                                            />
+                                            />  
+                                            <SampleQueryCard 
+                                                onExecuteClick={handleExecuteSampleQuery} 
+                                                queryHeading='Create an API for live sports scores' 
+                                                sx={{ textAlign: 'left' }} 
+                                            />                                          
                                         </Stack>
                                     </Box>
                                 )}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/DisplayCode.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/DisplayCode.tsx
@@ -25,7 +25,9 @@ import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import SwaggerUI from './swaggerUIChatbot/SwaggerUI';
 import { Typography } from '@mui/material';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import 'swagger-ui-react/swagger-ui.css';
+import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
 
 interface DisplayCodeProps {
   finalOutcomeCode: string;
@@ -36,6 +38,18 @@ interface DisplayCodeProps {
 const DisplayCode: React.FC<DisplayCodeProps> = ({ finalOutcomeCode, apiType, sessionId }) => {
   const [showCode, setShowCode] = useState(false);
 
+  const handleDownload = () => {
+    const blob = new Blob([finalOutcomeCode], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `api-source.yaml`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <Box sx={{ width: '100%', height: '85vh' }}>
       <Stack spacing={0} sx={{ height: '100%', mt: 2 }}>
@@ -45,10 +59,10 @@ const DisplayCode: React.FC<DisplayCodeProps> = ({ finalOutcomeCode, apiType, se
             display: 'flex',
             justifyContent: 'flex-end',
             alignItems: 'flex-end',
-            paddingRight: '20px',
+            paddingRight: '0px',
+            paddingBottom: '10px',
           }}
         >
-          {/* <Stack direction="row" spacing={1}> */}
             {apiType === 'REST' && (
 
                   <FormControlLabel
@@ -64,9 +78,19 @@ const DisplayCode: React.FC<DisplayCodeProps> = ({ finalOutcomeCode, apiType, se
                       />
                   }
                   labelPlacement='start'
+                  sx={{ marginRight: '20px' }}
                   />
             )}
-          {/* </Stack> */}
+            <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                onClick={handleDownload}
+                sx={{ marginRight: '0px', minWidth: '100px', height: '35px', px: 2, }}
+            >
+                Download
+                <CloudDownloadRounded sx={{ marginLeft: '8px' }} />
+            </Button>
         </Box>
 
         {apiType === 'REST' ? (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/LoadingDots.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/LoadingDots.tsx
@@ -62,7 +62,7 @@ const LoadingDots: React.FC = () => {
       <style>
         {keyframesStyle}
       </style>
-      <div style={containerStyle}>
+      <div style={{ ...containerStyle, display: 'flex', alignItems: 'center', justifyContent: 'flex-start', marginLeft: '16px' }}>
         <span style={textStyle}>Generating a response</span>
         <div style={dotsStyle}>
           <span style={{ ...dotStyle, animationDelay: '-0.32s' }}></span>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/SampleQueryCard.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/SampleQueryCard.tsx
@@ -95,34 +95,26 @@ const SampleQueryCard: React.FC<SampleQueryCardProps> = ({
                     border: 'none',
                 }}
             >
-                <CardContent>
-                    <Box display='flex' flexDirection='column' height={1} alignItems='flex-start' >
-                        <Box mb={2}>
-                            <Typography variant='body1'>
+                <CardContent sx={{ '&:last-child': { paddingBottom: '16px' } }}>
+                    <Box display="flex" flexDirection="row" height={1} alignItems="center" justifyContent="space-between">
+                        <Box>
+                            <Typography variant="body1">
                                 {queryHeading}
                             </Typography>
-                            <Typography variant='body2' color='textSecondary' component='p' className={classes.sampleQuery}>
-                                {queryData}
-                            </Typography>
                         </Box>
-                        <Box mt='auto'>
-                            <Box>
-                                <Button
-                                    size='small'
-                                    id='sample-query-execute'
-                                    variant='outlined'
-                                    onClick={() => onExecuteClick(queryData)}
-                                    disabled={
-                                        !designAssistantEnabled
-                                        || !aiAuthTokenProvided
-                                    }
-                                >
-                                    {intl.formatMessage({
-                                        id: 'Apis.Details.ApiChat.components.SampleQueryCard.executeButton',
-                                        defaultMessage: 'Try It',
-                                    })}
-                                </Button>
-                            </Box>
+                        <Box>
+                            <Button
+                                size="small"
+                                id="sample-query-execute"
+                                variant="outlined"
+                                onClick={() => onExecuteClick(queryHeading)}
+                                disabled={!designAssistantEnabled || !aiAuthTokenProvided}
+                            >
+                                {intl.formatMessage({
+                                    id: 'Apis.Details.ApiChat.components.SampleQueryCard.executeButton',
+                                    defaultMessage: 'Try It',
+                                })}
+                            </Button>
                         </Box>
                     </Box>
                 </CardContent>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/SimilaritySearch.js
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/components/SimilaritySearch.js
@@ -1,0 +1,82 @@
+/*eslint-disable*/
+const predefinedAnswers = {
+    hi: 'Hello there!, How can I assist you today?',
+    hiii: 'Hello there!, How can I assist you today?',
+    hello: 'Hi! How can I assist you today?',
+    hey: 'Hey! How can I help you?',
+    greetings: 'Greetings! What can I assist you with?',
+    thanks: 'You\'re welcome!',
+    bye: 'Goodbye! Have a great day!',
+    goodbye: 'Goodbye! Have a great day!',
+    'thank you': 'You\'re welcome!',
+    'thank you for your help': 'You\'re welcome!',
+    'good morning': 'Good morning! How can I assist you today?',
+    'good afternoon': 'Good afternoon! What can I do for you?',
+    'good evening': 'Good evening! How can I help?',
+    'hey there': 'Hey! What can I assist you with?',
+    'hi there': 'Hello! How may I assist you?',
+    'hello there': 'Hello! How can I assist you today?',
+    'how are you': 'I\'m doing well, thank you! How can I help you?',
+    'can you help me': 'You can ask me to create an API you want!',
+    'what can I ask you': 'You can ask me to create an API you want!',
+    'what can you do': 'I can help you with creating APIs based on the information you share with me',
+    'what do you do': 'I can help you create APIs based on the information you share with me!',
+    'what do you know': 'I know a lot about creating APIs! What API are you looking to create?',
+    'what are you': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+    'what are u': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+    'who are you': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+    'who are u': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+    'what is your name': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+    'whats ur name': 'I am the API Design Assistant. I can help you create APIs based on the information you share with me!',
+};
+
+const calculateStringSimilarity = (string1, string2) => {
+    const str1 = string1.toLowerCase();
+    const str2 = string2.toLowerCase();
+
+    if (str1.length < 2 || str2.length < 2) return 0;
+
+    const subsequenceMap = new Map();
+    for (let i = 0; i < str1.length - 1; i++) {
+        const subsequence = str1.substr(i, 2);
+        subsequenceMap.set(subsequence, subsequenceMap.has(subsequence) ? subsequenceMap.get(subsequence) + 1 : 1);
+    }
+
+    let matchCount = 0;
+    for (let j = 0; j < str2.length - 1; j++) {
+        const subsequence = str2.substr(j, 2);
+        const count = subsequenceMap.has(subsequence) ? subsequenceMap.get(subsequence) : 0;
+        if (count > 0) {
+            subsequenceMap.set(subsequence, count - 1);
+            matchCount++;
+        }
+    }
+
+    return (matchCount * 2) / (str1.length + str2.length - 2);
+};
+
+const findBestMatchingAnswer = (inputString) => {
+    let bestMatch = null;
+    let bestScore = -1;
+
+    const searchString = inputString.toLowerCase();
+
+    if (searchString.length < 2) return null;
+
+    for (const [key] of Object.entries(predefinedAnswers)) {
+        const comparisonString = key.toLowerCase();
+
+        const score = calculateStringSimilarity(searchString, comparisonString);
+
+        if (score > bestScore) {
+            bestScore = score;
+            bestMatch = key;
+        }
+    }
+
+    if (bestScore < 0.8) return null;
+
+    return predefinedAnswers[bestMatch];
+};
+
+export default findBestMatchingAnswer;


### PR DESCRIPTION
## Purpose
> This PR includes several changes to the UI of API Design Assistant.
> Related issue: https://github.com/wso2/api-manager/issues/3564

> 1. Removes the API type from the sample query cards, rearranges the order and placing and adds a new card for GraphQL APIs.
![image](https://github.com/user-attachments/assets/3b08cfd0-cab7-4c34-8cce-80a72da1df96)

> 2. Aligns the loading dots with the 'Generating a response' text and also shifts this component a little bit to the right.
![image](https://github.com/user-attachments/assets/8168403d-c7df-4630-8550-291dd18cc5fe)

> 3. Adds a download button for all API types next to the 'View Source' toggle (for REST APIs) to enable downloading the source code of the API specification.

> Below is an image of how it is shown for REST APIs.
![image](https://github.com/user-attachments/assets/64fad251-851e-4e69-bccd-1844dec83fea)

> Below is an image of how it is shown for GraphQL or Async APIs.
![image](https://github.com/user-attachments/assets/736a42cd-c1d3-4071-b14c-55642761d265)

> Below is an image of it having the functionality to download the spec to their 'Downloads' folder.
![image](https://github.com/user-attachments/assets/4fae5ff8-6404-4a97-bd36-5d6bb2832356)

> 4. Adds functionality to respond to simple non-API related questions and statements.
![image](https://github.com/user-attachments/assets/615fcbf0-e6a7-4725-8611-c34995829964)

> Below is an image of the assistant creating an API after asking non-API related questions.
![image](https://github.com/user-attachments/assets/4c965df2-3fe1-4623-8348-4874fe03da06)

