### PR TITLE
Ensure security config dialog is properly updated with props changes

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -365,6 +365,21 @@ function EndpointOverview(props) {
         setEndpointSecurityInfo(endpointConfig.endpoint_security);
     }, [props]);
 
+    // If the props change while the dialog is open,
+    // re-initialize the security info and security config
+    useEffect(() => {
+        if (endpointSecurityConfig.open) {
+            const tmpSecurityInfo = !endpointSecurityInfo ? {
+                production: CONSTS.DEFAULT_ENDPOINT_SECURITY,
+                sandbox: CONSTS.DEFAULT_ENDPOINT_SECURITY,
+            } : endpointSecurityInfo;
+            setEndpointSecurityInfo(tmpSecurityInfo);
+            setEndpointSecurityConfig((prev) => ({
+                ...prev,
+                config: tmpSecurityInfo === undefined ? {} : tmpSecurityInfo,
+            }));
+        }
+    }, [props, endpointSecurityConfig.open]);
 
     const getEndpoints = (type) => {
         if (epConfig[type]) {


### PR DESCRIPTION
### Purpose
Purpose of the PR is to fix https://github.com/wso2/api-manager/issues/3661

### Issue
When the user clicks the security configuration button while the endpoint text box is focused, both [editEndpoint](https://github.com/wso2/apim-apps/blob/main/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx#L439) and [toggleEndpointSecurityConfig](https://github.com/wso2/apim-apps/blob/main/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx#L656) are triggered simultaneously. This causes the [securityInfo](https://github.com/wso2/apim-apps/blob/2534c2404beb9d59c742c77719da3554cd00fc1f/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx#L365) to become undefined after the security config dialog box is opened.

### Fix
Added a useEffect hook to ensures that securityInfo is reinitialized with the default values if the props change while the dialog box is open
