### PR TITLE
Removed the 'Create API with AI' card in the landing page when AI features are disabled 

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/index.jsx
@@ -155,7 +155,6 @@ const APILanding = () => {
                                             display: 'flex', 
                                             justifyContent: 'center', 
                                             width: '100%',
-
                                         }}
                                     >
                                         <DesignAssistantMenu />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/Landing/index.jsx
@@ -135,23 +135,32 @@ const APILanding = () => {
                                     }
                                     <AIAPIMenu icon={aiApiIcon} />
                                 </Grid>
-                                <Divider 
-                                    variant='middle' 
-                                    sx={{
-                                        backgroundColor: '#A0A5A3', 
-                                        height: 1,
-                                        width: '85%',
-                                        mt: '30px', 
-                                        mb: '10px', 
-                                        marginX: 'auto',
-                                    }}
-                                />
-                                <Grid
-                                    item
-                                    sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}
-                                >
-                                    <DesignAssistantMenu />
-                                </Grid>
+                                {settings.designAssistantEnabled && (
+                                    <Divider 
+                                        variant='middle' 
+                                        sx={{
+                                            backgroundColor: '#A0A5A3', 
+                                            height: 1,
+                                            width: '85%',
+                                            mt: '30px', 
+                                            mb: '10px', 
+                                            marginX: 'auto',
+                                        }}
+                                    />
+                                )}
+                                {settings.designAssistantEnabled && (
+                                    <Grid
+                                        item
+                                        sx={{ 
+                                            display: 'flex', 
+                                            justifyContent: 'center', 
+                                            width: '100%',
+
+                                        }}
+                                    >
+                                        <DesignAssistantMenu />
+                                    </Grid>
+                                )}
                             </Grid>
                         </Box>
                     </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/TopMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/TopMenu.jsx
@@ -31,6 +31,7 @@ import ButtonGroup from '@mui/material/ButtonGroup';
 import VerticalDivider from 'AppComponents/Shared/VerticalDivider';
 import { isRestricted } from 'AppData/AuthManager';
 import { app } from 'Settings';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import APICreateMenu from './APICreateMenu';
 
 const PREFIX = 'TopMenu';
@@ -122,7 +123,11 @@ function getTitleForArtifactType(props, count) {
 function TopMenu(props) {
     const {
         data, setListType, count, isAPIProduct, listType, showToggle, query,
-    } = props;   
+    } = props;
+
+    const { data: settings } = usePublisherSettings();
+    const designAssistantEnabled = settings?.designAssistantEnabled;
+      
     if (count > 0) {
         return (
             <Root className={classes.root}>
@@ -193,7 +198,7 @@ function TopMenu(props) {
                         </APICreateMenu>
                     )} 
                     {/* Button to Create API with AI */}
-                    {!query && !isAPIProduct && !isRestricted(['apim:api_create']) && (
+                    {!query && !isAPIProduct && !isRestricted(['apim:api_create']) && designAssistantEnabled && (
                         <Button
                             variant='contained'
                             color='primary'


### PR DESCRIPTION
Resolves: https://github.com/wso2/api-manager/issues/3753

With this fix the 'Create API with AI' button in the top menu also will be disabled when AI features are disabled. 