### PR TITLE
Fix: Disable Deploy Button for Pending API Revision Deployment Approval

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -557,6 +557,8 @@ export default function Environments() {
                 });
                 setVhosts(defaultVhosts);
                 setVhostsDeploy(defaultVhosts);
+                setSelectedEnvironment(selectedInternalGateways.length === 1 ?
+                    [selectedInternalGateways[0].name] : []);
             } else {
                 const external = settings.environment.filter((p) => !p.provider.toLowerCase().includes('wso2'));
                 const selectedExternalGateways = external.filter((p) =>
@@ -578,6 +580,8 @@ export default function Environments() {
                     });
                     setVhosts(defaultVhosts);
                     setVhostsDeploy(defaultVhosts);
+                    setSelectedEnvironment(selectedExternalGateways.length === 1 ?
+                        [selectedExternalGateways[0].name] : []);
                 } else {
                     setNoEnv(true);
                 }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -2802,6 +2802,12 @@ export default function Environments() {
                                 || (allRevisions && allRevisions.length === revisionCount && !extraRevisionToDelete)
                                 || isRestricted(['apim:api_create', 'apim:api_publish'], api)
                                 || (api.advertiseInfo && api.advertiseInfo.advertised)
+                                || (SelectedEnvironment.length === 1
+                                    && allEnvRevision && allEnvRevision.some(revision => {
+                                    return revision.deploymentInfo.some(deployment =>
+                                        deployment.name === SelectedEnvironment[0] &&
+                                        deployment.status === 'CREATED');
+                                }) )
                                 || isDeployButtonDisabled || isDeploying}
                         >
                             <FormattedMessage

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -557,8 +557,6 @@ export default function Environments() {
                 });
                 setVhosts(defaultVhosts);
                 setVhostsDeploy(defaultVhosts);
-                setSelectedEnvironment(selectedInternalGateways.length === 1 ?
-                    [selectedInternalGateways[0].name] : []);
             } else {
                 const external = settings.environment.filter((p) => !p.provider.toLowerCase().includes('wso2'));
                 const selectedExternalGateways = external.filter((p) =>
@@ -580,8 +578,6 @@ export default function Environments() {
                     });
                     setVhosts(defaultVhosts);
                     setVhostsDeploy(defaultVhosts);
-                    setSelectedEnvironment(selectedExternalGateways.length === 1 ?
-                        [selectedExternalGateways[0].name] : []);
                 } else {
                     setNoEnv(true);
                 }


### PR DESCRIPTION
### Purpose

Resolves: https://github.com/wso2/api-manager/issues/3681

Fixes the issue where the **Deploy** button remains enabled in **Deploy New Revision** when the previous deployment is still pending approval.

### Approach

Added a condition to check whether the selected environment's deployment is in created state. This fixes the `Deploy` button remaining enabled even when the gateway radio button is not selected.

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/7ecb0275-26a5-4197-ba09-d092e7beec7f" />
