### PR TITLE
Fix the issue of "Approve" Text not Visible in Publisher Portal Subscription Update Tasks List

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -2249,6 +2249,7 @@
   "Workflow.SubscriptionUpdate.help.link.one": "Create a subscription update request",
   "Workflow.SubscriptionUpdate.permission.denied.content": "You dont have enough permission to view Subscription Update - Approval Tasks. Please contact the site administrator.",
   "Workflow.SubscriptionUpdate.permission.denied.title": "Permission Denied",
+  "Workflow.SubscriptionUpdate.table.button.approve": "Approve",
   "Workflow.subscriptionupdate.updateStatus.has.errors": "Unable to complete subscription update approve/reject process.",
   "api.console.security.heading": "Security",
   "app.components.Shared.Banner.back": "Back",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Subscription/SubscriptionUpdate/SubscriptionUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Subscription/SubscriptionUpdate/SubscriptionUpdate.jsx
@@ -54,6 +54,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import WarningBase from 'AppComponents/Addons/Addons/WarningBase';
+import EastIcon from '@mui/icons-material/EastRounded';
 import { Dialog, DialogActions, DialogContent, DialogContentText, 
     DialogTitle, Alert as MUIAlert } from '@mui/material';
 
@@ -279,7 +280,7 @@ function ListLabels() {
             name: 'requestedTier',
             label: intl.formatMessage({
                 id: 'Workflow.SubscriptionCreation.table.header.Tier',
-                defaultMessage: 'Tier',
+                defaultMessage: 'Tier Transition',
             }),
             options: {
                 sort: false,
@@ -288,8 +289,12 @@ function ListLabels() {
                     const dataRow = data[tableMeta.rowIndex];
                     const { properties } = dataRow;
                     return (
-                        <div>
-                            {properties.currentTier} : {properties.requestedTier}
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                            {properties.currentTier} 
+                            <EastIcon 
+                                sx={{ mx: 1, fontSize: '1rem' }}
+                            />
+                            {properties.requestedTier}
                         </div>
                     );
                 },
@@ -347,6 +352,10 @@ function ListLabels() {
                                     disabled={isUpdating}
                                 >
                                     <CheckIcon />
+                                    <FormattedMessage
+                                        id='Workflow.SubscriptionUpdate.table.button.approve'
+                                        defaultMessage='Approve'
+                                    />
                                     {(isUpdating && buttonValue === 'APPROVED') && <CircularProgress size={15} /> }
                                 </Button>
                                 &nbsp;&nbsp;


### PR DESCRIPTION
The final UI will be as follows,

- Add the "Approve" text.
- Add the arrow icon for Tier transition

![Screenshot from 2025-03-03 17-46-17](https://github.com/user-attachments/assets/44a59eec-849f-4381-812e-bb2c17024859)

Resolves:https://github.com/wso2/api-manager/issues/3732