### PR TITLE
Improve AI API policy parameters to include endpointName

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelCard.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelCard.tsx
@@ -52,6 +52,13 @@ const ModelCard: FC<ModelCardProps> = ({
         const { name, value } = event.target;
         const updatedModel = { ...modelData, [name]: name === "weight" ? parseFloat(value) : value };
 
+        if (name === 'endpointId') {
+            const selectedEndpoint = endpointList.find((endpoint) => endpoint.id === value);
+            if (selectedEndpoint) {
+                updatedModel.endpointName = selectedEndpoint.name;
+            }
+        }
+
         onUpdate(updatedModel);
     }
 
@@ -69,7 +76,7 @@ const ModelCard: FC<ModelCardProps> = ({
                         <Select
                             labelId='model-label'
                             id='model'
-                            value={modelData.model || ""}
+                            value={model}
                             label='Model'
                             name='model'
                             onChange={(e: any) => handleChange(e)}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelFailover.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelFailover.tsx
@@ -82,6 +82,7 @@ const ModelFailover: FC<ModelFailoverProps> = ({
             targetModel: {
                 model: '',
                 endpointId: '',
+                endpointName: '',
             },
             fallbackModels: [],
         },
@@ -89,6 +90,7 @@ const ModelFailover: FC<ModelFailoverProps> = ({
             targetModel: {
                 model: '',
                 endpointId: '',
+                endpointName: '',
             },
             fallbackModels: [],
         },
@@ -191,6 +193,7 @@ const ModelFailover: FC<ModelFailoverProps> = ({
         const newModel: ModelData = {
             model: '',
             endpointId: '',
+            endpointName: '',
         };
 
         setConfig((prevConfig) => ({
@@ -271,6 +274,7 @@ const ModelFailover: FC<ModelFailoverProps> = ({
                     targetModel: {
                         model: '',
                         endpointId: '',
+                        endpointName: '',
                     },
                     fallbackModels: [],
                 },
@@ -287,6 +291,7 @@ const ModelFailover: FC<ModelFailoverProps> = ({
                     targetModel: {
                         model: '',
                         endpointId: '',
+                        endpointName: '',
                     },
                     fallbackModels: [],
                 },
@@ -521,8 +526,6 @@ const ModelFailover: FC<ModelFailoverProps> = ({
                             id='request-timeout'
                             label='Request Timeout (s)'
                             size='small'
-                            // helperText={getError(spec) === '' ? spec.description : getError(spec)}
-                            // error={getError(spec) !== ''}
                             variant='outlined'
                             name='requestTimeout'
                             type='number'
@@ -536,8 +539,6 @@ const ModelFailover: FC<ModelFailoverProps> = ({
                             id='suspend-duration'
                             label='Suspend Duration (s)'
                             size='small'
-                            // helperText={getError(spec) === '' ? spec.description : getError(spec)}
-                            // error={getError(spec) !== ''}
                             variant='outlined'
                             name='suspendDuration'
                             type='number'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelRoundRobin.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelRoundRobin.tsx
@@ -166,6 +166,7 @@ const ModelRoundRobin: FC<ModelRoundRobinProps> = ({
         const newModel: ModelData = {
             model: '',
             endpointId: '',
+            endpointName: '',
         };
 
         setConfig((prevConfig) => ({
@@ -426,8 +427,6 @@ const ModelRoundRobin: FC<ModelRoundRobinProps> = ({
                     label='Suspend Duration (s)'
                     size='small'
                     sx={{ mt: 2 }}
-                    // helperText={getError(spec) === '' ? spec.description : getError(spec)}
-                    // error={getError(spec) !== ''}
                     variant='outlined'
                     name='suspendDuration'
                     type='number'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelWeightedRoundRobin.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/ModelWeightedRoundRobin.tsx
@@ -169,6 +169,7 @@ const ModelWeightedRoundRobin: FC<ModelWeightedRoundRobinProps> = ({
         const newModel: ModelData = {
             model: '',
             endpointId: '',
+            endpointName: '',
         };
 
         setConfig((prevConfig) => ({
@@ -429,8 +430,6 @@ const ModelWeightedRoundRobin: FC<ModelWeightedRoundRobinProps> = ({
                     label='Suspend Duration (s)'
                     size='small'
                     sx={{ mt: 2 }}
-                    // helperText={getError(spec) === '' ? spec.description : getError(spec)}
-                    // error={getError(spec) !== ''}
                     variant='outlined'
                     name='suspendDuration'
                     type='number'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/Types.d.ts
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/CustomPolicies/Types.d.ts
@@ -27,5 +27,6 @@ export type Endpoint = {
 export type ModelData = {
     model: string;
     endpointId: string;
+    endpointName: string;
     weight?: number;
 }


### PR DESCRIPTION
### Purpose

With this PR, we improve the AI API policy parameter value to include the endpoint name. This is done to address the AI API import improvements reported via [1].

- Before:

```json
{
   "production":[
      {
         "model":"mistral-medium",
         "endpointId":"e910d0e5-d4d4-4a22-85dc-7e9e9228c721--PRODUCTION",
         "weight":100
      }
   ],
   "sandbox":[
      {
         "model":"mistral-small-latest",
         "endpointId":"d2b3c0e7-0a7f-4e63-8901-e5177dcc3f04",
         "weight":90
      },
      {
         "model":"mistral-medium",
         "endpointId":"d2b3c0e7-0a7f-4e63-8901-e5177dcc3f04",
         "weight":10
      }
   ],
   "suspendDuration":"20"
}
```

- After:

```json
{
   "production":[
      {
         "model":"mistral-medium",
         "endpointId":"e910d0e5-d4d4-4a22-85dc-7e9e9228c721--PRODUCTION",
         "endpointName":"Default Production Endpoint",
         "weight":100
      }
   ],
   "sandbox":[
      {
         "model":"mistral-small-latest",
         "endpointId":"d2b3c0e7-0a7f-4e63-8901-e5177dcc3f04",
         "endpointName":"Sand",
         "weight":90
      },
      {
         "model":"mistral-medium",
         "endpointId":"d2b3c0e7-0a7f-4e63-8901-e5177dcc3f04",
         "endpointName":"Sand",
         "weight":10
      }
   ],
   "suspendDuration":"20"
}
```

1.  https://github.com/wso2/api-manager/issues/3760