### PR TITLE
Support validating gov rulesets in API definition linter UI

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
@@ -91,7 +91,7 @@ export default function ProvideOpenAPI(props) {
     function lint(content) {
         // Validate and linting
         setIsLinting(true);
-        getLinterResultsFromContent(content, null, "HTTP").then((results)=>{
+        getLinterResultsFromContent(content, null, 'HTTP').then((results)=>{
             if (results) {
                 setLinterResults(results);
             } else {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
@@ -91,7 +91,7 @@ export default function ProvideOpenAPI(props) {
     function lint(content) {
         // Validate and linting
         setIsLinting(true);
-        getLinterResultsFromContent(content).then((results)=>{
+        getLinterResultsFromContent(content, null, "HTTP").then((results)=>{
             if (results) {
                 setLinterResults(results);
             } else {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -357,7 +357,7 @@ class APIDefinition extends React.Component {
             }
         }
 
-        getLinterResultsFromContent(modifiedContent).then((results) => {
+        getLinterResultsFromContent(modifiedContent, this.props.api.id).then((results) => {
             this.setState({ linterResults: results });
         });
     }
@@ -468,7 +468,7 @@ class APIDefinition extends React.Component {
      * */
     openEditor() {
         this.setState({ isImporting: false, linterSelectedLine: null });
-        getLinterResultsFromContent(this.state.swaggerModified).then((results) => {
+        getLinterResultsFromContent(this.state.swaggerModified, this.props.api.id).then((results) => {
             this.setState({ linterResults: results, openEditor: true });
         });
         
@@ -477,7 +477,7 @@ class APIDefinition extends React.Component {
     openEditorToImport(importingSwagger, linterSelectedLine) {
         this.setState({ isImporting: true, swaggerImporting: importingSwagger, 
             linterSelectedLine, isSwaggerUI: false });
-        getLinterResultsFromContent(importingSwagger).then((results) => {
+        getLinterResultsFromContent(importingSwagger, this.props.api.id).then((results) => {
             this.setState({ linterResults: results, openEditor: true });
         });
     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
@@ -19,6 +19,7 @@ import {
     ISpectralDiagnostic,
 } from '@stoplight/spectral-core';
 import *  as spectralFunc from "@stoplight/spectral-functions";
+import * as spectralFormats from "@stoplight/spectral-formats";
 import { oas } from '@stoplight/spectral-rulesets';
 import { green, orange } from '@mui/material/colors';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -41,19 +42,34 @@ Something to hint to a better way of doing it, like proposing a refactoring.
     Hint = 3
 */
 
-const spectralFunctions: { [key: string]: any} = {
+const spectralFunctions: { [key: string]: any } = {
     "alphabetical": spectralFunc.alphabetical,
     "casing": spectralFunc.casing,
     "defined": spectralFunc.defined,
     "enumeration": spectralFunc.enumeration,
     "falsy": spectralFunc.falsy,
     "length": spectralFunc.length,
-    "pattern":spectralFunc.pattern,
+    "pattern": spectralFunc.pattern,
     "truthy": spectralFunc.truthy,
     "undefined": spectralFunc.undefined,
     "unreferencedReusableObject": spectralFunc.unreferencedReusableObject,
     "xor": spectralFunc.xor,
     "schema": spectralFunc.schema,
+}
+
+const spectralFormatsList: { [key: string]: any } = {
+    "oas2": spectralFormats.oas2,
+    "oas3": spectralFormats.oas3,
+    "oas3_0": spectralFormats.oas3_0,
+    "oas3_1": spectralFormats.oas3_1,
+    "aas2": spectralFormats.aas2,
+    "aas2_0": spectralFormats.aas2_0,
+    "aas2_1": spectralFormats.aas2_1,
+    "aas2_2": spectralFormats.aas2_2,
+    "aas2_3": spectralFormats.aas2_3,
+    "aas2_4": spectralFormats.aas2_4,
+    "aas2_5": spectralFormats.aas2_5,
+    "aas2_6": spectralFormats.aas2_6,
 }
 
 export const spectralSeverityMap: { [key: number]: JSX.Element } = {
@@ -70,18 +86,19 @@ export const spectralSeverityNames: { [key: number]: string } = {
     3: "Hints"
 };
 
-export async function getLinterResultsFromContent(swagger: string|undefined) {
+export async function getLinterResultsFromContent(
+    swagger: string | undefined,
+    apiId?: string,
+    apiType?: string
+) {
     let validationResults: ISpectralDiagnostic[] = [];
-    
     if (swagger) {
         // Validate againt default ruleset by Spectral
         let defaultRuleSet = { extends: [oas], rules: {} };
         const linter = new Spectral();
         linter.setRuleset(defaultRuleSet);
-        
         try {
-            
-            await linter.run(swagger).then((results)=> {
+            await linter.run(swagger).then((results) => {
                 if (results) {
                     validationResults = validationResults.concat(results);
                 }
@@ -89,64 +106,82 @@ export async function getLinterResultsFromContent(swagger: string|undefined) {
         } catch (err) {
             console.error("OpenAPI linter default ruleset validation failed", err);
             Alert.error(
-            <FormattedMessage
-                id='Apis.Details.APIDefinition.Linting.Linting.default.ruleset.validation.failed'
-                defaultMessage='OpenAPI linter default ruleset validation failed'
-            />);
+                <FormattedMessage
+                    id='Apis.Details.APIDefinition.Linting.Linting.default.ruleset.validation.failed'
+                    defaultMessage='OpenAPI linter default ruleset validation failed'
+                />
+            );
         }
 
+        let params = {};
+        if (apiId) {
+            params = { apiId: apiId };
+        } else if (apiType) {
+            params = { apiType: apiType };
+        } else {
+            params = { apiType: "HTTP" };
+        }
 
-        // Validate againt custom ruleset defined in tenant config
-        let customRuleset:JSON = await API.getLinterCustomRules().then((LinterCustomRuleset: JSON) => {
-            return LinterCustomRuleset;
+        // Validate against custom rulesets defined in tenant config
+        const customRulesets: string[] = await API.getLinterCustomRules(params).then((LinterCustomRulesets: string[]) => {
+            return LinterCustomRulesets;
         }).catch((error: any) => {
-            console.log("Error retrieving custom linter rules", error);
+            console.log("Error retrieving custom linter rulesets", error);
             Alert.error(
-            <FormattedMessage
-                id='Apis.Details.APIDefinition.Linting.Linting.error.retrieving.custom.rules'
-                defaultMessage='Error retrieving custom linter rules'
-            />);
+                <FormattedMessage
+                    id='Apis.Details.APIDefinition.Linting.Linting.error.retrieving.custom.rules'
+                    defaultMessage='Error retrieving custom linter rulesets'
+                />);
+            return [];
         });
-        if (customRuleset) {
-            //Parse JSON to JS object to support spectral
-            const parsedCustomRuleset = JSON.parse(
-                JSON.stringify(customRuleset), 
-                function (key, value) {
-                    if (key === "function") {
-                        return spectralFunctions[value];
-                    } else {
-                        return value;
-                    }
-                }
-            );
 
-            linter.setRuleset(parsedCustomRuleset);
-            
-            try {
-                await linter.run(swagger).then((results)=> {
+        // Process each custom ruleset
+        if (customRulesets && customRulesets.length > 0) {
+            for (const rulesetString of customRulesets) {
+                try {
+                    // Parse JSON to JS object to support spectral
+                    const parsedCustomRuleset = JSON.parse(
+                        JSON.stringify(JSON.parse(rulesetString)),
+                        function (key, value) {
+                            if (key === "function") {
+                                return spectralFunctions[value];
+                            } else if (key === "formats") {
+                                return value.map((element: string) => {
+                                    return spectralFormatsList[element];
+                                });
+                            } else {
+                                return value;
+                            }
+                        }
+                    );
+
+                    linter.setRuleset(parsedCustomRuleset);
+
+                    const results = await linter.run(swagger);
                     if (results) {
                         validationResults = validationResults.concat(results);
                     }
-                });
-            } catch (error) {
-                if (error instanceof Error) {
-                    console.error("OpenAPI linter custom ruleset validation failed\n", error, error.stack);
+                } catch (error) {
+                    if (error instanceof Error) {
+                        console.error("OpenAPI linter custom ruleset validation failed\n", error, error.stack);
+                    }
+                    Alert.error(
+                        <FormattedMessage
+                            id='Apis.Details.APIDefinition.Linting.Linting.custom.ruleset.validation.failed'
+                            defaultMessage='OpenAPI linter custom ruleset validation failed'
+                        />
+                    );
                 }
-                Alert.error(
-                    <FormattedMessage
-                        id='Apis.Details.APIDefinition.Linting.Linting.custom.ruleset.validation.failed'
-                        defaultMessage='OpenAPI linter custom ruleset validation failed'
-                    />);
             }
         }
 
-        //Sort linter results order based of severity
-        validationResults = validationResults.sort( function compare(a, b) {
-            if (a.severity < b.severity){
-              return -1;
+        // Sort linter results order based on severity
+        validationResults = validationResults.sort(function compare(a, b) {
+            if (a.severity < b.severity) {
+                return -1;
             }
-            if (a.severity > b.severity){
-              return 1;
+            if (a.severity > b.severity) {
+                return 1;
             }
             return 0;
         });

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/Linting/Linting.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
  *
@@ -119,7 +118,7 @@ export async function getLinterResultsFromContent(
         } else if (apiType) {
             params = { apiType: apiType };
         } else {
-            params = { apiType: "HTTP" };
+            params = { apiType: 'HTTP' };
         }
 
         // Validate against custom rulesets defined in tenant config

--- a/portals/publisher/src/main/webapp/source/src/app/data/api.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/api.js
@@ -2370,12 +2370,12 @@ class API extends Resource {
     }
 
     /**
-     * Get settings of an API
+     * Get the list of custom rules (Custom linter rules in the tenant config and applicable governance rulesets)
      */
-     static getLinterCustomRules() {
+    static getLinterCustomRules(params) {
         const apiClient = new APIClientFactory().getAPIClient(Utils.getCurrentEnvironment(), Utils.CONST.API_CLIENT).client;
         const promisedLinterCustomeRules = apiClient.then(client => {
-            return client.apis['Linter Custom Rules'].getLinterCustomRules();
+            return client.apis['Linter Custom Rules'].getLinterCustomRules(params);
         });
         return promisedLinterCustomeRules.then(response => response.body);
     }


### PR DESCRIPTION
### Purpose
Validate the associated governance rulesets in the API definition linter, in addition to the default Spectral ruleset and the ruleset from the tenant config.

### Approach
- Updated the `getLinterResultsFromContent` function to handle multiple rulesets
- Note: This only supports the Spectral formats available in the currently used version of the `@stoplight/spectral-formats` dependency. Newer versions may support additional formats.

### Screenshots
- No UI Changes