### PR TITLE
Fix API Thumbnail Retrieval Issue in Publisher UI After Migration

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/ImageGenerator.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/ImageGenerator.jsx
@@ -113,6 +113,6 @@ ImageGenerator.propTypes = {
 };
 
 export default ((props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return <ImageGenerator {...props} theme={theme} />;
 });

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/ThumbnailView.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/ThumbnailView.jsx
@@ -606,6 +606,6 @@ ThumbnailView.propTypes = {
 };
 
 export default injectIntl(withAPI((props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return <ThumbnailView {...props} theme={theme} />;
 }));


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3762

This fix resolves an issue where API thumbnails were not displayed in the Publisher UI after migrating from APIM-3.2.0. The issue occurred because the theme was not retrieved properly, causing errors when rendering the API grid view. Updating the way useTheme() is assigned ensures correct theme retrieval and proper thumbnail display.