### PR TITLE
Fix UI issue where loading message shows a shadow on top

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/css/main.css
+++ b/portals/publisher/src/main/webapp/site/public/css/main.css
@@ -273,9 +273,9 @@ a {
 /* Progress bar styles */
 .progress-bar-striped {
   position: absolute;
-  top: 50%;
+  top: 45%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   background-color: #356eac52;
 }
 .progress-bar-striped > div {


### PR DESCRIPTION
This PR fixes the issue where a shadow appears at the top of the progress bar.

<img width="412" alt="image" src="https://github.com/user-attachments/assets/a6df3d86-4602-4eb1-ab86-81004d332647" />
