### PR TITLE
Disable buttons in policy and deployment pages for Observer user.

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -1979,7 +1979,7 @@ export default function Environments() {
                         margin='dense'
                         variant='outlined'
                         style={{ width: '50%' }}
-                        disabled={api.isRevision ||
+                        disabled={api.isRevision || isRestricted(['apim:api_create', 'apim:api_publish'], api) ||
                             (settings && settings.portalConfigurationOnlyModeEnabled) ||
                             !allRevisions || allRevisions.length === 0}
                     >
@@ -1991,6 +1991,7 @@ export default function Environments() {
                         className={classes.button2}
                         disabled={
                             api.isRevision || (settings && settings.portalConfigurationOnlyModeEnabled) ||
+                            isRestricted(['apim:api_create', 'apim:api_publish'], api) ||
                             !selectedRevision.some((r) => r.env === row.name && r.revision) ||
                             !selectedVhosts.some((v) => v.env === row.name && v.vhost) ||
                             (api.advertiseInfo && api.advertiseInfo.advertised) ||
@@ -2091,7 +2092,7 @@ export default function Environments() {
                     margin='dense'
                     variant='outlined'
                     style={{ width: '50%' }}
-                    disabled={api.isRevision ||
+                    disabled={api.isRevision || isRestricted(['apim:api_create', 'apim:api_publish'], api) ||
                         (settings && settings.portalConfigurationOnlyModeEnabled) ||
                         !filteredRevisions || filteredRevisions.length === 0}
                 >
@@ -2103,6 +2104,7 @@ export default function Environments() {
                     className={classes.button2}
                     disabled={
                         api.isRevision || (settings && settings.portalConfigurationOnlyModeEnabled) ||
+                        isRestricted(['apim:api_create', 'apim:api_publish'], api) ||
                         !selectedRevision.some((r) => r.env === row.name && r.revision) ||
                         !selectedVhosts.some((v) => v.env === row.name && v.vhost) ||
                         (api.advertiseInfo && api.advertiseInfo.advertised) ||

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyList.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyList.tsx
@@ -26,6 +26,7 @@ import Tab from '@mui/material/Tab';
 import CardContent from '@mui/material/CardContent';
 import { FormattedMessage } from 'react-intl';
 import Typography from '@mui/material/Typography';
+import { isRestricted } from 'AppData/AuthManager';
 import { AddCircle } from '@mui/icons-material';
 import { Button , Theme } from '@mui/material';
 import CONSTS from 'AppData/Constants';
@@ -108,7 +109,7 @@ const PolicyList: FC<PolicyListPorps> = ({apiPolicyList, commonPolicyList, fetch
                         {!isChoreoConnectEnabled && (
                             <Button
                                 onClick={handleAddPolicy}
-                                disabled={false}
+                                disabled={isRestricted(['apim:api_create', 'apim:api_publish'])}
                                 variant='outlined'
                                 color='primary'
                                 data-testid='add-new-api-specific-policy'


### PR DESCRIPTION
## Purpose
In the publisher portal, when logged in as an observer user, 

- Deploy button is clickable on the deployments table
- Add Operation policies button is visible 

This PR fixes those by restricting the button based on `'apim:api_create'` and `'apim:api_publish'` scopes.
Fixes: https://github.com/wso2/api-manager/issues/3605
