### PR TITLE
Add support for global connection timeout and proxy configurations

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -18,14 +18,14 @@ import React, { useState, useEffect, useContext } from 'react';
 import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import {
-    Divider, Grid, TextField, Typography, MenuItem,
+    Grid, TextField, Typography, MenuItem,
     Icon,
     ListItem,
     ListItemAvatar,
     ListItemText,
-    Switch,
-    FormGroup,
     FormControlLabel,
+    FormControl,
+    RadioGroup, Radio,
 } from '@mui/material';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Table from '@mui/material/Table';
@@ -191,6 +191,7 @@ function EndpointSecurity(props) {
             const {
                 type, username, password, grantType, tokenUrl, clientId, clientSecret, customParameters,
                 connectionTimeoutDuration, connectionRequestTimeoutDuration, socketTimeoutDuration, proxyConfigs,
+                connectionTimeoutConfigType, proxyConfigType,
             } = securityInfo;
             const secretPlaceholder = '******';
             tmpSecurity.type = type === null ? 'NONE' : type;
@@ -205,6 +206,8 @@ function EndpointSecurity(props) {
             tmpSecurity.connectionRequestTimeoutDuration = connectionRequestTimeoutDuration;
             tmpSecurity.socketTimeoutDuration = socketTimeoutDuration;
             tmpSecurity.proxyConfigs = proxyConfigs;
+            tmpSecurity.connectionTimeoutConfigType = connectionTimeoutConfigType;
+            tmpSecurity.proxyConfigType = proxyConfigType;
         }
         setEndpointSecurityInfo(tmpSecurity);
     }, [securityInfo]);
@@ -643,12 +646,15 @@ function EndpointSecurity(props) {
                 <>
                     {settings && settings.retryCallWithNewOAuthTokenEnabled && (
                         <>
-                            <Grid item xs={12}>
-                                <Divider />
-                            </Grid>
-
-                            <Grid item xs={12}>
-                                <Typography className={classes.subTitle}>
+                            <Grid
+                                item
+                                xs={12}
+                                style={{
+                                    paddingTop: '10px',
+                                    borderTop: '1px solid Gainsboro',
+                                }}
+                            >
+                                <Typography>
                                     <FormattedMessage
                                         id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.token.endpoint.
                                             connection.configurations'
@@ -657,250 +663,353 @@ function EndpointSecurity(props) {
                                 </Typography>
                             </Grid>
 
-                            <Grid item xs={6}>
-                                <TextField
-                                    required
-                                    fullWidth
-                                    className={classes.textField}
-                                    id='auth-connectionTimeoutDuration'
-                                    label={(
-                                        <FormattedMessage
-                                            id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.connection.
-                                                timeout.duration'
-                                            defaultMessage='Connection Timeout Duration (ms)'
+                            <Grid item xs={12}>
+                                <Typography className={classes.subTitle}>
+                                    <FormattedMessage
+                                        id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.token.endpoint.
+                                            connection.configurations.timeout.configurations'
+                                        defaultMessage='Timeout Configurations'
+                                    />
+                                </Typography>
+                                <FormControl>
+                                    <RadioGroup
+                                        row
+                                        name='connectionTimeoutConfigType'
+                                        value={endpointSecurityInfo.connectionTimeoutConfigType}
+                                        defaultValue={endpointSecurityInfo.proxyConfigType}
+                                        onChange={(event) => setEndpointSecurityInfo({
+                                            ...endpointSecurityInfo,
+                                            connectionTimeoutConfigType: event.target.value,
+                                        })}
+                                        onBlur={() => validateAndUpdateSecurityInfo('connectionTimeoutConfigType')}
+                                    >
+                                        <FormControlLabel
+                                            value='GLOBAL'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.connection.configurations.global'
+                                                    defaultMessage='Global'
+                                                />
+                                            )}
                                         />
-                                    )}
-                                    type='number'
-                                    margin='normal'
-                                    onChange={(event) => setEndpointSecurityInfo(
-                                        { ...endpointSecurityInfo, connectionTimeoutDuration: event.target.value },
-                                    )}
-                                    value={endpointSecurityInfo.connectionTimeoutDuration}
-                                    onBlur={() => validateAndUpdateSecurityInfo('connectionTimeoutDuration')}
-                                />
+                                        <FormControlLabel
+                                            value='ENDPOINT_SPECIFIC'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.connection.configurations.endpoint.specific'
+                                                    defaultMessage='Endpoint Specific'
+                                                />
+                                            )}
+                                        />
+                                        <FormControlLabel
+                                            value='NONE'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.connection.configurations.none'
+                                                    defaultMessage='None'
+                                                />
+                                            )}
+                                        />
+                                    </RadioGroup>
+                                </FormControl>
                             </Grid>
 
-                            <Grid item xs={6}>
-                                <TextField
-                                    required
-                                    fullWidth
-                                    className={classes.textField}
-                                    id='duration-connectionRequestTimeoutDuration'
-                                    label={(
-                                        <FormattedMessage
-                                            id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.connection.
-                                                request.timeout.duration'
-                                            defaultMessage='Connection Request Timeout Duration (ms)'
+                            {endpointSecurityInfo.connectionTimeoutConfigType === 'ENDPOINT_SPECIFIC' && (
+                                <>
+                                    <Grid item xs={6}>
+                                        <TextField
+                                            required
+                                            fullWidth
+                                            className={classes.textField}
+                                            id='auth-connectionTimeoutDuration'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .connection.timeout.duration'
+                                                    defaultMessage='Connection Timeout Duration (ms)'
+                                                />
+                                            )}
+                                            type='number'
+                                            margin='normal'
+                                            onChange={(event) => setEndpointSecurityInfo(
+                                                {
+                                                    ...endpointSecurityInfo,
+                                                    connectionTimeoutDuration: event.target
+                                                        .value,
+                                                },
+                                            )}
+                                            value={endpointSecurityInfo.connectionTimeoutDuration}
+                                            onBlur={() => validateAndUpdateSecurityInfo('connectionTimeoutDuration')}
                                         />
-                                    )}
-                                    type='number'
-                                    margin='normal'
-                                    onChange={(event) => setEndpointSecurityInfo(
-                                        { ...endpointSecurityInfo, connectionRequestTimeoutDuration: event.target.
-                                            value },
-                                    )}
-                                    value={endpointSecurityInfo.connectionRequestTimeoutDuration}
-                                    onBlur={() => validateAndUpdateSecurityInfo('connectionRequestTimeoutDuration')}
-                                />
-                            </Grid>
+                                    </Grid>
 
-                            <Grid item xs={6}>
-                                <TextField
-                                    required
-                                    fullWidth
-                                    className={classes.textField}
-                                    id='duration-socketTimeoutDuration'
-                                    label={(
-                                        <FormattedMessage
-                                            id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.socket.
-                                                timeout.duration'
-                                            defaultMessage='Socket Timeout Duration (ms)'
+                                    <Grid item xs={6}>
+                                        <TextField
+                                            required
+                                            fullWidth
+                                            className={classes.textField}
+                                            id='duration-connectionRequestTimeoutDuration'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .connection.request.timeout.duration'
+                                                    defaultMessage='Connection Request Timeout Duration (ms)'
+                                                />
+                                            )}
+                                            type='number'
+                                            margin='normal'
+                                            onChange={(event) => setEndpointSecurityInfo(
+                                                {
+                                                    ...endpointSecurityInfo,
+                                                    connectionRequestTimeoutDuration: event
+                                                        .target.value,
+                                                },
+                                            )}
+                                            value={endpointSecurityInfo.connectionRequestTimeoutDuration}
+                                            onBlur={() => validateAndUpdateSecurityInfo(
+                                                'connectionRequestTimeoutDuration',
+                                            )}
                                         />
-                                    )}
-                                    type='number'
-                                    margin='normal'
-                                    onChange={(event) => setEndpointSecurityInfo(
-                                        { ...endpointSecurityInfo, socketTimeoutDuration: event.target.value },
-                                    )}
-                                    value={endpointSecurityInfo.socketTimeoutDuration}
-                                    onBlur={() => validateAndUpdateSecurityInfo('socketTimeoutDuration')}
-                                />
+                                    </Grid>
+
+                                    <Grid item xs={6}>
+                                        <TextField
+                                            required
+                                            fullWidth
+                                            className={classes.textField}
+                                            id='duration-socketTimeoutDuration'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .socket.timeout.duration'
+                                                    defaultMessage='Socket Timeout Duration (ms)'
+                                                />
+                                            )}
+                                            type='number'
+                                            margin='normal'
+                                            onChange={(event) => setEndpointSecurityInfo(
+                                                { ...endpointSecurityInfo, socketTimeoutDuration: event.target.value },
+                                            )}
+                                            value={endpointSecurityInfo.socketTimeoutDuration}
+                                            onBlur={() => validateAndUpdateSecurityInfo('socketTimeoutDuration')}
+                                        />
+                                    </Grid>
+                                </>
+                            )}
+                            <Grid
+                                item
+                                xs={12}
+                                style={{
+                                    paddingTop: '10px',
+                                }}
+                            >
+                                <Typography className={classes.subTitle}>
+                                    <FormattedMessage
+                                        id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.token.endpoint
+                                        .connection.configurations.proxy.configurations'
+                                        defaultMessage='Proxy Configurations'
+                                    />
+                                </Typography>
+                                <FormControl>
+                                    <RadioGroup
+                                        row
+                                        name='proxyConfigType'
+                                        value={endpointSecurityInfo.proxyConfigType}
+                                        defaultValue={endpointSecurityInfo.proxyConfigType}
+                                        onChange={(event) => {
+                                            if (event.target.value === 'ENDPOINT_SPECIFIC') {
+                                                endpointSecurityInfo.proxyConfigs.proxyEnabled = true;
+                                            } else {
+                                                endpointSecurityInfo.proxyConfigs.proxyEnabled = false;
+                                            }
+                                            endpointSecurityInfo.proxyConfigType = event.target.value;
+                                            setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                            validateAndUpdateSecurityInfo('endpointSecurityInfo');
+                                        }}
+                                        onBlur={() => validateAndUpdateSecurityInfo('proxyConfigType')}
+                                    >
+                                        <FormControlLabel
+                                            value='GLOBAL'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.proxy.configurations.global'
+                                                    defaultMessage='Global'
+                                                />
+                                            )}
+                                        />
+                                        <FormControlLabel
+                                            value='ENDPOINT_SPECIFIC'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.proxy.configurations.endpoint.specific'
+                                                    defaultMessage='Endpoint Specific'
+                                                />
+                                            )}
+                                        />
+                                        <FormControlLabel
+                                            value='NONE'
+                                            control={<Radio />}
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .token.endpoint.proxy.configurations.none'
+                                                    defaultMessage='None'
+                                                />
+                                            )}
+                                        />
+                                    </RadioGroup>
+                                </FormControl>
                             </Grid>
+                            {endpointSecurityInfo.proxyConfigType === 'ENDPOINT_SPECIFIC' && (
+                                <>
+                                    <Grid
+                                        item
+                                        xs={6}
+                                        style={{}}
+                                    >
+                                        <TextField
+                                            disabled={isRestricted(['apim:api_create'], api)}
+                                            required
+                                            fullWidth
+                                            variant='outlined'
+                                            id='proxy-host'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .proxyHost.input'
+                                                    defaultMessage='Proxy Hostname'
+                                                />
+                                            )}
+                                            onChange={(event) => {
+                                                endpointSecurityInfo.proxyConfigs.proxyHost = event.target.value;
+                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                validateAndUpdateSecurityInfo('proxyConfigs');
+                                            }}
+                                            value={endpointSecurityInfo.proxyConfigs.proxyHost}
+                                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
+                                        />
+                                    </Grid>
+                                    <Grid
+                                        item
+                                        xs={6}
+                                        style={{}}
+                                    >
+                                        <TextField
+                                            disabled={isRestricted(['apim:api_create'], api)}
+                                            required
+                                            fullWidth
+                                            variant='outlined'
+                                            id='proxy-port'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .proxyPort.input'
+                                                    defaultMessage='Proxy Port'
+                                                />
+                                            )}
+                                            onChange={(event) => {
+                                                endpointSecurityInfo.proxyConfigs.proxyPort = event.target.value;
+                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                validateAndUpdateSecurityInfo('proxyConfigs');
+                                            }}
+                                            value={endpointSecurityInfo.proxyConfigs.proxyPort}
+                                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
+                                        />
+                                    </Grid>
+                                    <Grid
+                                        item
+                                        xs={6}
+                                        style={{}}
+                                    >
+                                        <TextField
+                                            disabled={isRestricted(['apim:api_create'], api)}
+                                            fullWidth
+                                            variant='outlined'
+                                            id='proxy-username'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .proxyUsername.input'
+                                                    defaultMessage='Proxy Username'
+                                                />
+                                            )}
+                                            onChange={(event) => {
+                                                endpointSecurityInfo.proxyConfigs.proxyUsername = event.target.value;
+                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                validateAndUpdateSecurityInfo('proxyConfigs');
+                                            }}
+                                            value={endpointSecurityInfo.proxyConfigs.proxyUsername}
+                                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
+                                        />
+                                    </Grid>
+                                    <Grid
+                                        item
+                                        xs={6}
+                                        style={{}}
+                                    >
+                                        <TextField
+                                            disabled={isRestricted(['apim:api_create'], api)}
+                                            fullWidth
+                                            variant='outlined'
+                                            id='proxy-password'
+                                            type='password'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .proxyPassword.input'
+                                                    defaultMessage='Proxy Password'
+                                                />
+                                            )}
+                                            onChange={(event) => {
+                                                endpointSecurityInfo.proxyConfigs.proxyPassword = event.target.value;
+                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                validateAndUpdateSecurityInfo('proxyConfigs');
+                                            }}
+                                            value={endpointSecurityInfo.proxyConfigs.proxyPassword}
+                                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
+                                        />
+                                    </Grid>
+                                    <Grid
+                                        item
+                                        xs={6}
+                                        style={{}}
+                                    >
+                                        <TextField
+                                            disabled={isRestricted(['apim:api_create'], api)}
+                                            required
+                                            fullWidth
+                                            variant='outlined'
+                                            id='proxy-protocol'
+                                            label={(
+                                                <FormattedMessage
+                                                    id='Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity
+                                                    .proxyProtocol.input'
+                                                    defaultMessage='Proxy Protocol'
+                                                />
+                                            )}
+                                            onChange={(event) => {
+                                                endpointSecurityInfo.proxyConfigs.proxyProtocol = event.target.value;
+                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                validateAndUpdateSecurityInfo('proxyConfigs');
+                                            }}
+                                            value={endpointSecurityInfo.proxyConfigs.proxyProtocol}
+                                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
+                                        />
+                                    </Grid>
+                                </>
+                            )}
                         </>
                     )}
-
-                    <Grid
-                        item
-                        xs={12}
-                        style={{
-                            paddingTop: '30px',
-                        }}
-                    />
-                    <Grid
-                        item
-                        xs={12}
-                        style={{
-                            paddingTop: '20px',
-                            borderTop: '1px solid Gainsboro',
-                        }}
-                    >
-                        <FormGroup row>
-                            <FormControlLabel
-                                control={(
-                                    <Switch
-                                        name='proxyEnabled'
-                                        onChange={(event) => {
-                                            endpointSecurityInfo.proxyConfigs.proxyEnabled = event.target.checked;
-                                            setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                            validateAndUpdateSecurityInfo('proxyEnabled');
-                                        }}
-                                        checked={endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                                    />
-                                )}
-                                label='Proxy Configurations'
-                            />
-
-                        </FormGroup>
-                    </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        style={{}}
-                    >
-                        <TextField
-                            disabled={isRestricted(['apim:api_create'], api)
-                                || !endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                            required
-                            fullWidth
-                            variant='outlined'
-                            id='proxy-host'
-                            label={(
-                                <FormattedMessage
-                                    id={'Apis.Details.Endpoints.GeneralConfiguration.'
-                                        + 'EndpointSecurity.proxyHost.input'}
-                                    defaultMessage='Proxy Hostname'
-                                />
-                            )}
-                            onChange={(event) => {
-                                endpointSecurityInfo.proxyConfigs.proxyHost = event.target.value;
-                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                validateAndUpdateSecurityInfo('proxyConfigs');
-                            }}
-                            value={endpointSecurityInfo.proxyConfigs.proxyHost}
-                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
-                        />
-                    </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        style={{}}
-                    >
-                        <TextField
-                            disabled={isRestricted(['apim:api_create'], api)
-                                || !endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                            required
-                            fullWidth
-                            variant='outlined'
-                            id='proxy-port'
-                            label={(
-                                <FormattedMessage
-                                    id={'Apis.Details.Endpoints.GeneralConfiguration.'
-                                        + 'EndpointSecurity.proxyPort.input'}
-                                    defaultMessage='Proxy Port'
-                                />
-                            )}
-                            onChange={(event) => {
-                                endpointSecurityInfo.proxyConfigs.proxyPort = event.target.value;
-                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                validateAndUpdateSecurityInfo('proxyConfigs');
-                            }}
-                            value={endpointSecurityInfo.proxyConfigs.proxyPort}
-                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
-                        />
-                    </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        style={{}}
-                    >
-                        <TextField
-                            disabled={isRestricted(['apim:api_create'], api)
-                                || !endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                            fullWidth
-                            variant='outlined'
-                            id='proxy-username'
-                            label={(
-                                <FormattedMessage
-                                    id={'Apis.Details.Endpoints.GeneralConfiguration.'
-                                        + 'EndpointSecurity.proxyUsername.input'}
-                                    defaultMessage='Proxy Username'
-                                />
-                            )}
-                            onChange={(event) => {
-                                endpointSecurityInfo.proxyConfigs.proxyUsername = event.target.value;
-                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                validateAndUpdateSecurityInfo('proxyConfigs');
-                            }}
-                            value={endpointSecurityInfo.proxyConfigs.proxyUsername}
-                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
-                        />
-                    </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        style={{}}
-                    >
-                        <TextField
-                            disabled={isRestricted(['apim:api_create'], api)
-                                || !endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                            fullWidth
-                            variant='outlined'
-                            id='proxy-password'
-                            type='password'
-                            label={(
-                                <FormattedMessage
-                                    id={'Apis.Details.Endpoints.GeneralConfiguration.'
-                                        + 'EndpointSecurity.proxyPassword.input'}
-                                    defaultMessage='Proxy Password'
-                                />
-                            )}
-                            onChange={(event) => {
-                                endpointSecurityInfo.proxyConfigs.proxyPassword = event.target.value;
-                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                validateAndUpdateSecurityInfo('proxyConfigs');
-                            }}
-                            value={endpointSecurityInfo.proxyConfigs.proxyPassword}
-                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
-                        />
-                    </Grid>
-                    <Grid
-                        item
-                        xs={6}
-                        style={{}}
-                    >
-                        <TextField
-                            disabled={isRestricted(['apim:api_create'], api)
-                                || !endpointSecurityInfo.proxyConfigs.proxyEnabled}
-                            required
-                            fullWidth
-                            variant='outlined'
-                            id='proxy-protocol'
-                            label={(
-                                <FormattedMessage
-                                    id={'Apis.Details.Endpoints.GeneralConfiguration.'
-                                        + 'EndpointSecurity.proxyProtocol.input'}
-                                    defaultMessage='Proxy Protocol'
-                                />
-                            )}
-                            onChange={(event) => {
-                                endpointSecurityInfo.proxyConfigs.proxyProtocol = event.target.value;
-                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                validateAndUpdateSecurityInfo('proxyConfigs');
-                            }}
-                            value={endpointSecurityInfo.proxyConfigs.proxyProtocol}
-                            onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
-                        />
-                    </Grid>
                     <Grid item xs={12}>
                         <ListItem
                             className={classes.listItem}

--- a/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
@@ -55,6 +55,8 @@ const CONSTS = {
         connectionTimeoutDuration: -1,
         connectionRequestTimeoutDuration: -1,
         socketTimeoutDuration: -1,
+        connectionTimeoutConfigType: 'GLOBAL',
+        proxyConfigType: 'GLOBAL',
         proxyConfigs: {
             proxyEnabled: '',
             proxyHost: '',


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3590

This pull request adds support for configuring connection timeouts and proxy settings at both global and endpoint levels. Additionally, connection timeouts and proxy configurations can be disabled at the endpoint level.

Related backend PR: https://github.com/wso2/carbon-apimgt/pull/13054