### PR TITLE
Fix treating the common parameters array as an operation

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -144,6 +144,14 @@ export default function Resources(props) {
                 setSelectedOperation({});
                 return Object.entries(newData).reduce((resourceAcc, [resourceKey, verbObj]) => {
                     const verbList = Object.entries(verbObj).reduce((verbListAcc, [verbKey, operation]) => {
+                        // Preserve the "parameters" array without modification
+                        if (verbKey === 'parameters') {
+                            const newVerbListAcc = { ...verbListAcc };
+                            newVerbListAcc[verbKey] = operation;
+                            return newVerbListAcc;
+                        }
+            
+                        // Update the "x-auth-type" field for each operation
                         const newOperation = { ...operation };
                         newOperation['x-auth-type'] = data.disable ? 'None' : 'Any';
                         const newVerbListAcc = { ...verbListAcc };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/Resources.jsx
@@ -146,21 +146,15 @@ export default function Resources(props) {
                     const verbList = Object.entries(verbObj).reduce((verbListAcc, [verbKey, operation]) => {
                         // Preserve the "parameters" array without modification
                         if (verbKey === 'parameters') {
-                            const newVerbListAcc = { ...verbListAcc };
-                            newVerbListAcc[verbKey] = operation;
-                            return newVerbListAcc;
+                            return { ...verbListAcc, parameters: operation };
                         }
             
                         // Update the "x-auth-type" field for each operation
-                        const newOperation = { ...operation };
-                        newOperation['x-auth-type'] = data.disable ? 'None' : 'Any';
-                        const newVerbListAcc = { ...verbListAcc };
-                        newVerbListAcc[verbKey] = newOperation;
-                        return newVerbListAcc;
+                        const newOperation = { ...operation, 'x-auth-type': data.disable ? 'None' : 'Any' };
+                        return { ...verbListAcc, [verbKey]: newOperation };
                     }, {});
-                    const newResourceListAcc = { ...resourceAcc };
-                    newResourceListAcc[resourceKey] = verbList;
-                    return newResourceListAcc;
+            
+                    return { ...resourceAcc, [resourceKey]: verbList };
                 }, {});
             case 'description':
             case 'summary':

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/OperationsSelector.jsx
@@ -59,7 +59,12 @@ export default function OperationsSelector(props) {
     let operationWithSecurityCount = 0;
 
     Object.entries(operations).forEach(([, verbObj]) => {
-        Object.entries(verbObj).forEach(([, operation]) => {
+        Object.entries(verbObj).forEach(([verbKey, operation]) => {
+            // Skip the "parameters" array
+            if (verbKey === 'parameters') {
+                return;
+            }
+    
             if (operation['x-auth-type'] && operation['x-auth-type'].toLowerCase() !== 'none') {
                 operationWithSecurityCount++;
             }


### PR DESCRIPTION
### Purpose

> - An error occurs when common `parameters` exist for a set of paths in the API definition. When enabling or disabling security, the `parameters` array is incorrectly considered as an `operation` in the current logic. 
> - Fix https://github.com/wso2/api-manager/issues/3824

### Approach

> - Add a check to exclude the `parameters` array from being processed as an `operation`.