### PR TITLE
Add configurable limit to display throttling policies in devportal

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Credentials/Wizard/CreateAppStep.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Credentials/Wizard/CreateAppStep.jsx
@@ -29,6 +29,7 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import Button from '@mui/material/Button';
 import InlineMessage from 'AppComponents/Shared/InlineMessage';
 import { ApiContext } from 'AppComponents/Apis/Details/ApiContext';
+import { app } from 'Settings';
 import ButtonPanel from './ButtonPanel';
 
 const PREFIX = 'CreateAppStep';
@@ -193,7 +194,7 @@ const createAppStep = (props) => {
     useEffect(() => {
         // Get all the tiers to populate the drop down.
         const api = new API();
-        const promiseTiers = api.getAllTiers('application');
+        const promiseTiers = api.getAllTiers('application', app.throttlingPolicyLimit);
         const promisedAttributes = api.getAllApplicationAttributes();
         const promisedKeyManagers = api.getKeyManagers();
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Overview.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Overview.jsx
@@ -50,6 +50,7 @@ import Progress from 'AppComponents/Shared/Progress';
 import API from 'AppData/api';
 import CONSTANTS from 'AppData/Constants';
 import View from 'AppComponents/Apis/Details/Documents/View';
+import Settings from 'Settings';
 import SolaceEndpoints from './SolaceEndpoints';
 import Environments from './Environments';
 import Comments from './Comments/Comments';
@@ -261,7 +262,7 @@ function Overview() {
 
     const getSubscriptionPolicies = () => {
         const restApi = new API();
-        return restApi.getAllTiers('subscription')
+        return restApi.getAllTiers('subscription', Settings.app.throttlingPolicyLimit)
             .then((response) => {
                 try {
                     // Filter policies base on async or not.

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/ApplicationFormHandler.jsx
@@ -32,6 +32,7 @@ import Application from 'AppData/Application';
 import { Link } from 'react-router-dom';
 import AuthManager from 'AppData/AuthManager';
 import Progress from 'AppComponents/Shared/Progress';
+import { app } from 'Settings';
 import ApplicationCreateBase from './Create/ApplicationCreateBase';
 
 const PREFIX = 'ApplicationFormHandler';
@@ -134,7 +135,7 @@ class ApplicationFormHandler extends React.Component {
         const promisedApplication = Application.get(applicationId);
         // Get all the tires to populate the drop down.
         const api = new API();
-        const promiseTiers = api.getAllTiers('application');
+        const promiseTiers = api.getAllTiers('application', app.throttlingPolicyLimit);
         const promisedAttributes = api.getAllApplicationAttributes();
         Promise.all([promisedApplication, promiseTiers, promisedAttributes])
             .then((response) => {
@@ -177,7 +178,7 @@ class ApplicationFormHandler extends React.Component {
     initApplicationCreateState = () => {
         // Get all the tiers to populate the drop down.
         const api = new API();
-        const promiseTiers = api.getAllTiers('application');
+        const promiseTiers = api.getAllTiers('application', app.throttlingPolicyLimit);
         const promisedAttributes = api.getAllApplicationAttributes();
         Promise.all([promiseTiers, promisedAttributes])
             .then((response) => {

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -254,10 +254,10 @@ export default class API extends Resource {
      * @param callback {function} Function which needs to be called upon success
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
-    getAllTiers(policyLevel, callback = null) {
+    getAllTiers(policyLevel, limit, callback = null) {
         const promiseGetAll = this.client.then((client) => {
             return client.apis['Throttling Policies'].get_throttling_policies__policyLevel_(
-                { policyLevel },
+                { policyLevel, limit },
                 this._requestMetaData(),
             );
         });


### PR DESCRIPTION
### Purpose
The Devportal currently displays only 25 application or subscription level policies, regardless of the total number available. Users cannot modify this default limit.

This fix allows users to configure this limit via settings.json. 

### Approach
Added a new property for throttling-policy limit in settings.json under the app object.
Updated the frontend API call to send this limit (if configured) with the request.
```
app: {
   throttlingPolicyLimit : 50,
}
```
Fix: https://github.com/wso2/api-manager/issues/3775