### PR TITLE
Add popover to display webhook callback URLs

### DIFF
--- a/portals/devportal/src/main/webapp/site/public/locales/en.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/en.json
@@ -444,7 +444,7 @@
   "Applications.Details.Subscriptions.Status": "Subscription Status",
   "Applications.Details.Subscriptions.action": "Action",
   "Applications.Details.Subscriptions.api.name": "API",
-  "Applications.Details.Subscriptions.api.webhooks": "Web Hooks",
+  "Applications.Details.Subscriptions.api.webhooks": "Webhooks",
   "Applications.Details.Subscriptions.api.webhooks.delivery.time.unavailable": "Delivery data unavailable",
   "Applications.Details.Subscriptions.api.webhooks.subscriptions.unavailable": "No Webhook subscriptions available at this time.",
   "Applications.Details.Subscriptions.business.plan.updated": "Business Plan updated successfully!",

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/WebHookDetails.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/WebHookDetails.jsx
@@ -18,7 +18,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
-import { matchPath } from 'react-router';
 import Typography from '@mui/material/Typography';
 import { FormattedMessage, useIntl } from 'react-intl';
 import List from '@mui/material/List';
@@ -100,7 +99,7 @@ const Root = styled('div')((
     },
 
     [`& .${classes.listWrapper}`]: {
-        width: '50%',
+        width: '100%',
     },
 
     [`& .${classes.subscriptionRow}`]: {
@@ -129,16 +128,8 @@ dayjs.extend(relativeTime);
  * @returns {JSX} jsx output
  */
 export default function WebHookDetails(props) {
-    const { location: { pathname } } = props;
+    const { apiId, applicationId } = props;
     const intl = useIntl();
-    const match = matchPath(pathname, {
-        path: '/applications/:applicationId/webhooks/:apiId',
-        exact: true,
-        strict: false,
-    });
-    const { applicationId } = props.match.params;
-    const { apiId } = match.params;
-
     const [subscribedTopics, setSubscribedTopics] = useState('');
 
     const getLogoForDeliveryStatus = (subscription) => {
@@ -173,7 +164,7 @@ export default function WebHookDetails(props) {
                 <Typography variant='h5' className={classes.keyTitle}>
                     <FormattedMessage
                         id='Applications.Details.Subscriptions.api.webhooks'
-                        defaultMessage='Web Hooks'
+                        defaultMessage='Webhooks'
                     />
                 </Typography>
             </div>
@@ -187,7 +178,7 @@ export default function WebHookDetails(props) {
                         />
                     </Typography>
                 )}
-                {Object.keys(subscribedTopics).map((key) => (
+                {Object.keys(subscribedTopics).map((key, keyIndex) => (
                     <>
                         <ListItem className={classes.SubscriptionHeader}>
                             <ListItemText primary={key} />
@@ -233,7 +224,9 @@ export default function WebHookDetails(props) {
                                 <Divider component='li' />
                             </Grid>
                         ))}
-                        <Divider component='li' />
+                        {(keyIndex !== Object.keys(subscribedTopics).length - 1) && (
+                            <Divider component='li' sx={{ padding: '5px' }} />
+                        )}
                     </>
                 ))}
             </List>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/index.jsx
@@ -41,7 +41,6 @@ import Paper from '@mui/material/Paper';
 import Subscriptions from './Subscriptions';
 import InfoBar from './InfoBar';
 import Overview from './Overview';
-import WebHookDetails from './WebHookDetails';
 
 const PREFIX = 'index';
 
@@ -474,10 +473,6 @@ class Details extends Component {
                             <Route
                                 path='/applications/:applicationId/overview'
                                 component={Overview}
-                            />
-                            <Route
-                                path='/applications/:applicationId/webhooks/:apiId'
-                                component={WebHookDetails}
                             />
                             <Route
                                 path='/applications/:applicationId/productionkeys/oauth'


### PR DESCRIPTION
## Purpose
> After subscribing to a WebSub/WebHook API with a specific topic, the subscription (callback URL) is not displayed in the Developer Portal.
Related Issue: https://github.com/wso2/api-manager/issues/3850

## Goals
> Display the callback URLs of the specific topic in the subscriptions page.

## Approach
> Add a view callback URLs link in the API column for Webhook APIs in the API subscriptions page. 
Trigger a popover to display the callback URLs for each subscribed topic from clicking this link.

<img width="1218" alt="Screenshot 2025-04-07 at 23 13 10" src="https://github.com/user-attachments/assets/076bfe38-158e-4323-b30b-81098ffb3699" />