### PR TITLE
Support secret custom params in endpoint security config

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -896,6 +896,7 @@
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.input.parameter.value": "Parameter Value",
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.label.parameter.name": "Parameter Name",
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.label.parameter.value": "Parameter Value",
+  "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.mark.as.secret": "Mark as Secret",
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.no.clientId.error": "Client ID should not be empty",
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.no.clientSecret.error": "Client Secret should not be empty",
   "Apis.Details.Endpoints.GeneralConfiguration.EndpointSecurity.no.password.error": "Password should not be empty",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -680,18 +680,6 @@ function EndpointOverview(props) {
         });
     };
 
-    /**
-     * Method to handle the endpoint security changes.
-     * @param {string} value The value
-     * @param {string} type The security property that is being modified.
-     * */
-    const handleEndpointSecurityChange = (value, type) => {
-        endpointsDispatcher({
-            action: 'endpointSecurity',
-            value: { ...endpointSecurityInfo, [type]: value },
-        });
-    };
-
     const saveEndpointSecurityConfig = (endpointSecurityObj, enType) => {
         const { type } = endpointSecurityObj;
         let newEndpointSecurityObj = endpointSecurityObj;
@@ -1391,7 +1379,6 @@ function EndpointOverview(props) {
                                     securityInfo={endpointSecurityInfo
                                         && (endpointSecurityInfo.production
                                             ? endpointSecurityInfo.production : endpointSecurityInfo)}
-                                    onChangeEndpointAuth={handleEndpointSecurityChange}
                                     saveEndpointSecurityConfig={saveEndpointSecurityConfig}
                                     closeEndpointSecurityConfig={closeEndpointSecurityConfig}
                                     isProduction
@@ -1402,7 +1389,6 @@ function EndpointOverview(props) {
                                     securityInfo={endpointSecurityInfo
                                         && (endpointSecurityInfo.sandbox
                                             ? endpointSecurityInfo.sandbox : endpointSecurityInfo)}
-                                    onChangeEndpointAuth={handleEndpointSecurityChange}
                                     saveEndpointSecurityConfig={saveEndpointSecurityConfig}
                                     closeEndpointSecurityConfig={closeEndpointSecurityConfig}
                                     endpointSecurityTypes={endpointSecurityTypes}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EditableParameterRow.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EditableParameterRow.jsx
@@ -22,6 +22,9 @@ import TextField from '@mui/material/TextField';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import CancelIcon from '@mui/icons-material/Cancel';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import IconButton from '@mui/material/IconButton';
@@ -29,13 +32,18 @@ import IconButton from '@mui/material/IconButton';
 const PREFIX = 'EditableParameterRow';
 
 const classes = {
-    link: `${PREFIX}-link`
+    link: `${PREFIX}-link`,
+    actionCell: `${PREFIX}-actionCell`,
 };
 
 const StyledTableRow = styled(TableRow)(() => ({
     [`& .${classes.link}`]: {
         cursor: 'pointer',
-    }
+    },
+    [`& .${classes.actionCell}`]: {
+        paddingRight: 0,
+        paddingLeft: 0,
+    },
 }));
 
 /**
@@ -45,13 +53,14 @@ const StyledTableRow = styled(TableRow)(() => ({
  */
 function EditableParameterRow(props) {
     const {
-        oldName, oldValue,
+        oldName, oldValue, isSecret,
         handleUpdateList, handleDelete,
         intl, isRestricted, api,
     } = props;
     const [newName, setName] = useState(oldName);
     const [newValue, setValue] = useState(oldValue);
     const [editMode, setEditMode] = useState(false);
+    const [showValue, setShowValue] = useState(false);
 
     /**
      * Set edit mode
@@ -70,12 +79,39 @@ function EditableParameterRow(props) {
     };
 
     /**
-     * Update value field
+     * Update value field considering masking for secret parameters
      * @param {*} event value entered for the value field
      */
     const handleValueChange = (event) => {
-        const { value } = event.target;
+        let { value } = event.target;
+
+        // Special handling for secret parameters
+        if (isSecret) {
+            if (value === '******') {
+                // User hasn't changed the masked value, keep empty to preserve original
+                value = '';
+            } else if (value.includes('******')) {
+                // User is editing part of the masked value, remove mask
+                value = value.replace('******', '');
+            }
+
+            if (value === '') {
+                // If the value is empty, hide the stars
+                setShowValue(false);
+            }
+        }
+
         setValue(value);
+    };
+
+    /**
+     * Get display value considering masking for secret parameters
+     */
+    const getDisplayValue = () => {
+        if (isSecret) {
+            return oldValue ? oldValue.replace(/./g, '•') : '••••••';
+        }
+        return oldValue;
     };
 
     /**
@@ -86,7 +122,7 @@ function EditableParameterRow(props) {
     const validateEmpty = (itemValue) => {
         if (itemValue === null) {
             return false;
-        } else if (itemValue === '') {
+        } else if (itemValue === '' && !isSecret) {
             return true;
         } else {
             return false;
@@ -98,8 +134,18 @@ function EditableParameterRow(props) {
      */
     const saveRow = () => {
         const oldRow = { oldName, oldValue };
-        const newRow = { newName: newName || oldName, newValue: newValue || oldValue };
-        handleUpdateList(oldRow, newRow);
+        let updatedValue = newValue;
+        
+        // For secret parameters, preserve empty value if masked value wasn't changed
+        if (isSecret && updatedValue === '') {
+            updatedValue = oldValue; // Keep original value if user didn't change masked value
+        }
+
+        const newRow = {
+            newName: newName || oldName,
+            newValue: updatedValue || oldValue,
+        };
+        handleUpdateList(oldRow, newRow, isSecret);
         setEditMode(false);
     };
 
@@ -108,6 +154,16 @@ function EditableParameterRow(props) {
      */
     const deleteRow = () => {
         handleDelete(oldName);
+    };
+
+    /**
+     * Cancel editing and reset values
+     */
+    const cancelEdit = () => {
+        setName(oldName);
+        setValue(oldValue);
+        setEditMode(false);
+        setShowValue(false);
     };
 
     /**
@@ -160,16 +216,33 @@ function EditableParameterRow(props) {
                         margin='normal'
                         variant='outlined'
                         className={classes.addProperty}
-                        value={newValue}
+                        value={newValue === '' && isSecret ? '******' : newValue}
                         onChange={handleValueChange}
                         onKeyDown={handleKeyDown}
                         error={validateEmpty(newValue)}
+                        type={isSecret && !showValue ? 'password' : 'text'}
+                        InputProps={isSecret ? {
+                            endAdornment: (
+                                <IconButton
+                                    onClick={() => {
+                                        // Only allow toggling if value is not masked
+                                        if (newValue !== '' && newValue !== '******') {
+                                            setShowValue(!showValue);
+                                        }
+                                    }}
+                                    edge='end'
+                                    size='small'
+                                >
+                                    {showValue ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                                </IconButton>
+                            ),
+                        } : undefined}
                     />
                 </TableCell>
             ) : (
-                <TableCell>{oldValue}</TableCell>
+                <TableCell>{getDisplayValue()}</TableCell>
             )}
-            <TableCell align='right'>
+            <TableCell align='right' className={classes.actionCell}>
                 {editMode ? (
                     <>
                         <IconButton
@@ -182,29 +255,40 @@ function EditableParameterRow(props) {
                             size='large'>
                             <SaveIcon className={classes.buttonIcon} />
                         </IconButton>
+                        <IconButton
+                            className={classes.link}
+                            aria-label='cancel'
+                            onClick={cancelEdit}
+                            onKeyDown={() => { }}
+                            color='inherit'
+                        >
+                            <CancelIcon className={classes.buttonIcon} />
+                        </IconButton>
                     </>
                 ) : (
-                    <IconButton
-                        className={classes.link}
-                        aria-label='edit'
-                        onClick={updateEditMode}
-                        onKeyDown={() => {}}
-                        color='inherit'
-                        disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
-                        size='large'>
-                        <EditIcon className={classes.buttonIcon} />
-                    </IconButton>
+                    <>
+                        <IconButton
+                            className={classes.link}
+                            aria-label='edit'
+                            onClick={updateEditMode}
+                            onKeyDown={() => {}}
+                            color='inherit'
+                            disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
+                            size='large'>
+                            <EditIcon className={classes.buttonIcon} />
+                        </IconButton>
+                        <IconButton
+                            className={classes.link}
+                            aria-label='remove'
+                            onClick={deleteRow}
+                            onKeyDown={() => {}}
+                            color='inherit'
+                            disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
+                            size='large'>
+                            <DeleteForeverIcon className={classes.buttonIcon} />
+                        </IconButton>
+                    </>
                 )}
-                <IconButton
-                    className={classes.link}
-                    aria-label='remove'
-                    onClick={deleteRow}
-                    onKeyDown={() => {}}
-                    color='inherit'
-                    disabled={isRestricted(['apim:api_create', 'apim:api_publish'], api)}
-                    size='large'>
-                    <DeleteForeverIcon className={classes.buttonIcon} />
-                </IconButton>
             </TableCell>
         </StyledTableRow>
     );
@@ -216,6 +300,11 @@ EditableParameterRow.propTypes = {
     classes: PropTypes.shape({}).isRequired,
     handleUpdateList: PropTypes.func.isRequired,
     handleDelete: PropTypes.func.isRequired,
+    isSecret: PropTypes.bool,
+};
+
+EditableParameterRow.defaultProps = {
+    isSecret: false,
 };
 
 export default injectIntl(EditableParameterRow);


### PR DESCRIPTION
## Purpose
Fixing https://github.com/wso2/api-manager/issues/3842

## Goals
Allowing users to add secret custom parameters to the endpoint security (OAuth) of an API

## Approach
Added the checkbox option to mark the parameter as a secret
Implemented the secret parameter hiding logic

## Samples

https://github.com/user-attachments/assets/9ac74a7d-098e-45a4-8e0f-6b71e8a5ad05

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/dc32118f-e3fa-423d-95c7-a57c0fa15df8" />


## Related PRs
N/A

