### PR TITLE
Restrict OAuth key deletion to application owner only

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -914,7 +914,7 @@ class TokenManager extends React.Component {
                                                 />
                                             </Box>
                                         )}
-                                        {(keymanager.enableTokenGeneration && keys.get(selectedTab))
+                                        {(keymanager.enableTokenGeneration && keys.get(selectedTab)) && isUserOwner
                                             && (
                                                 mode !== 'MAPPED'
                                                     ? (


### PR DESCRIPTION
## Purpose
Enhance the Developer Portal UI by restricting access to the **"REMOVE KEYS"** button in the **Application Keys** section, allowing only the **application owner** to remove OAuth keys.

## Background
In WSO2 API Manager's Developer Portal, applications can be **shared among users via groups**. However, **only the application owner** has full permissions to:
- Edit application details
- Generate or regenerate keys
- Update OAuth configurations

This change ensures that **removing keys** is also restricted to the **application owner**, aligning with the existing ownership-based permission model.

## Goals
- Prevent non-owner users (who access applications via group sharing) from seeing or using the **"REMOVE KEYS"** button.
- Ensure only the application owner has full control over key lifecycle operations.

## Approach
- Updated Developer Portal UI logic to conditionally render the **"REMOVE KEYS"** button only when the logged-in user is the **owner** of the application.
- This complements backend enforcement, which already restricts key deletion to the owner.

## User Stories
- ✅ As an application owner, I can see and use the **"REMOVE KEYS"** button in the Developer Portal to manage my keys.
- 🚫 As a user who has access to the application via group sharing, I cannot see or remove OAuth keys for applications I do not own.

## Release Note
In the **WSO2 API Manager Developer Portal**, only **application owners** can now see and use the **"REMOVE KEYS"** button under the **Application Keys** section. This change aligns with the existing permissions model for shared applications.

## Documentation
N/A – UI-only change, no impact on published documentation.

## Related PRs
- **Backend**: Restricts OAuth key deletion to the application owner – [wso2/carbon-apimgt#13133](https://github.com/wso2/carbon-apimgt/pull/13133)

## Related Issue
- [wso2/api-manager/issues#3919](https://github.com/wso2/api-manager/issues/3919)