### PR TITLE
Allow third-party KM to rename as resident key manager

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -331,7 +331,8 @@ function AddEditKeyManager(props) {
                     } else if (result.body.tokenType === 'BOTH') {
                         setEnableExchangeToken(true);
                     }
-                    if (result.body.name === residentKeyManagerName) {
+                    if (result.body.name === residentKeyManagerName && (result.body.type === 'default' || result.body
+                        .type === 'WSO2-IS')) {
                         setIsResidentKeyManager(true);
                     }
                 }
@@ -369,7 +370,7 @@ function AddEditKeyManager(props) {
                         id: 'KeyManagers.AddEditKeyManager.is.empty.error',
                         defaultMessage: ' is empty',
                     })}`;
-                } else if (fieldValue !== '' && /\s/g.test(fieldValue)) {
+                } else if (fieldValue !== '' && fieldValue !== residentKeyManagerName && /\s/g.test(fieldValue)) {
                     error = intl.formatMessage({
                         id: 'KeyManagers.AddEditKeyManager.space.error',
                         defaultMessage: 'Key Manager name contains white spaces.',


### PR DESCRIPTION
## Purpose
> When user migrating from IS as a resident KM to third-party KM admin portal not using third-party KM template for UI. This fix will allow third-party KM to rename as "Resident Key Manager" and use third-party KM template at same time. 
Related issues - https://github.com/wso2/api-manager/issues/3909

## Approach
> Change the logic to identify resident key manager using KM type. 