### PR TITLE
Show document creation error alerts in all environments

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Create.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Create.jsx
@@ -130,13 +130,10 @@ function Create(props) {
                             history.push(listingPath);
                         })
                         .catch((error) => {
-                            if (process.env.NODE_ENV !== 'production') {
-                                console.log(error);
-                                Alert.error(intl.formatMessage({
-                                    id: 'Apis.Details.Documents.Create.markdown.editor.upload.error',
-                                    defaultMessage: 'Error uploading the file',
-                                }));
-                            }
+                            Alert.error(intl.formatMessage({
+                                id: 'Apis.Details.Documents.Create.markdown.editor.upload.error',
+                                defaultMessage: 'Error uploading the file',
+                            }));
                         });
                 } else {
                     Alert.info(`${doc.body.name} ${intl.formatMessage({
@@ -147,13 +144,10 @@ function Create(props) {
                 }
             })
             .catch((error) => {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(error);
-                    Alert.error(intl.formatMessage({
-                        id: 'Apis.Details.Documents.Create.markdown.editor.add.error',
-                        defaultMessage: 'Error adding the document',
-                    }));
-                }
+                Alert.error(intl.formatMessage({
+                    id: 'Apis.Details.Documents.Create.markdown.editor.add.error',
+                    defaultMessage: 'Error adding the document',
+                }));
             });
     };
     return (

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Edit.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Documents/Edit.jsx
@@ -105,13 +105,10 @@ function Edit(props) {
                             toggleOpen();
                         })
                         .catch((error) => {
-                            if (process.env.NODE_ENV !== 'production') {
-                                console.log(error);
-                                Alert.error(intl.formatMessage({
-                                    id: 'Apis.Details.Documents.Edit.markdown.editor.upload.error.message',
-                                    defaultMessage: 'Error uploading the file.',
-                                }));
-                            }
+                            Alert.error(intl.formatMessage({
+                                id: 'Apis.Details.Documents.Edit.markdown.editor.upload.error.message',
+                                defaultMessage: 'Error uploading the file.',
+                            }));
                         });
                 } else {
                     Alert.info(`${name} ${intl.formatMessage({
@@ -123,13 +120,10 @@ function Edit(props) {
                 }
             })
             .catch((error) => {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(error);
-                    Alert.error(intl.formatMessage({
-                        id: 'Apis.Details.Documents.Edit.markdown.editor.update.error.message',
-                        defaultMessage: 'Error adding the document',
-                    }));
-                }
+                Alert.error(intl.formatMessage({
+                    id: 'Apis.Details.Documents.Edit.markdown.editor.update.error.message',
+                    defaultMessage: 'Error adding the document',
+                }));
             });
     };
 


### PR DESCRIPTION
## Description

This PR ensures that file upload errors in API Documents are always visible to the user, regardless of the environment. Currently it's set to not show in production environments. Hence, we need to $subject, which will improve visibility and user experience by informing users of document creation failures and file upload failures.

## Approach
Removed the conditional check for process.env.NODE_ENV !== 'production'. 
This change is applied to both document creation and editing flows ensuring both flows are fixed and `alerts` appear in each case.

## Related Issue
- https://github.com/wso2/api-manager/issues/3947