### PR TITLE
Fix version mismatch issue in attached policy view/edit drawer

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/AttachedPolicyForm/General.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/AttachedPolicyForm/General.tsx
@@ -595,6 +595,7 @@ const General: FC<GeneralProps> = ({
                             color='primary'
                             onClick={handleDrawerClose}
                             className={classes.btn}
+                            data-testid='policy-attached-details-cancel'
                         >
                             <FormattedMessage
                                 id='Apis.Details.Policies.AttachedPolicyForm.General.cancel'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyConfigurationEditDrawer.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/PolicyConfigurationEditDrawer.tsx
@@ -91,7 +91,9 @@ const PolicyConfigurationEditDrawer: FC<PolicyConfigurationEditDrawerProps> = ({
         (async () => {
             if (policyObj) {
                 let policySpecVal = allPolicies?.find(
-                    (policy: PolicySpec) => policy.name === policyObj.name,
+                    (policy: PolicySpec) =>
+                        policy.name === policyObj.name &&
+                        policy.version === policyObj.version,
                 );
 
                 // If this policy is a deleted common policy we need to do an API call to get the policy specification

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/AttachedPolicyCard.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/AttachedPolicyCard.tsx
@@ -136,6 +136,7 @@ const AttachedPolicyCardShared: FC<AttachedPolicyCardSharedProps> = ({
                     {...listeners}
                     onClick={handleDrawerOpen}
                     onKeyDown={handleDrawerOpen}
+                    data-testid={`attached-policy-card-${policyObj.name}`}
                 >
                     <Tooltip
                         key={policyObj.id}
@@ -206,6 +207,7 @@ const AttachedPolicyCardShared: FC<AttachedPolicyCardSharedProps> = ({
                     {...listeners}
                     onClick={handleDrawerOpen}
                     onKeyDown={handleDrawerOpen}
+                    data-testid={`attached-policy-card-${policyObj.name}`}
                 >
                     <Tooltip
                         key={policyObj.id}

--- a/tests/cypress/integration/publisher/017-api-policies/01-api-specific-policy.spec.js
+++ b/tests/cypress/integration/publisher/017-api-policies/01-api-specific-policy.spec.js
@@ -67,6 +67,98 @@ describe("Common Policies", () => {
             cy.get('[data-testid="download-policy-file"]').click();
             cy.get('[data-testid="done-view-policy-file"]').click();
 
+            // Drag and drop the policy to attach it
+            const dataTransfer = new DataTransfer();
+            cy.contains('API Specific Policy Sample', { timeout: Cypress.config().largeTimeout }).trigger('dragstart', {
+                dataTransfer
+            });
+            cy.get('#operation-level-tabpanel').contains('Drag and drop policies here').trigger('drop', {
+                dataTransfer
+            });
+
+            // Verify the policy is attached and configure attributes
+            cy.get('#sampleAttribute').type('test value for sample attribute');
+            cy.get('[data-testid="policy-attached-details-save"]').click();
+            cy.get('[data-testid="custom-select-save-button"]').scrollIntoView().click();
+
+            // Verify attached policy details
+            cy.get('[data-testid="drop-policy-zone-request"]')
+              .get('[data-testid="attached-policy-card-APISpecificPolicySample"]')
+              .click({ force: true });
+            cy.get('#sampleAttribute').should('have.value', 'test value for sample attribute');
+            cy.get('[data-testid="policy-attached-details-cancel"]').click();
+
+            // delete the policy . get button with aria-label="delete attached policy"
+            cy.get('[data-testid="attached-policy-card-APISpecificPolicySample"]')
+              .get('[aria-label="delete attached policy"]')
+              .click();
+            cy.get('[data-testid="custom-select-save-button"]').scrollIntoView().click();
+
+            // Create Version 2 of the same policy
+            cy.get('[data-testid="add-new-api-specific-policy"]').click();
+            cy.get('#name').type('API Specific Policy Sample');
+            cy.get('#version').type('2');
+            cy.get('input[name="description"]').type('Enhanced API specific policy description version 2');
+            cy.get('#fault-select-check-box').uncheck()
+
+            // Upload policy file for version 2
+            cy.get('#upload-policy-file-for-policy').then(function () {
+                const filepath = `api_artifacts/samplePolicyTemplate.j2`
+                cy.get('input[type="file"]').attachFile(filepath)
+            });
+
+            // Add different attributes for version 2
+            cy.get('#add-policy-attributes-btn').click();
+            cy.get('[data-testid="add-policy-attribute-name-btn"]').type('enhancedAttribute');
+            cy.get('[data-testid="add-policy-attribute-display-name-btn"]').type('Enhanced Attribute V2');
+            cy.get('#attribute-require-btn').click();
+
+            // Add second attribute for version 2
+            cy.get('#add-policy-attributes-btn').click();
+            cy.get('[data-testid="add-policy-attribute-name-btn"]').eq(1).type('optionalAttribute');
+            cy.get('[data-testid="add-policy-attribute-display-name-btn"]').eq(1).type('Optional Attribute V2');
+
+            // Save API specific policy version 2
+            cy.get('[data-testid="policy-create-save-btn"]').click();
+            cy.wait(2000);
+
+            // View API specific policy
+            cy.get('#tabPanel-api-policies').click();
+            cy.contains('API Specific Policy Sample').trigger('mouseover');
+            cy.get('[aria-label="view-APISpecificPolicySample"]').click({force:true});
+
+            // Verify version 2 details
+            cy.get('[data-testid="description"] input').should('have.value', 'Enhanced API specific policy description version 2');
+            cy.get('[data-testid="done-view-policy-file"]').click();
+
+            // Drag and drop version 2 policy
+            const dataTransferV2 = new DataTransfer();
+            cy.contains('API Specific Policy Sample', { timeout: Cypress.config().largeTimeout }).trigger('dragstart', {
+                dataTransfer: dataTransferV2
+            });
+            cy.get('#operation-level-tabpanel').contains('Drag and drop policies here').trigger('drop', {
+                dataTransfer: dataTransferV2
+            });
+
+            // Configure version 2 policy attributes
+            cy.contains('Enhanced API specific policy description version 2').should('be.visible');
+            cy.get('#enhancedAttribute').type('enhanced test value version 2');
+            cy.get('#optionalAttribute').type('optional test value');
+            cy.get('[data-testid="policy-attached-details-save"]').click();
+            cy.get('[data-testid="custom-select-save-button"]').scrollIntoView().click();
+
+            // Open edit mode for version 2 and verify correct data is displayed
+            cy.get('[data-testid="drop-policy-zone-request"]')
+              .get('[data-testid="attached-policy-card-APISpecificPolicySample"]')
+              .click({ force: true });
+            cy.contains('Enhanced API specific policy description version 2').should('be.visible');
+            cy.get('#enhancedAttribute').should('have.value', 'enhanced test value version 2');
+            cy.get('#optionalAttribute').should('have.value', 'optional test value');
+            
+            // Verify policy name and version in edit mode
+            cy.contains('API Specific Policy Sample : v2').should('be.visible');
+            cy.get('[data-testid="policy-attached-details-cancel"]').click();
+
             cy.logoutFromPublisher();
 
         });


### PR DESCRIPTION
## Purpose
Purpose of this PR is to fix https://github.com/wso2/api-manager/issues/3999

## Goals
Fix version mismatch issue in attached policy view/edit drawer

## Approach
Used the `policyVersion` along with the `policyName` when searching the attached policy specification from the policies list

## Automation tests
Updated the UI test to verify the functionality

## Samples
<img width="998" alt="image" src="https://github.com/user-attachments/assets/f6a6ce0f-fcb0-43b4-a960-de57f00c8dc1" />
