### PR TITLE
Add null safety to proxy config and custom param updates

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -120,17 +120,6 @@ function EndpointSecurity(props) {
         endpointSecurityTypes,
     } = props;
     const [endpointSecurityInfo, setEndpointSecurityInfo] = useState(CONSTS.DEFAULT_ENDPOINT_SECURITY);
-
-    if (securityInfo && securityInfo.proxyConfigs == null) {
-        securityInfo.proxyConfigs = {
-            proxyEnabled: false,
-            proxyHost: '',
-            proxyPort: '',
-            proxyUsername: '',
-            proxyPassword: '',
-            proxyProtocol: '',
-        };
-    }
     const [securityValidity, setSecurityValidity] = useState();
 
     const [showAddParameter, setShowAddParameter] = useState(false);
@@ -209,7 +198,7 @@ function EndpointSecurity(props) {
                 connectionTimeoutConfigType, proxyConfigType,
             } = securityInfo;
             const secretPlaceholder = '******';
-            tmpSecurity.type = type === null ? 'NONE' : type;
+            tmpSecurity.type = type == null ? 'NONE' : type;
             tmpSecurity.username = username;
             tmpSecurity.password = password === '' ? secretPlaceholder : password;
             tmpSecurity.grantType = grantType;
@@ -220,7 +209,14 @@ function EndpointSecurity(props) {
             tmpSecurity.connectionTimeoutDuration = connectionTimeoutDuration;
             tmpSecurity.connectionRequestTimeoutDuration = connectionRequestTimeoutDuration;
             tmpSecurity.socketTimeoutDuration = socketTimeoutDuration;
-            tmpSecurity.proxyConfigs = proxyConfigs;
+            tmpSecurity.proxyConfigs = proxyConfigs || {
+                proxyEnabled: false,
+                proxyHost: '',
+                proxyPort: '',
+                proxyUsername: '',
+                proxyPassword: '',
+                proxyProtocol: '',
+            };
             tmpSecurity.connectionTimeoutConfigType = connectionTimeoutConfigType;
             tmpSecurity.proxyConfigType = proxyConfigType;
         }
@@ -316,9 +312,9 @@ function EndpointSecurity(props) {
      * Add new custom parameter
      */
     const handleAddToList = () => {
-        const customParametersCopy = { ...endpointSecurityInfo.customParameters };
+        const customParametersCopy = { ...endpointSecurityInfo.customParameters } || {};
 
-        if (customParametersCopy !== null
+        if (customParametersCopy != null
             && Object.prototype.hasOwnProperty.call(customParametersCopy, parameterName)) {
             Alert.warning('Parameter name: ' + parameterName + ' already exists');
         } else {
@@ -343,10 +339,10 @@ function EndpointSecurity(props) {
      * @param {*} newRow new name-value pair
      */
     const handleUpdateList = (oldRow, newRow, isSecret) => {
-        const customParametersCopy = { ...endpointSecurityInfo.customParameters };
+        const customParametersCopy = { ...endpointSecurityInfo.customParameters } || {};
         const { oldName, oldValue } = oldRow;
         const { newName, newValue } = newRow;
-        if (customParametersCopy !== null
+        if (customParametersCopy != null
             && Object.prototype.hasOwnProperty.call(customParametersCopy, newName) && oldName === newName) {
             // Only the value is updated
             if (newValue && oldValue !== newValue) {
@@ -379,7 +375,7 @@ function EndpointSecurity(props) {
      */
     const handleDelete = (oldName) => {
         const customParametersCopy = { ...endpointSecurityInfo.customParameters };
-        if (customParametersCopy !== null && Object.prototype.hasOwnProperty.call(customParametersCopy, oldName)) {
+        if (customParametersCopy != null && Object.prototype.hasOwnProperty.call(customParametersCopy, oldName)) {
             delete customParametersCopy[oldName];
         }
         setEndpointSecurityInfo({ ...endpointSecurityInfo, customParameters: customParametersCopy });
@@ -877,14 +873,14 @@ function EndpointSecurity(props) {
                                         value={endpointSecurityInfo.proxyConfigType}
                                         defaultValue={endpointSecurityInfo.proxyConfigType}
                                         onChange={(event) => {
-                                            if (event.target.value === 'ENDPOINT_SPECIFIC') {
-                                                endpointSecurityInfo.proxyConfigs.proxyEnabled = true;
-                                            } else {
-                                                endpointSecurityInfo.proxyConfigs.proxyEnabled = false;
-                                            }
-                                            endpointSecurityInfo.proxyConfigType = event.target.value;
-                                            setEndpointSecurityInfo({ ...endpointSecurityInfo });
-                                            validateAndUpdateSecurityInfo('endpointSecurityInfo');
+                                            setEndpointSecurityInfo({
+                                                ...endpointSecurityInfo,
+                                                proxyConfigType: event.target.value,
+                                                proxyConfigs: {
+                                                    ...endpointSecurityInfo.proxyConfigs,
+                                                    proxyEnabled: event.target.value === 'ENDPOINT_SPECIFIC'
+                                                }
+                                            });
                                         }}
                                         onBlur={() => validateAndUpdateSecurityInfo('proxyConfigType')}
                                     >
@@ -945,11 +941,16 @@ function EndpointSecurity(props) {
                                                 />
                                             )}
                                             onChange={(event) => {
-                                                endpointSecurityInfo.proxyConfigs.proxyHost = event.target.value;
-                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                setEndpointSecurityInfo({
+                                                    ...endpointSecurityInfo,
+                                                    proxyConfigs: {
+                                                        ...endpointSecurityInfo.proxyConfigs,
+                                                        proxyHost: event.target.value,
+                                                    }
+                                                });
                                                 validateAndUpdateSecurityInfo('proxyConfigs');
                                             }}
-                                            value={endpointSecurityInfo.proxyConfigs.proxyHost}
+                                            value={endpointSecurityInfo.proxyConfigs?.proxyHost || ''}
                                             onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
                                         />
                                     </Grid>
@@ -972,11 +973,16 @@ function EndpointSecurity(props) {
                                                 />
                                             )}
                                             onChange={(event) => {
-                                                endpointSecurityInfo.proxyConfigs.proxyPort = event.target.value;
-                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                setEndpointSecurityInfo({
+                                                    ...endpointSecurityInfo,
+                                                    proxyConfigs: {
+                                                        ...endpointSecurityInfo.proxyConfigs,
+                                                        proxyPort: event.target.value,
+                                                    }
+                                                });
                                                 validateAndUpdateSecurityInfo('proxyConfigs');
                                             }}
-                                            value={endpointSecurityInfo.proxyConfigs.proxyPort}
+                                            value={endpointSecurityInfo.proxyConfigs?.proxyPort || ''}
                                             onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
                                         />
                                     </Grid>
@@ -998,11 +1004,16 @@ function EndpointSecurity(props) {
                                                 />
                                             )}
                                             onChange={(event) => {
-                                                endpointSecurityInfo.proxyConfigs.proxyUsername = event.target.value;
-                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                setEndpointSecurityInfo({
+                                                    ...endpointSecurityInfo,
+                                                    proxyConfigs: {
+                                                        ...endpointSecurityInfo.proxyConfigs,
+                                                        proxyUsername: event.target.value,
+                                                    }
+                                                });
                                                 validateAndUpdateSecurityInfo('proxyConfigs');
                                             }}
-                                            value={endpointSecurityInfo.proxyConfigs.proxyUsername}
+                                            value={endpointSecurityInfo.proxyConfigs?.proxyUsername || ''}
                                             onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
                                         />
                                     </Grid>
@@ -1025,11 +1036,16 @@ function EndpointSecurity(props) {
                                                 />
                                             )}
                                             onChange={(event) => {
-                                                endpointSecurityInfo.proxyConfigs.proxyPassword = event.target.value;
-                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                setEndpointSecurityInfo({
+                                                    ...endpointSecurityInfo,
+                                                    proxyConfigs: {
+                                                        ...endpointSecurityInfo.proxyConfigs,
+                                                        proxyPassword: event.target.value,
+                                                    }
+                                                });
                                                 validateAndUpdateSecurityInfo('proxyConfigs');
                                             }}
-                                            value={endpointSecurityInfo.proxyConfigs.proxyPassword}
+                                            value={endpointSecurityInfo.proxyConfigs?.proxyPassword || ''}
                                             onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
                                         />
                                     </Grid>
@@ -1052,11 +1068,16 @@ function EndpointSecurity(props) {
                                                 />
                                             )}
                                             onChange={(event) => {
-                                                endpointSecurityInfo.proxyConfigs.proxyProtocol = event.target.value;
-                                                setEndpointSecurityInfo({ ...endpointSecurityInfo });
+                                                setEndpointSecurityInfo({
+                                                    ...endpointSecurityInfo,
+                                                    proxyConfigs: {
+                                                        ...endpointSecurityInfo.proxyConfigs,
+                                                        proxyProtocol: event.target.value,
+                                                    }
+                                                });
                                                 validateAndUpdateSecurityInfo('proxyConfigs');
                                             }}
-                                            value={endpointSecurityInfo.proxyConfigs.proxyProtocol}
+                                            value={endpointSecurityInfo.proxyConfigs?.proxyProtocol || ''}
                                             onBlur={() => validateAndUpdateSecurityInfo('proxyConfigs')}
                                         />
                                     </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/EndpointSecurity.jsx
@@ -312,7 +312,8 @@ function EndpointSecurity(props) {
      * Add new custom parameter
      */
     const handleAddToList = () => {
-        const customParametersCopy = { ...endpointSecurityInfo.customParameters } || {};
+        const customParametersCopy = endpointSecurityInfo.customParameters ?
+            { ...endpointSecurityInfo.customParameters } : {};
 
         if (customParametersCopy != null
             && Object.prototype.hasOwnProperty.call(customParametersCopy, parameterName)) {
@@ -339,7 +340,8 @@ function EndpointSecurity(props) {
      * @param {*} newRow new name-value pair
      */
     const handleUpdateList = (oldRow, newRow, isSecret) => {
-        const customParametersCopy = { ...endpointSecurityInfo.customParameters } || {};
+        const customParametersCopy = endpointSecurityInfo.customParameters ?
+            { ...endpointSecurityInfo.customParameters } : {};
         const { oldName, oldValue } = oldRow;
         const { newName, newValue } = newRow;
         if (customParametersCopy != null
@@ -374,7 +376,8 @@ function EndpointSecurity(props) {
      * @param {*} oldName name property of the name-value pair to be removed
      */
     const handleDelete = (oldName) => {
-        const customParametersCopy = { ...endpointSecurityInfo.customParameters };
+        const customParametersCopy = endpointSecurityInfo.customParameters ?
+            { ...endpointSecurityInfo.customParameters } : {};
         if (customParametersCopy != null && Object.prototype.hasOwnProperty.call(customParametersCopy, oldName)) {
             delete customParametersCopy[oldName];
         }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix https://github.com/wso2/api-manager/issues/3984
Note: The bug mentioned in the above issue was already fixed with a different approach, but it leads to several other bugs. Therefore, fixed the issue with a new approach.

## Goals
Preventing runtime errors and minor bugs in undefined sandbox endpoint scenario

## Approach

Added initial/default values and null checks to the attributes
Improved state change logics

## Samples

https://github.com/user-attachments/assets/f6ef5038-9fc9-4754-b6e6-2a219ef5625c

Prior to this change, if the above actions were done, it will create an unwanted proxyConfig element as below:

<img width="785" alt="image" src="https://github.com/user-attachments/assets/938cc67d-d180-41ac-85ed-ba471be1edbd" />



