### PR TITLE
Application scopes for client credentials grant type

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/AppConfiguration.jsx
@@ -34,6 +34,7 @@ import Select from '@mui/material/Select';
 import Input from '@mui/material/Input';
 import Box from '@mui/material/Box';
 import ChipInput from 'AppComponents/Shared/ChipInput';
+import Autocomplete from '@mui/material/Autocomplete';
 import Settings from 'AppComponents/Shared/SettingsContext';
 
 
@@ -104,7 +105,7 @@ const Root = styled('div')(
 const AppConfiguration = (props) => {
 
     const {
-        config, isUserOwner, previousValue, handleChange,
+        config, isUserOwner, previousValue, handleChange, subscriptionScopes,
     } = props;
 
     const [selectedValue, setSelectedValue] = useState(previousValue);
@@ -248,7 +249,48 @@ const AppConfiguration = (props) => {
                                     </MenuItem>
                                 ))}
                             </TextField>
-                        ) : (config.type === 'select' && config.multiple === true && Array.isArray(selectedValue)) ? (
+                    ) : (config.type === 'select' && config.multiple === true && Array.isArray(selectedValue)) ? 
+                        (config.name === 'application_scopes') ? (
+                            <>
+                                <Autocomplete
+                                    multiple
+                                    disabled={subscriptionScopes.length === 0}
+                                    options={subscriptionScopes} // Available subscription scopes
+                                    value={selectedValue} // Selected values
+                                    onChange={(event, newValue) => {
+                                        const e = { target: { name: config.name, value: newValue } };
+                                        handleAppRequestChange(e); // Update the selected values
+                                    }}
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            classes={{
+                                                root: classes.removeHelperPadding,
+                                            }}
+                                            fullWidth
+                                            disabled={subscriptionScopes.length === 0}
+                                            margin='dense'
+                                            size='small'
+                                            variant='outlined'
+                                            label={config.label}
+                                            placeholder="Select scopes"
+                                            error={config.required && hasMandatoryError(selectedValue)}
+                                            helperText={(config.required && hasMandatoryError(selectedValue)) || getAppConfigToolTip()}
+                                        />
+                                    )}
+                                    renderTags={(tagValue, getTagProps) =>
+                                        tagValue.map((option, index) => (
+                                            <Chip
+                                                key={option}
+                                                label={option}
+                                                {...getTagProps({ index })}
+                                                size="small"
+                                            />
+                                        ))
+                                    }
+                                />
+                            </>
+                        ) : (
                             <>
                                 <FormControl variant="outlined" className={classes.formControl} fullWidth>
                                     <InputLabel id="multi-select-label">{config.label}</InputLabel>
@@ -284,12 +326,11 @@ const AppConfiguration = (props) => {
                                             </MenuItem>
                                         ))}
                                     </Select>
+
+                                    <Typography variant='caption'>
+                                        {getAppConfigToolTip()}
+                                    </Typography>
                                 </FormControl>
-
-
-                                <Typography variant='caption'>
-                                    {getAppConfigToolTip()}
-                                </Typography>
                             </>
                         ) : (config.type === 'input' && config.multiple === true) ? (
                             <>
@@ -399,6 +440,7 @@ AppConfiguration.contextType = Settings;
 
 AppConfiguration.defaultProps = {
     notFound: false,
+    subscriptionScopes: [],
 };
 
 AppConfiguration.propTypes = {
@@ -407,6 +449,7 @@ AppConfiguration.propTypes = {
     isUserOwner: PropTypes.bool.isRequired,
     handleChange: PropTypes.func.isRequired,
     config: PropTypes.any.isRequired,
+    subscriptionScopes: PropTypes.arrayOf(PropTypes.string),
     notFound: PropTypes.bool,
     intl: PropTypes.shape({ formatMessage: PropTypes.func }).isRequired,
 };

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/KeyConfiguration.jsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState, useContext } from 'react';
+import React, {useEffect, useState, useContext} from 'react';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import cloneDeep from 'lodash.clonedeep';
@@ -34,9 +34,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Settings from 'Settings';
 import PropTypes from 'prop-types';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
-import Validation from 'AppData/Validation';
 import AppConfiguration from './AppConfiguration';
 import ContextSettings from 'AppComponents/Shared/SettingsContext';
+import Application from 'AppData/Application';
 
 const PREFIX = 'KeyConfiguration';
 
@@ -145,7 +145,8 @@ const KeyConfiguration = (props) => {
     const [callbackHelper, setCallbackHelper] = useState(false);
     const intl = useIntl();
     const {
-        notFound, isUserOwner, keyManagerConfig, updateKeyRequest, keyRequest, updateHasError, callbackError,mode,
+        notFound, isUserOwner, keyManagerConfig, updateKeyRequest, keyRequest, updateHasError, callbackError, mode,
+        selectedApp
     } = props;
     const {
         selectedGrantTypes, callbackUrl,
@@ -157,6 +158,24 @@ const KeyConfiguration = (props) => {
     } = keyManagerConfig;
     const [isOrgWideAppUpdateEnabled, setIsOrgWideAppUpdateEnabled] = useState(false);
     const settingsContext = useContext(ContextSettings);
+    const [subscriptionScopes, setSubscriptionScopes] = useState([]);
+
+    useEffect(() => {
+        if (selectedApp) {
+            const appId = selectedApp.appId || selectedApp.value;
+            Application.get(appId)
+                .then((app) => {
+                    const scopes = app.subscriptionScopes
+                        .map((scope) => { return scope.key; });
+                    setSubscriptionScopes(scopes);
+                })
+                .catch((error) => {
+                    if (process.env.NODE_ENV !== 'production') {
+                        console.error(error);
+                    }
+                });
+        }
+    }, [selectedApp]);
 
     /**
      * Updates isOrgWideAppUpdateEnabled whenever settingsContext changes
@@ -490,6 +509,7 @@ const KeyConfiguration = (props) => {
                                 previousValue={getPreviousValue(config)}
                                 isUserOwner={isUserOwner}
                                 handleChange={handleChange}
+                                subscriptionScopes={subscriptionScopes}
                             />
                         ))}
                         </>)}


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of subscription scopes in the `AppConfiguration` and `KeyConfiguration` components. The updates include adding support for displaying and managing subscription scopes via an `Autocomplete` component and fetching these scopes dynamically based on the selected application.
Related to wso2/api-manager#3910, wso2/api-manager#3998

### Enhancements to `AppConfiguration`:

* Added an `Autocomplete` component to handle multi-select inputs for `application_scopes`. This component dynamically populates options based on the `subscriptionScopes` prop and updates the selected values accordingly. 
* Introduced a new `subscriptionScopes` prop to the `AppConfiguration` component, with a default value of an empty array and updated prop types to reflect this addition.

### Enhancements to `KeyConfiguration`:

* Added logic to fetch subscription scopes for the selected application using the `Application.get` API and store them in a new `subscriptionScopes` state variable. This ensures the `AppConfiguration` component receives the relevant scopes.
* Passed the `subscriptionScopes` state to the `AppConfiguration` component as a prop. 

### Miscellaneous:

* Imported the `Autocomplete` component from Material-UI and the `Application` module for API interaction.