### PR TITLE
Bump actions/cache Version to v3

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: '22'
       - name: Cache maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2


### PR DESCRIPTION
### Purpose
- Bump actions/cache version to v3 required for UI tests under GitHub actions