### PR TITLE
Fix the failing API specific policy test

### DIFF
--- a/tests/cypress/integration/publisher/017-api-policies/01-api-specific-policy.spec.js
+++ b/tests/cypress/integration/publisher/017-api-policies/01-api-specific-policy.spec.js
@@ -65,7 +65,7 @@ describe("Common Policies", () => {
 
             // Download file
             cy.get('[data-testid="download-policy-file"]').click();
-            cy.get('[data-testid="done-view-policy-file"]').click();
+            cy.get('[aria-label="Close"]').click();
 
             // Drag and drop the policy to attach it
             const dataTransfer = new DataTransfer();
@@ -129,7 +129,7 @@ describe("Common Policies", () => {
 
             // Verify version 2 details
             cy.get('[data-testid="description"] input').should('have.value', 'Enhanced API specific policy description version 2');
-            cy.get('[data-testid="done-view-policy-file"]').click();
+            cy.get('[aria-label="Close"]').click();
 
             // Drag and drop version 2 policy
             const dataTransferV2 = new DataTransfer();


### PR DESCRIPTION
## Purpose
Fixing the failing API specific policy test

## Approach
The test has been failing as the "Done" button was removed from the API policy view modal
Update API specific policy test to use close button for closing policy view modal

## Screenshots
<img width="542" height="250" alt="image" src="https://github.com/user-attachments/assets/6dd887fa-5c0e-4051-babb-d72b2d1f765a" />
