### PR TITLE
Add Azure gateway type in the policy page.

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -211,6 +211,8 @@ const Policies: React.FC = () => {
             } else if (api.gatewayType === "AWS") {
                 // Get AWS gateway supported policies
                 gatewayType = 'AWS';
+            } else if (api.gatewayType === "Azure") {
+                gatewayType = 'Azure';
             } else {
                 // Get synpase gateway supported policies
                 gatewayType = 'Synapse';


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/4032

This fix will only display the policies that support Azure Gateway in the Azure API policies page.