### PR TITLE
Implement UI Support for `updateDisabled` Configuration in Key Manager

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -1776,6 +1776,7 @@ function AddEditKeyManager(props) {
                                              <KeyManagerConfiguration
                                                  keymanagerConnectorConfigurations={keymanagerConnectorConfigurations}
                                                  additionalProperties={cloneDeep(additionalProperties)}
+                                                 keyManagerId={cloneDeep(id)}
                                                  setAdditionalProperties={setAdditionalProperties}
                                                  hasErrors={hasErrors}
                                                  validating={validating}

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
@@ -57,21 +57,30 @@ export default function KeyManagerConfiguration(props) {
     };
     const getComponent = (keymanagerConnectorConfiguration) => {
         let value = '';
-        const disabled = (keymanagerConnectorConfiguration.updateDisabled
-            && keyManagerId) || false;
+        const disabled = Boolean(keymanagerConnectorConfiguration.updateDisabled && keyManagerId);
         if (additionalProperties[keymanagerConnectorConfiguration.name]) {
             value = additionalProperties[keymanagerConnectorConfiguration.name];
-        } else if (!keyManagerId
-            && keymanagerConnectorConfiguration.default
-            && typeof keymanagerConnectorConfiguration.default === 'string'
-        ) {
-            onChange({
-                target: {
-                    name: keymanagerConnectorConfiguration.name,
-                    value: keymanagerConnectorConfiguration.default,
-                    type: keymanagerConnectorConfiguration.type,
-                },
-            });
+        } else if (!keyManagerId && keymanagerConnectorConfiguration.default) {
+            if (typeof keymanagerConnectorConfiguration.default === 'string'
+                && ['input', 'select', 'options'].includes(keymanagerConnectorConfiguration.type)
+            ) {
+                onChange({
+                    target: {
+                        name: keymanagerConnectorConfiguration.name,
+                        value: keymanagerConnectorConfiguration.default,
+                        type: keymanagerConnectorConfiguration.type,
+                    },
+                });
+            } else if (typeof keymanagerConnectorConfiguration.default === 'boolean'
+                && keymanagerConnectorConfiguration.type === 'checkbox'
+            ) {
+                onChangeCheckBox({
+                    target: {
+                        name: keymanagerConnectorConfiguration.name,
+                        checked: keymanagerConnectorConfiguration.default,
+                    },
+                });
+            }
         }
         if (keymanagerConnectorConfiguration.type === 'input') {
             if (keymanagerConnectorConfiguration.mask) {

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
@@ -29,7 +29,7 @@ const StyledSpan = styled('span')(({ theme }) => ({ color: theme.palette.error.d
 export default function KeyManagerConfiguration(props) {
     const {
         keymanagerConnectorConfigurations, additionalProperties,
-        setAdditionalProperties, hasErrors, validating,
+        setAdditionalProperties, hasErrors, validating, keyManagerId,
     } = props;
 
     const onChange = (e) => {
@@ -57,13 +57,15 @@ export default function KeyManagerConfiguration(props) {
     };
     const getComponent = (keymanagerConnectorConfiguration) => {
         let value = '';
+        const disabled = (keymanagerConnectorConfiguration.updateDisabled
+            && keyManagerId) || false;
         if (additionalProperties[keymanagerConnectorConfiguration.name]) {
             value = additionalProperties[keymanagerConnectorConfiguration.name];
         }
         if (keymanagerConnectorConfiguration.type === 'input') {
             if (keymanagerConnectorConfiguration.mask) {
                 return (
-                    <FormControl variant='outlined' fullWidth>
+                    <FormControl variant='outlined' fullWidth disabled={disabled}>
                         <InputLabel sx={{ bgcolor: 'white' }}>
                             {keymanagerConnectorConfiguration.label}
                             {keymanagerConnectorConfiguration.required && (<StyledSpan>*</StyledSpan>)}
@@ -100,11 +102,12 @@ export default function KeyManagerConfiguration(props) {
                     value={value}
                     defaultValue={keymanagerConnectorConfiguration.default}
                     onChange={onChange}
+                    disabled={disabled}
                 />
             );
         } else if (keymanagerConnectorConfiguration.type === 'select') {
             return (
-                <FormControl variant='standard' component='fieldset'>
+                <FormControl variant='standard' component='fieldset' disabled={disabled}>
                     <FormLabel component='legend'>
                         <span>
                             {keymanagerConnectorConfiguration.label}
@@ -131,8 +134,13 @@ export default function KeyManagerConfiguration(props) {
             );
         } else if (keymanagerConnectorConfiguration.type === 'checkbox') {
             return (
-                <FormControl variant='standard' component='fieldset'>
-                    <FormLabel component='legend'>{keymanagerConnectorConfiguration.label}</FormLabel>
+                <FormControl variant='standard' component='fieldset' disabled={disabled}>
+                    <FormLabel component='legend'>
+                        <span>
+                            {keymanagerConnectorConfiguration.label}
+                            {keymanagerConnectorConfiguration.required && (<StyledSpan>*</StyledSpan>)}
+                        </span>
+                    </FormLabel>
                     <FormGroup>
                         {keymanagerConnectorConfiguration.values.map((selection) => (
                             <FormControlLabel
@@ -153,8 +161,13 @@ export default function KeyManagerConfiguration(props) {
             );
         } else if (keymanagerConnectorConfiguration.type === 'options') {
             return (
-                <FormControl variant='standard' component='fieldset'>
-                    <FormLabel component='legend'>{keymanagerConnectorConfiguration.label}</FormLabel>
+                <FormControl variant='standard' component='fieldset' disabled={disabled}>
+                    <FormLabel component='legend'>
+                        <span>
+                            {keymanagerConnectorConfiguration.label}
+                            {keymanagerConnectorConfiguration.required && (<StyledSpan>*</StyledSpan>)}
+                        </span>
+                    </FormLabel>
                     <RadioGroup
                         aria-label={keymanagerConnectorConfiguration.label}
                         name={keymanagerConnectorConfiguration.name}
@@ -180,6 +193,7 @@ export default function KeyManagerConfiguration(props) {
                     value={value}
                     defaultValue={keymanagerConnectorConfiguration.default}
                     onChange={onChange}
+                    disabled={disabled}
                 />
             );
         }

--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/KeyManagerConfiguration.jsx
@@ -61,6 +61,17 @@ export default function KeyManagerConfiguration(props) {
             && keyManagerId) || false;
         if (additionalProperties[keymanagerConnectorConfiguration.name]) {
             value = additionalProperties[keymanagerConnectorConfiguration.name];
+        } else if (!keyManagerId
+            && keymanagerConnectorConfiguration.default
+            && typeof keymanagerConnectorConfiguration.default === 'string'
+        ) {
+            onChange({
+                target: {
+                    name: keymanagerConnectorConfiguration.name,
+                    value: keymanagerConnectorConfiguration.default,
+                    type: keymanagerConnectorConfiguration.type,
+                },
+            });
         }
         if (keymanagerConnectorConfiguration.type === 'input') {
             if (keymanagerConnectorConfiguration.mask) {


### PR DESCRIPTION
## Purpose
Implement UI support for the new `updateDisabled` connector configuration in the key manager. This field is editable **only during key manager creation**.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/b3673f87-a2e6-4004-9a44-03a428b59518" />

When updating an existing key manager, this field is disabled in the UI as shown.

<img width="852" alt="image" src="https://github.com/user-attachments/assets/aabfa2db-e7c5-4e2e-827f-82fa51161210" />

## Approach
Pass the key manager ID as a prop from `AddEditKeyManager` to `KeyManagerConfiguration`.  
Within `KeyManagerConfiguration`, derive a flag to disable any connector configuration field that is marked as `updateDisabled` during key manager update flow.

## Related to
Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8968
