### PR TITLE
Fix VHost default port configuration and DTO mapping

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -108,9 +108,6 @@ function AddEditGWEnvironment(props) {
     const intl = useIntl();
     const { dataRow } = props;
 
-    const defaultVhost = {
-        host: '', httpContext: '', httpsPort: 8243, httpPort: 8280, wssPort: 8099, wsPort: 9099, isNew: true,
-    };
     const { settings } = useAppContext();
     const [validRoles, setValidRoles] = useState([]);
     const [invalidRoles, setInvalidRoles] = useState([]);
@@ -119,17 +116,32 @@ function AddEditGWEnvironment(props) {
     const [validating, setValidating] = useState(false);
     const [saving, setSaving] = useState(false);
     const { gatewayTypes } = settings;
+
+    const createDefaultVhost = (currentGatewayType) => {
+        const gatewaysProvidedByWSO2 = ['Regular', 'APK'];
+        const isExternalGateway = !gatewaysProvidedByWSO2.includes(currentGatewayType);
+        return {
+            host: '',
+            httpContext: '',
+            httpsPort: isExternalGateway ? 443 : 8243,
+            httpPort: isExternalGateway ? 80 : 8280,
+            wssPort: 8099,
+            wsPort: 9099,
+            isNew: true,
+        };
+    };
     const { match: { params: { id } }, history } = props;
     const initialPermissions = dataRow && dataRow.permissions
         ? dataRow.permissions
         : { roles: [], permissionType: 'PUBLIC' };
+    const initialGatewayType = gatewayTypes && gatewayTypes.length > 1 && gatewayTypes.includes('Regular') ? 'Regular'
+        : gatewayTypes[0];
     const [initialState, setInitialState] = useState({
         displayName: '',
         description: '',
-        gatewayType: gatewayTypes && gatewayTypes.length > 1 && gatewayTypes.includes('Regular') ? 'Regular'
-            : gatewayTypes[0],
+        gatewayType: initialGatewayType,
         type: 'hybrid',
-        vhosts: [defaultVhost],
+        vhosts: [createDefaultVhost(initialGatewayType)],
         permissions: initialPermissions,
         additionalProperties: {},
     });
@@ -169,7 +181,7 @@ function AddEditGWEnvironment(props) {
                 description: '',
                 gatewayType: '',
                 type: 'hybrid',
-                vhosts: [defaultVhost],
+                vhosts: [createDefaultVhost('')],
                 permissions: {
                     roles: [],
                     permissionType: 'PUBLIC',

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -425,8 +425,9 @@ function AddEditGWEnvironment(props) {
             vhosts.forEach((vhost) => {
                 vhostDto.push({
                     host: vhost.host,
-                    httpPort: 80,
-                    httpsPort: 443,
+                    httpContext: vhost.httpContext,
+                    httpPort: vhost.httpPort,
+                    httpsPort: vhost.httpsPort,
                 });
             });
             provider = 'external';

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -181,7 +181,7 @@ function AddEditGWEnvironment(props) {
                 description: '',
                 gatewayType: '',
                 type: 'hybrid',
-                vhosts: [createDefaultVhost('')],
+                vhosts: [createDefaultVhost('Regular')],
                 permissions: {
                     roles: [],
                     permissionType: 'PUBLIC',

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
@@ -47,9 +47,20 @@ function AddEditVhost(props) {
     } = props;
     const [userVhosts, setUserVhosts] = useState([]);
     const [id, setId] = useState(0);
-    const defaultVhost = {
-        host: '', httpContext: '', httpsPort: 443, httpPort: 80, wssPort: 8099, wsPort: 9099, isNew: true,
+    const createDefaultVhost = (currentGatewayType) => {
+        const gatewaysProvidedByWSO2 = ['Regular', 'APK'];
+        const isExternalGateway = !gatewaysProvidedByWSO2.includes(currentGatewayType);
+        return {
+            host: '',
+            httpContext: '',
+            httpsPort: isExternalGateway ? 443 : 8243,
+            httpPort: isExternalGateway ? 80 : 8280,
+            wssPort: 8099,
+            wsPort: 9099,
+            isNew: true,
+        };
     };
+
     const prevRef = useRef();
     const { settings } = useAppContext();
 
@@ -99,7 +110,7 @@ function AddEditVhost(props) {
     };
 
     const handleNewVhost = () => {
-        const vhost = defaultVhost;
+        const vhost = createDefaultVhost(gatewayType);
         vhost.key = '' + id;
         setId(id + 1);
         const tempItems = [...userVhosts, vhost];
@@ -127,7 +138,7 @@ function AddEditVhost(props) {
             setId(i);
         } else {
             setId(id + 1);
-            const vhost = defaultVhost;
+            const vhost = createDefaultVhost(gatewayType);
             vhost.key = '' + id;
             setUserVhosts([vhost]);
         }
@@ -171,7 +182,7 @@ function AddEditVhost(props) {
                 setId(i);
             } else {
                 setId(id + 1);
-                const vhost = defaultVhost;
+                const vhost = createDefaultVhost(gatewayType);
                 vhost.key = '' + id;
                 if (config && config.defaultHostnameTemplate) {
                     vhost.host = config.defaultHostnameTemplate;

--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditVhost.jsx
@@ -48,7 +48,7 @@ function AddEditVhost(props) {
     const [userVhosts, setUserVhosts] = useState([]);
     const [id, setId] = useState(0);
     const defaultVhost = {
-        host: '', httpContext: '', httpsPort: 8243, httpPort: 8280, wssPort: 8099, wsPort: 9099, isNew: true,
+        host: '', httpContext: '', httpsPort: 443, httpPort: 80, wssPort: 8099, wsPort: 9099, isNew: true,
     };
     const prevRef = useRef();
     const { settings } = useAppContext();


### PR DESCRIPTION
## Summary
This PR fixes the VHost configuration by updating default port values for external GWs and correcting the DTO mapping.

## Changes Made
- **Updated default ports in `AddEditVhost.jsx` and `AddEditGWEnvironment.jsx` for external GWs:**
  - HTTP port: `8280` → `80` (standard HTTP port)
  - HTTPS port: `8243` → `443` (standard HTTPS port)

- **Fixed VHost DTO mapping:**
  - Added missing `httpContext` field mapping
  - Updated `httpPort` and `httpsPort` to use dynamic values from vhost object instead of hardcoded values

## Related Issue
- https://github.com/wso2/api-manager/issues/4109