### PR TITLE
Handle MCP Server support disabled mode in Publisher portal and Developer portal

### DIFF
--- a/portals/devportal/src/main/webapp/site/public/locales/en.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/en.json
@@ -534,6 +534,7 @@
   "Applications.Listing.ResetPolicyDialog.dialog.user.required": "Application name is required",
   "Base.Errors.ResourceNotFound.api.list": "API List",
   "Base.Errors.ResourceNotFound.applications": "Applications",
+  "Base.Errors.ResourceNotFound.mcp.list": "MCP Server List",
   "Base.Errors.ResourceNotFound.more.links": "You may check the links below",
   "Base.Errors.ResourceNotfound.default_body": "The page you are looking for is not available",
   "Base.Errors.ResourceNotfound.default_tittle": "Page Not Found",

--- a/portals/devportal/src/main/webapp/source/src/app/AppRouts.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/AppRouts.jsx
@@ -15,13 +15,18 @@
  * limitations under the License.
  */
 
-import React, { lazy, Suspense } from 'react';
+import React, {
+    lazy, Suspense,
+} from 'react';
+import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import ApplicationFormHandler from 'AppComponents/Applications/ApplicationFormHandler';
 import { PageNotFound, ScopeNotFound } from 'AppComponents/Base/Errors';
 import RedirectToLogin from 'AppComponents/Login/RedirectToLogin';
 import Progress from 'AppComponents/Shared/Progress';
+import PortalModeRouteGuard from 'AppComponents/Shared/PortalModeRouteGuard';
 import { useTheme } from '@mui/material';
+import { usePortalMode, PORTAL_MODES } from './utils/PortalModeUtils';
 
 const Apis = lazy(() => import('AppComponents/Apis/Apis' /* webpackChunkName: "Apis" */));
 const MCPServers = lazy(() => import('AppComponents/MCPServers/MCPServers' /* webpackChunkName: "MCPServers" */));
@@ -33,39 +38,59 @@ const Details = lazy(() => import('AppComponents/Applications/Details/index' /* 
 
 /**
  * Handle redirection
- * @param {*} theme configuration
- * @returns {*}
+ * @param {Object} theme configuration
+ * @param {string} portalMode current portal mode
+ * @returns {string} redirect path
  */
-function getRedirectingPath(theme) {
+function getRedirectingPath(theme, portalMode = PORTAL_MODES.HYBRID) {
     if (theme.custom.landingPage.active) {
         return '/home';
-    } else if (
+    } if (
         theme.custom.landingPage.active === false
         && theme.custom.tagWise.active
         && theme.custom.tagWise.style === 'page'
     ) {
         return '/api-groups';
-    } else {
-        return 'apis';
     }
+    // Default redirection based on portal mode
+    if (portalMode === PORTAL_MODES.MCP_ONLY) {
+        return '/mcp-servers';
+    }
+    return '/apis';
 }
 
 /**
  * Handle routes
- * @param {*} props properties
- * @returns {*}
+ * @param {Object} props properties
+ * @returns {React.ReactElement} routes component
  */
 function AppRouts(props) {
     const { isAuthenticated, isUserFound } = props;
     const theme = useTheme();
+    const portalMode = usePortalMode();
+
     return (
         <Suspense fallback={<Progress />}>
             <Switch>
-                <Redirect exact from='/' to={getRedirectingPath(theme)} />
+                <Redirect exact from='/' to={getRedirectingPath(theme, portalMode)} />
                 <Route path='/home' component={Landing} />
                 <Route path='/api-groups' component={TagCloudListing} />
-                <Route path='/(apis|api-products)' component={Apis} />
-                <Route path='/mcp-servers' component={MCPServers} />
+                <Route
+                    path='/(apis|api-products)'
+                    render={(routeProps) => (
+                        <PortalModeRouteGuard>
+                            <Apis {...routeProps} />
+                        </PortalModeRouteGuard>
+                    )}
+                />
+                <Route
+                    path='/mcp-servers'
+                    render={(routeProps) => (
+                        <PortalModeRouteGuard>
+                            <MCPServers {...routeProps} />
+                        </PortalModeRouteGuard>
+                    )}
+                />
                 <Route
                     path='/settings/change-password/'
                     render={(localProps) => {
@@ -142,5 +167,10 @@ function AppRouts(props) {
         </Suspense>
     );
 }
+
+AppRouts.propTypes = {
+    isAuthenticated: PropTypes.bool.isRequired,
+    isUserFound: PropTypes.bool.isRequired,
+};
 
 export default AppRouts;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -513,7 +513,7 @@ class ApiConsole extends React.Component {
         const downloadSwagger = JSON.stringify({ ...swagger });
         const downloadLink = 'data:text/json;charset=utf-8, ' + encodeURIComponent(downloadSwagger);
         const fileName = 'swagger.json';
-        const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
+        const isMCPServer = api.type === 'MCP';
 
         if (api == null || swagger == null) {
             return <Progress />;
@@ -617,7 +617,7 @@ class ApiConsole extends React.Component {
                         />
                     </Grid>
 
-                    {api.type !== 'SOAP' && !isMCPServersRoute && (
+                    {api.type !== 'SOAP' && !isMCPServer && (
                         <Grid container>
                             <Grid xs={7} item />
                             <Grid xs={2} item>
@@ -673,7 +673,7 @@ class ApiConsole extends React.Component {
                         </Grid>
                     )}
                 </Paper>
-                {!isMCPServersRoute && (
+                {!isMCPServer && (
                     <Paper className={classes.swaggerUIPaper}>
                         <SwaggerUI
                             api={this.state.api}
@@ -684,7 +684,7 @@ class ApiConsole extends React.Component {
                         />
                     </Paper>
                 )}
-                {isMCPServersRoute && (
+                {isMCPServer && (
                     <Grid container className={classes.grid}>
                         <MCPTryOut
                             api={this.state.api}

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GoToTryOut.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/GoToTryOut.jsx
@@ -83,7 +83,6 @@ export default function GoToTryOut() {
             || api.type === CONSTANTS.API_TYPES.SSE
             || api.type === CONSTANTS.API_TYPES.ASYNC));
     const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
-    const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
 
     const getKeyRequest = async () => {
         const promisedKeyManagers = restApi.getKeyManagers();
@@ -182,7 +181,7 @@ export default function GoToTryOut() {
         await updateSubscriptionData();
         if (isAsyncAPI) {
             history.push('/apis/' + api.id + '/definition');
-        } else if (isMCPServersRoute) {
+        } else if (api.type === 'MCP') {
             history.push('/mcp-servers/' + api.id + '/mcp-playground');
         } else {
             history.push('/apis/' + api.id + '/api-console');

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -34,6 +34,7 @@ import AuthManager from 'AppData/AuthManager';
 import withSettings from 'AppComponents/Shared/withSettingsContext';
 import SolaceTopicsInfo from 'AppComponents/Apis/Details/SolaceApi/SolaceTopicsInfo';
 import Alert from 'AppComponents/Shared/Alert';
+import PortalModeRouteGuard from 'AppComponents/Shared/PortalModeRouteGuard';
 import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 import { app } from 'Settings';
@@ -881,12 +882,14 @@ class DetailsLegacy extends React.Component {
                                 { [classes.contentLoaderRightMenu]: position === 'vertical-right' },
                             )}
                         >
-                            <LoadableSwitch
-                                api={api}
-                                updateSubscriptionData={this.updateSubscriptionData}
-                                setbreadcrumbDocument={this.setbreadcrumbDocument}
-                                apiChatEnabled={apiChatEnabled}
-                            />
+                            <PortalModeRouteGuard>
+                                <LoadableSwitch
+                                    api={api}
+                                    updateSubscriptionData={this.updateSubscriptionData}
+                                    setbreadcrumbDocument={this.setbreadcrumbDocument}
+                                    apiChatEnabled={apiChatEnabled}
+                                />
+                            </PortalModeRouteGuard>
                         </div>
                     </div>
                 </ApiContext.Provider>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/APIThumbPlain.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/APIThumbPlain.jsx
@@ -151,12 +151,12 @@ function APIThumbPlain(props) {
     const [technicalAnchorEl, setTechnicalAnchorEl] = useState(null);
     const [businessOpenPopover, setBusinessOpenPopover] = useState(false);
     const [technicalOpenPopover, setTechnicalOpenPopover] = useState(false);
-    const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
-    const pathPrefix = isMCPServersRoute ? '/mcp-servers/' : '/apis/';
+    const isMCPServer = api.type === 'MCP';
+    const pathPrefix = isMCPServer ? '/mcp-servers/' : '/apis/';
 
     useEffect(() => {
         let promisedThumbnail;
-        if (isMCPServersRoute) {
+        if (isMCPServer) {
             promisedThumbnail = new MCPServer().getMCPServerThumbnail(api.id);
         } else {
             promisedThumbnail = new Api().getAPIThumbnail(api.id);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/ApiThumbClassic.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/ApiThumbClassic.jsx
@@ -319,9 +319,8 @@ class ApiThumbClassicLegacy extends React.Component {
         const { imageLoaded } = this.state;
         if (imageLoaded) return;
         const { api } = this.props;
-        const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
         let promisedThumbnail;
-        if (isMCPServersRoute) {
+        if (api.type === 'MCP') {
             promisedThumbnail = new MCPServer().getMCPServerThumbnail(api.id);
         } else {
             promisedThumbnail = new Api().getAPIThumbnail(api.id);
@@ -355,17 +354,6 @@ class ApiThumbClassicLegacy extends React.Component {
         }
     }
 
-    /**
-     * Get Path Prefix depedning on the respective API Type being rendered
-     *
-     * @returns {String} path
-     * @memberof ApiThumb
-     */
-    getPathPrefix() {
-        const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
-        return isMCPServersRoute ? '/mcp-servers/' : '/apis/';
-    }
-
     handleBusinessPopoverOpen = (event) => {
         this.setState({ businessAnchorEl: event.currentTarget, buniessOpenPopover: true });
     };
@@ -391,13 +379,13 @@ class ApiThumbClassicLegacy extends React.Component {
         const {
             imageObj, selectedIcon, color, backgroundIndex, category, imageLoaded,
         } = this.state;
-        const path = this.getPathPrefix();
         const { isMonetizationEnabled } = this.context;
 
-        const detailsLink = path + this.props.api.id;
         const {
             api, theme, customWidth, customHeight, showInfo,
         } = this.props;
+        const path = api.type === 'MCP' ? '/mcp-servers/' : '/apis/';
+        const detailsLink = path + api.id;
         const { custom: { thumbnail, social: { showRating }, thumbnailTemplates: { variant, active } } } = theme;
         const { name, version, context } = api;
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -38,6 +38,7 @@ import Subscription from 'AppData/Subscription';
 import Api from 'AppData/api';
 import { app } from 'Settings';
 import SubscriptionSection from './SubscriptionSection';
+import { useAreApisAccessible, useAreMcpServersAccessible } from '../../../utils/PortalModeUtils';
 
 const PREFIX = 'Subscriptions';
 
@@ -200,10 +201,10 @@ const StyledDialog = styled(Dialog)((
 /**
  *
  *
- * @class Subscriptions
+ * @class SubscriptionsBase
  * @extends {React.Component}
  */
-class Subscriptions extends React.Component {
+class SubscriptionsBase extends React.Component {
     /**
      *Creates an instance of Subscriptions.
      * @param {*} props properties
@@ -574,8 +575,10 @@ class Subscriptions extends React.Component {
             window.location = app.context + '/services/configs';
         }
 
-        const { applicationId } = this.props.application;
-        const { intl } = this.props;
+        const {
+            application, intl, apisAccessible, mcpServersAccessible,
+        } = this.props;
+        const { applicationId } = application;
 
         if (subscriptions) {
             return (
@@ -594,272 +597,280 @@ class Subscriptions extends React.Component {
                             />
                         </Typography>
 
-                        <SubscriptionSection
-                            title={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.subscribed.apis'
-                                    defaultMessage='Subscribed APIs'
-                                />
-                            )}
-                            buttonText={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.apis.add.subscription.button'
-                                    defaultMessage='Subscribe'
-                                />
-                            )}
-                            subscriptions={apiSubscriptions}
-                            subscriptionsNotFound={subscriptionsNotFound}
-                            pseudoSubscriptions={pseudoSubscriptions}
-                            onAddClick={this.handleOpenDialog}
-                            handleSubscriptionDelete={this.handleSubscriptionDelete}
-                            handleSubscriptionUpdate={this.handleSubscriptionUpdate}
-                            noSubscriptionsMessage={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.no.api.subscriptions'
-                                    defaultMessage='No API Subscriptions Available'
-                                />
-                            )}
-                            noSubscriptionsContent={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.no.api.subscriptions.content'
-                                    defaultMessage='No API subscriptions are available for this Application'
-                                />
-                            )}
-                            entityNameColumn={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.api.name'
-                                    defaultMessage='API'
-                                />
-                            )}
-                        />
+                        {apisAccessible && (
+                            <SubscriptionSection
+                                title={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.subscribed.apis'
+                                        defaultMessage='Subscribed APIs'
+                                    />
+                                )}
+                                buttonText={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.apis.add.subscription.button'
+                                        defaultMessage='Subscribe'
+                                    />
+                                )}
+                                subscriptions={apiSubscriptions}
+                                subscriptionsNotFound={subscriptionsNotFound}
+                                pseudoSubscriptions={pseudoSubscriptions}
+                                onAddClick={this.handleOpenDialog}
+                                handleSubscriptionDelete={this.handleSubscriptionDelete}
+                                handleSubscriptionUpdate={this.handleSubscriptionUpdate}
+                                noSubscriptionsMessage={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.no.api.subscriptions'
+                                        defaultMessage='No API Subscriptions Available'
+                                    />
+                                )}
+                                noSubscriptionsContent={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.no.api.subscriptions.content'
+                                        defaultMessage='No API subscriptions are available for this Application'
+                                    />
+                                )}
+                                entityNameColumn={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.api.name'
+                                        defaultMessage='API'
+                                    />
+                                )}
+                            />
+                        )}
 
-                        <SubscriptionSection
-                            title={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.subscribed.mcp.servers'
-                                    defaultMessage='Subscribed MCP Servers'
-                                />
-                            )}
-                            buttonText={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.mcp.servers.add.subscription.button'
-                                    defaultMessage='Subscribe'
-                                />
-                            )}
-                            subscriptions={mcpSubscriptions}
-                            subscriptionsNotFound={subscriptionsNotFound}
-                            pseudoSubscriptions={pseudoMcpSubscriptions}
-                            onAddClick={this.handleOpenMcpDialog}
-                            handleSubscriptionDelete={this.handleSubscriptionDelete}
-                            handleSubscriptionUpdate={this.handleSubscriptionUpdate}
-                            noSubscriptionsMessage={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.no.mcp.subscriptions'
-                                    defaultMessage='No MCP Server Subscriptions Available'
-                                />
-                            )}
-                            noSubscriptionsContent={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.no.mcp.subscriptions.content'
-                                    defaultMessage='No MCP server subscriptions are available for this Application'
-                                />
-                            )}
-                            entityNameColumn={(
-                                <FormattedMessage
-                                    id='Applications.Details.Subscriptions.mcp.server.name'
-                                    defaultMessage='MCP Server'
-                                />
-                            )}
-                        />
+                        {mcpServersAccessible && (
+                            <SubscriptionSection
+                                title={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.subscribed.mcp.servers'
+                                        defaultMessage='Subscribed MCP Servers'
+                                    />
+                                )}
+                                buttonText={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.mcp.servers.add.subscription.button'
+                                        defaultMessage='Subscribe'
+                                    />
+                                )}
+                                subscriptions={mcpSubscriptions}
+                                subscriptionsNotFound={subscriptionsNotFound}
+                                pseudoSubscriptions={pseudoMcpSubscriptions}
+                                onAddClick={this.handleOpenMcpDialog}
+                                handleSubscriptionDelete={this.handleSubscriptionDelete}
+                                handleSubscriptionUpdate={this.handleSubscriptionUpdate}
+                                noSubscriptionsMessage={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.no.mcp.subscriptions'
+                                        defaultMessage='No MCP Server Subscriptions Available'
+                                    />
+                                )}
+                                noSubscriptionsContent={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.no.mcp.subscriptions.content'
+                                        defaultMessage='No MCP server subscriptions are available for this Application'
+                                    />
+                                )}
+                                entityNameColumn={(
+                                    <FormattedMessage
+                                        id='Applications.Details.Subscriptions.mcp.server.name'
+                                        defaultMessage='MCP Server'
+                                    />
+                                )}
+                            />
+                        )}
 
-                        <StyledDialog
-                            onClose={this.handleOpenDialog}
-                            aria-labelledby='simple-dialog-title'
-                            open={openDialog}
-                            fullWidth='true'
-                            maxWidth='sm'
-                            className={classes.subscribePop}
-                        >
-                            <Box className={classes.dialogHeader}>
-                                <MuiDialogTitle className={classes.dialogTitle} disableTypography>
-                                    <Typography variant='h6'>
-                                        <FormattedMessage
-                                            id='Applications.Details.Subscriptions.subscription.subscribe.apis'
-                                            defaultMessage='Subscribe to API(s)'
-                                        />
-                                    </Typography>
-                                </MuiDialogTitle>
-                                <Box className={classes.searchRoot}>
-                                    <Paper
-                                        component='form'
-                                        className={classes.searchBar}
-                                    >
-                                        {searchText && (
-                                            <HighlightOffIcon
-                                                className={classes.clearSearchIcon}
-                                                onClick={this.handleClearSearch}
+                        {apisAccessible && (
+                            <StyledDialog
+                                onClose={this.handleOpenDialog}
+                                aria-labelledby='simple-dialog-title'
+                                open={openDialog}
+                                fullWidth='true'
+                                maxWidth='sm'
+                                className={classes.subscribePop}
+                            >
+                                <Box className={classes.dialogHeader}>
+                                    <MuiDialogTitle className={classes.dialogTitle} disableTypography>
+                                        <Typography variant='h6'>
+                                            <FormattedMessage
+                                                id='Applications.Details.Subscriptions.subscription.subscribe.apis'
+                                                defaultMessage='Subscribe to API(s)'
                                             />
-                                        )}
-                                        <InputBase
-                                            className={classes.input}
-                                            placeholder={intl.formatMessage({
-                                                defaultMessage: 'Search APIs',
-                                                id: 'Applications.Details.Subscriptions.search',
-                                            })}
-                                            inputProps={{
-                                                'aria-label': intl.formatMessage({
+                                        </Typography>
+                                    </MuiDialogTitle>
+                                    <Box className={classes.searchRoot}>
+                                        <Paper
+                                            component='form'
+                                            className={classes.searchBar}
+                                        >
+                                            {searchText && (
+                                                <HighlightOffIcon
+                                                    className={classes.clearSearchIcon}
+                                                    onClick={this.handleClearSearch}
+                                                />
+                                            )}
+                                            <InputBase
+                                                className={classes.input}
+                                                placeholder={intl.formatMessage({
                                                     defaultMessage: 'Search APIs',
                                                     id: 'Applications.Details.Subscriptions.search',
-                                                }),
-                                            }}
-                                            inputRef={(el) => { this.searchInputElem = el; }}
-                                            onChange={this.handleSearchTextTmpChange}
-                                            onKeyDown={this.handleEnterPress}
-                                        />
-                                        <IconButton
-                                            className={classes.iconButton}
-                                            aria-label='search'
-                                            onClick={this.handleSearchTextChange}
-                                            size='large'
-                                        >
-                                            <SearchIcon />
-                                        </IconButton>
-                                    </Paper>
-                                    <Box className={classes.searchResults}>
-                                        {(searchText && searchText !== '') ? (
-                                            <>
+                                                })}
+                                                inputProps={{
+                                                    'aria-label': intl.formatMessage({
+                                                        defaultMessage: 'Search APIs',
+                                                        id: 'Applications.Details.Subscriptions.search',
+                                                    }),
+                                                }}
+                                                inputRef={(el) => { this.searchInputElem = el; }}
+                                                onChange={this.handleSearchTextTmpChange}
+                                                onKeyDown={this.handleEnterPress}
+                                            />
+                                            <IconButton
+                                                className={classes.iconButton}
+                                                aria-label='search'
+                                                onClick={this.handleSearchTextChange}
+                                                size='large'
+                                            >
+                                                <SearchIcon />
+                                            </IconButton>
+                                        </Paper>
+                                        <Box className={classes.searchResults}>
+                                            {(searchText && searchText !== '') ? (
+                                                <>
+                                                    <Typography variant='caption'>
+                                                        <FormattedMessage
+                                                            id='Applications.Details.Subscriptions.filter.msg'
+                                                            defaultMessage='Filtered APIs for'
+                                                        />
+                                                        {` ${searchText}`}
+                                                    </Typography>
+                                                </>
+                                            ) : (
                                                 <Typography variant='caption'>
                                                     <FormattedMessage
-                                                        id='Applications.Details.Subscriptions.filter.msg'
-                                                        defaultMessage='Filtered APIs for'
+                                                        id='Applications.Details.Subscriptions.filter.msg.all.apis'
+                                                        defaultMessage='Displaying all APIs'
                                                     />
-                                                    {` ${searchText}`}
                                                 </Typography>
-                                            </>
-                                        ) : (
-                                            <Typography variant='caption'>
-                                                <FormattedMessage
-                                                    id='Applications.Details.Subscriptions.filter.msg.all.apis'
-                                                    defaultMessage='Displaying all APIs'
-                                                />
-                                            </Typography>
-                                        )}
+                                            )}
+                                        </Box>
                                     </Box>
-                                </Box>
-                                <IconButton
-                                    aria-label='close'
-                                    className={classes.closeButton}
-                                    onClick={this.handleOpenDialog}
-                                    size='large'
-                                >
-                                    <Icon>cancel</Icon>
-                                </IconButton>
-                            </Box>
-                            <Box padding={2}>
-                                <APIList
-                                    apisNotFound={apisNotFound}
-                                    subscriptions={apiSubscriptions || []}
-                                    applicationId={applicationId}
-                                    handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
-                                    searchText={searchText}
-                                />
-                            </Box>
-                        </StyledDialog>
-
-                        <StyledDialog
-                            onClose={this.handleOpenMcpDialog}
-                            aria-labelledby='mcp-dialog-title'
-                            open={openMcpDialog}
-                            fullWidth='true'
-                            maxWidth='sm'
-                            className={classes.subscribePop}
-                        >
-                            <Box className={classes.dialogHeader}>
-                                <MuiDialogTitle className={classes.dialogTitle} disableTypography>
-                                    <Typography variant='h6'>
-                                        <FormattedMessage
-                                            id='Applications.Details.Subscriptions.subscription.subscribe.mcp.servers'
-                                            defaultMessage='Subscribe to MCP Server(s)'
-                                        />
-                                    </Typography>
-                                </MuiDialogTitle>
-                                <Box className={classes.searchRoot}>
-                                    <Paper
-                                        component='form'
-                                        className={classes.searchBar}
+                                    <IconButton
+                                        aria-label='close'
+                                        className={classes.closeButton}
+                                        onClick={this.handleOpenDialog}
+                                        size='large'
                                     >
-                                        {searchText && (
-                                            <HighlightOffIcon
-                                                className={classes.clearSearchIcon}
-                                                onClick={this.handleClearSearch}
+                                        <Icon>cancel</Icon>
+                                    </IconButton>
+                                </Box>
+                                <Box padding={2}>
+                                    <APIList
+                                        apisNotFound={apisNotFound}
+                                        subscriptions={apiSubscriptions || []}
+                                        applicationId={applicationId}
+                                        handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
+                                        searchText={searchText}
+                                    />
+                                </Box>
+                            </StyledDialog>
+                        )}
+
+                        {mcpServersAccessible && (
+                            <StyledDialog
+                                onClose={this.handleOpenMcpDialog}
+                                aria-labelledby='mcp-dialog-title'
+                                open={openMcpDialog}
+                                fullWidth='true'
+                                maxWidth='sm'
+                                className={classes.subscribePop}
+                            >
+                                <Box className={classes.dialogHeader}>
+                                    <MuiDialogTitle className={classes.dialogTitle} disableTypography>
+                                        <Typography variant='h6'>
+                                            <FormattedMessage
+                                                id='Applications.Details.Subscriptions.subscription.subscribe.mcp.servers'
+                                                defaultMessage='Subscribe to MCP Server(s)'
                                             />
-                                        )}
-                                        <InputBase
-                                            className={classes.input}
-                                            placeholder={intl.formatMessage({
-                                                defaultMessage: 'Search MCP Servers',
-                                                id: 'Applications.Details.Subscriptions.search.mcp',
-                                            })}
-                                            inputProps={{
-                                                'aria-label': intl.formatMessage({
+                                        </Typography>
+                                    </MuiDialogTitle>
+                                    <Box className={classes.searchRoot}>
+                                        <Paper
+                                            component='form'
+                                            className={classes.searchBar}
+                                        >
+                                            {searchText && (
+                                                <HighlightOffIcon
+                                                    className={classes.clearSearchIcon}
+                                                    onClick={this.handleClearSearch}
+                                                />
+                                            )}
+                                            <InputBase
+                                                className={classes.input}
+                                                placeholder={intl.formatMessage({
                                                     defaultMessage: 'Search MCP Servers',
                                                     id: 'Applications.Details.Subscriptions.search.mcp',
-                                                }),
-                                            }}
-                                            inputRef={(el) => { this.searchInputElem = el; }}
-                                            onChange={this.handleSearchTextTmpChange}
-                                            onKeyDown={this.handleEnterPress}
-                                        />
-                                        <IconButton
-                                            className={classes.iconButton}
-                                            aria-label='search'
-                                            onClick={this.handleSearchTextChange}
-                                            size='large'
-                                        >
-                                            <SearchIcon />
-                                        </IconButton>
-                                    </Paper>
-                                    <Box className={classes.searchResults}>
-                                        {(searchText && searchText !== '') ? (
-                                            <>
+                                                })}
+                                                inputProps={{
+                                                    'aria-label': intl.formatMessage({
+                                                        defaultMessage: 'Search MCP Servers',
+                                                        id: 'Applications.Details.Subscriptions.search.mcp',
+                                                    }),
+                                                }}
+                                                inputRef={(el) => { this.searchInputElem = el; }}
+                                                onChange={this.handleSearchTextTmpChange}
+                                                onKeyDown={this.handleEnterPress}
+                                            />
+                                            <IconButton
+                                                className={classes.iconButton}
+                                                aria-label='search'
+                                                onClick={this.handleSearchTextChange}
+                                                size='large'
+                                            >
+                                                <SearchIcon />
+                                            </IconButton>
+                                        </Paper>
+                                        <Box className={classes.searchResults}>
+                                            {(searchText && searchText !== '') ? (
+                                                <>
+                                                    <Typography variant='caption'>
+                                                        <FormattedMessage
+                                                            id='Applications.Details.Subscriptions.filter.mcp.msg'
+                                                            defaultMessage='Filtered MCP Servers for'
+                                                        />
+                                                        {` ${searchText}`}
+                                                    </Typography>
+                                                </>
+                                            ) : (
                                                 <Typography variant='caption'>
                                                     <FormattedMessage
-                                                        id='Applications.Details.Subscriptions.filter.mcp.msg'
-                                                        defaultMessage='Filtered MCP Servers for'
+                                                        id='Applications.Details.Subscriptions.filter.msg.all.mcp'
+                                                        defaultMessage='Displaying all MCP Servers'
                                                     />
-                                                    {` ${searchText}`}
                                                 </Typography>
-                                            </>
-                                        ) : (
-                                            <Typography variant='caption'>
-                                                <FormattedMessage
-                                                    id='Applications.Details.Subscriptions.filter.msg.all.mcp'
-                                                    defaultMessage='Displaying all MCP Servers'
-                                                />
-                                            </Typography>
-                                        )}
+                                            )}
+                                        </Box>
                                     </Box>
+                                    <IconButton
+                                        aria-label='close'
+                                        className={classes.closeButton}
+                                        onClick={this.handleOpenMcpDialog}
+                                        size='large'
+                                    >
+                                        <Icon>cancel</Icon>
+                                    </IconButton>
                                 </Box>
-                                <IconButton
-                                    aria-label='close'
-                                    className={classes.closeButton}
-                                    onClick={this.handleOpenMcpDialog}
-                                    size='large'
-                                >
-                                    <Icon>cancel</Icon>
-                                </IconButton>
-                            </Box>
-                            <Box padding={2}>
-                                <APIList
-                                    apisNotFound={apisNotFound}
-                                    subscriptions={mcpSubscriptions || []}
-                                    applicationId={applicationId}
-                                    handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
-                                    searchText={searchText}
-                                    entityType='mcp'
-                                />
-                            </Box>
-                        </StyledDialog>
+                                <Box padding={2}>
+                                    <APIList
+                                        apisNotFound={apisNotFound}
+                                        subscriptions={mcpSubscriptions || []}
+                                        applicationId={applicationId}
+                                        handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
+                                        searchText={searchText}
+                                        entityType='mcp'
+                                    />
+                                </Box>
+                            </StyledDialog>
+                        )}
                     </Box>
                 </Root>
             );
@@ -868,7 +879,8 @@ class Subscriptions extends React.Component {
         }
     }
 }
-Subscriptions.propTypes = {
+
+SubscriptionsBase.propTypes = {
     application: PropTypes.shape({
         applicationId: PropTypes.string.isRequired,
     }).isRequired,
@@ -876,6 +888,33 @@ Subscriptions.propTypes = {
     intl: PropTypes.shape({
         formatMessage: PropTypes.func.isRequired,
     }).isRequired,
+    apisAccessible: PropTypes.bool.isRequired,
+    mcpServersAccessible: PropTypes.bool.isRequired,
 };
 
-export default injectIntl((Subscriptions));
+/**
+ * Wrapper component that provides portal mode accessibility to SubscriptionsBase
+ * @param {Object} props - Component props
+ * @returns {React.ReactElement} SubscriptionsBase with portal mode props
+ */
+const Subscriptions = (props) => {
+    const apisAccessible = useAreApisAccessible();
+    const mcpServersAccessible = useAreMcpServersAccessible();
+
+    return (
+        <SubscriptionsBase
+            {...props}
+            apisAccessible={apisAccessible}
+            mcpServersAccessible={mcpServersAccessible}
+        />
+    );
+};
+
+Subscriptions.propTypes = {
+    application: PropTypes.shape({
+        applicationId: PropTypes.string.isRequired,
+    }).isRequired,
+    getApplication: PropTypes.func.isRequired,
+};
+
+export default injectIntl(Subscriptions);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFound.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFound.jsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { FormattedMessage } from 'react-intl';
@@ -25,8 +26,12 @@ import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Image404 from './Custom404Image';
+import { useAreApisAccessible, useAreMcpServersAccessible } from '../../../utils/PortalModeUtils';
 
-const ResourceNotFound = (props) => {
+const ResourceNotFound = ({ response, message }) => {
+    const apisAccessible = useAreApisAccessible();
+    const mcpServersAccessible = useAreMcpServersAccessible();
+
     return (
         <Container maxWidth='md'>
             <Box padding={4}>
@@ -35,19 +40,27 @@ const ResourceNotFound = (props) => {
                         <Grid container alignItems='center' justifyContent='center' style={{ height: '100%' }}>
                             <Grid item xs={12} md={6}>
                                 <Typography variant='h5' gutterBottom>
-                                    <FormattedMessage
-                                        id='Base.Errors.ResourceNotfound.default_tittle'
-                                        defaultMessage='Page Not Found'
-                                    />
+                                    {message && message.title ? (
+                                        message.title
+                                    ) : (
+                                        <FormattedMessage
+                                            id='Base.Errors.ResourceNotfound.default_tittle'
+                                            defaultMessage='Page Not Found'
+                                        />
+                                    )}
                                 </Typography>
                                 <Typography variant='subtitle1' gutterBottom>
-                                    <FormattedMessage
-                                        id='Base.Errors.ResourceNotfound.default_body'
-                                        defaultMessage='The page you are looking for is not available'
-                                    />
+                                    {message && message.body ? (
+                                        message.body
+                                    ) : (
+                                        <FormattedMessage
+                                            id='Base.Errors.ResourceNotfound.default_body'
+                                            defaultMessage='The page you are looking for is not available'
+                                        />
+                                    )}
                                     <span style={{ color: 'green' }}>
                                         {' '}
-                                        {props.response ? props.response.statusText : ''}
+                                        {response ? response.statusText : ''}
                                         {' '}
                                     </span>
                                 </Typography>
@@ -60,14 +73,26 @@ const ResourceNotFound = (props) => {
                                             />
                                         </Typography>
                                     </Box>
-                                    <Link to='/apis/' style={{ marginRight: 8 }}>
-                                        <Button variant='contained' color='primary'>
-                                            <FormattedMessage
-                                                id='Base.Errors.ResourceNotFound.api.list'
-                                                defaultMessage='API List'
-                                            />
-                                        </Button>
-                                    </Link>
+                                    {apisAccessible && (
+                                        <Link to='/apis/' style={{ marginRight: 8 }}>
+                                            <Button variant='contained' color='primary'>
+                                                <FormattedMessage
+                                                    id='Base.Errors.ResourceNotFound.api.list'
+                                                    defaultMessage='API List'
+                                                />
+                                            </Button>
+                                        </Link>
+                                    )}
+                                    {mcpServersAccessible && (
+                                        <Link to='/mcp-servers/' style={{ marginRight: 8 }}>
+                                            <Button variant='contained' color='primary'>
+                                                <FormattedMessage
+                                                    id='Base.Errors.ResourceNotFound.mcp.list'
+                                                    defaultMessage='MCP Server List'
+                                                />
+                                            </Button>
+                                        </Link>
+                                    )}
                                     <Link to='/applications/'>
                                         <Button variant='contained' color='primary'>
                                             <FormattedMessage
@@ -88,6 +113,21 @@ const ResourceNotFound = (props) => {
             </Box>
         </Container>
     );
+};
+
+ResourceNotFound.propTypes = {
+    response: PropTypes.shape({
+        statusText: PropTypes.string,
+    }),
+    message: PropTypes.shape({
+        title: PropTypes.string,
+        body: PropTypes.string,
+    }),
+};
+
+ResourceNotFound.defaultProps = {
+    response: null,
+    message: null,
 };
 
 export default ResourceNotFound;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Base/Header/GlobalNavbar.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Base/Header/GlobalNavbar.jsx
@@ -26,6 +26,7 @@ import {
 } from '@mui/material';
 import AuthManager from 'AppData/AuthManager';
 import CustomIcon from '../../Shared/CustomIcon';
+import { useAreApisAccessible, useAreMcpServersAccessible } from '../../../utils/PortalModeUtils';
 
 /**
  * GlobalNavBar
@@ -39,7 +40,9 @@ function GlobalNavBar(props) {
     const theme = useTheme();
     const { custom: { landingPage: { active: landingPageActive, activeForAnonymous } } } = theme;
     const isUserFound = AuthManager.getUser();
-    React.useEffect(() => {}, [selected]);
+    const apisAccessible = useAreApisAccessible();
+    const mcpServersAccessible = useAreMcpServersAccessible();
+
     return (
         <List className={classes.listRootInline} component='nav' aria-label='primary navigation' role='navigation'>
             {landingPageActive && ((isUserFound && !activeForAnonymous) || activeForAnonymous)
@@ -87,86 +90,90 @@ function GlobalNavBar(props) {
                         {(selected === 'home' && !drawerView) && (<div className={classes.triangleDown} />)}
                     </Link>
                 ) }
-            <Link
-                data-testid='itest-link-to-apis'
-                to={(theme.custom.tagWise.active && theme.custom.tagWise.style === 'page') ? '/api-groups' : '/apis'}
-                className={classNames({
-                    [classes.selected]: selected === 'apis',
-                    // eslint-disable-next-line quote-props
-                    'selected': selected === 'apis',
-                    [classes.links]: true,
-                }, 'header-link')}
-            >
-                <ListItem component='div' classes={{ root: classes.listItemRoot }}>
-                    <ListItemIcon classes={{
-                        root: classNames({ [classes.smallIcon]: !drawerView },
-                            'heder-menu-icon-apis', 'header-menu-icon'),
-                    }}
-                    >
-                        <CustomIcon
-                            width={iconWidth}
-                            height={iconWidth}
-                            icon='api'
-                            className={classes.listText}
-                            strokeColor={selected === 'apis' ? strokeColorSelected : strokeColor}
-                        />
-                    </ListItemIcon>
-                    <ListItemText
-                        classes={{
-                            root: classes.listItemTextRoot,
-                            primary: classNames({
-                                [classes.selectedText]: selected === 'apis',
-                                [classes.listText]: selected !== 'apis',
-                            }),
+            {apisAccessible && (
+                <Link
+                    data-testid='itest-link-to-apis'
+                    to={(theme.custom.tagWise.active && theme.custom.tagWise.style === 'page') ? '/api-groups' : '/apis'}
+                    className={classNames({
+                        [classes.selected]: selected === 'apis',
+                        // eslint-disable-next-line quote-props
+                        'selected': selected === 'apis',
+                        [classes.links]: true,
+                    }, 'header-link')}
+                >
+                    <ListItem component='div' classes={{ root: classes.listItemRoot }}>
+                        <ListItemIcon classes={{
+                            root: classNames({ [classes.smallIcon]: !drawerView },
+                                'heder-menu-icon-apis', 'header-menu-icon'),
                         }}
-                        primary={intl.formatMessage({
-                            id: 'Base.Header.GlobalNavbar.menu.apis',
-                            defaultMessage: 'APIs',
-                        })}
-                    />
-                </ListItem>
-                {(selected === 'apis' && !drawerView) && (<div className={classes.triangleDown} />)}
-            </Link>
-            <Link
-                data-testid='itest-link-to-mcp-servers'
-                to={(theme.custom.tagWise.active && theme.custom.tagWise.style === 'page') ? '/api-groups' : '/mcp-servers'}
-                className={classNames({
-                    [classes.selected]: selected === 'mcp-servers',
-                    // eslint-disable-next-line quote-props
-                    'selected': selected === 'mcp-servers',
-                    [classes.links]: true,
-                }, 'header-link')}
-            >
-                <ListItem component='div' classes={{ root: classes.listItemRoot }}>
-                    <ListItemIcon classes={{
-                        root: classNames({ [classes.smallIcon]: !drawerView },
-                            'heder-menu-icon-mcp-servers', 'header-menu-icon'),
-                    }}
-                    >
-                        <CustomIcon
-                            width={iconWidth}
-                            height={iconWidth}
-                            icon='mcp-server'
-                            className={classes.listText}
-                            strokeColor={selected === 'mcp-servers' ? strokeColorSelected : strokeColor}
+                        >
+                            <CustomIcon
+                                width={iconWidth}
+                                height={iconWidth}
+                                icon='api'
+                                className={classes.listText}
+                                strokeColor={selected === 'apis' ? strokeColorSelected : strokeColor}
+                            />
+                        </ListItemIcon>
+                        <ListItemText
+                            classes={{
+                                root: classes.listItemTextRoot,
+                                primary: classNames({
+                                    [classes.selectedText]: selected === 'apis',
+                                    [classes.listText]: selected !== 'apis',
+                                }),
+                            }}
+                            primary={intl.formatMessage({
+                                id: 'Base.Header.GlobalNavbar.menu.apis',
+                                defaultMessage: 'APIs',
+                            })}
                         />
-                    </ListItemIcon>
-                    <ListItemText
-                        classes={{
-                            root: classes.listItemTextRoot,
-                            primary: classNames({
-                                [classes.selectedText]: selected === 'mcp-servers',
-                                [classes.listText]: selected !== 'mcp-servers',
-                            }),
+                    </ListItem>
+                    {(selected === 'apis' && !drawerView) && (<div className={classes.triangleDown} />)}
+                </Link>
+            )}
+            {mcpServersAccessible && (
+                <Link
+                    data-testid='itest-link-to-mcp-servers'
+                    to={(theme.custom.tagWise.active && theme.custom.tagWise.style === 'page') ? '/api-groups' : '/mcp-servers'}
+                    className={classNames({
+                        [classes.selected]: selected === 'mcp-servers',
+                        // eslint-disable-next-line quote-props
+                        'selected': selected === 'mcp-servers',
+                        [classes.links]: true,
+                    }, 'header-link')}
+                >
+                    <ListItem component='div' classes={{ root: classes.listItemRoot }}>
+                        <ListItemIcon classes={{
+                            root: classNames({ [classes.smallIcon]: !drawerView },
+                                'heder-menu-icon-mcp-servers', 'header-menu-icon'),
                         }}
-                        primary={intl.formatMessage({
-                            id: 'Base.Header.GlobalNavbar.menu.mcpServers',
-                            defaultMessage: 'MCP Servers',
-                        })}
-                    />
-                </ListItem>
-                {(selected === 'mcp-servers' && !drawerView) && (<div className={classes.triangleDown} />)}
-            </Link>
+                        >
+                            <CustomIcon
+                                width={iconWidth}
+                                height={iconWidth}
+                                icon='mcp-server'
+                                className={classes.listText}
+                                strokeColor={selected === 'mcp-servers' ? strokeColorSelected : strokeColor}
+                            />
+                        </ListItemIcon>
+                        <ListItemText
+                            classes={{
+                                root: classes.listItemTextRoot,
+                                primary: classNames({
+                                    [classes.selectedText]: selected === 'mcp-servers',
+                                    [classes.listText]: selected !== 'mcp-servers',
+                                }),
+                            }}
+                            primary={intl.formatMessage({
+                                id: 'Base.Header.GlobalNavbar.menu.mcpServers',
+                                defaultMessage: 'MCP Servers',
+                            })}
+                        />
+                    </ListItem>
+                    {(selected === 'mcp-servers' && !drawerView) && (<div className={classes.triangleDown} />)}
+                </Link>
+            )}
             <Link
                 id='itest-link-to-applications'
                 to='/applications'

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/PortalModeRouteGuard.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/PortalModeRouteGuard.jsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
+import { ResourceNotFound } from 'AppComponents/Base/Errors';
+import { usePortalMode, PORTAL_MODES } from '../../utils/PortalModeUtils';
+
+/**
+ * Route guard component that blocks access based on portal mode
+ * @param {Object} props - Component props
+ * @param {React.ReactNode} props.children - Child components to render if access is allowed
+ * @returns {React.ReactNode} Either children or ResourceNotFound component
+ */
+const PortalModeRouteGuard = ({ children }) => {
+    const portalMode = usePortalMode();
+    const location = useLocation();
+    const currentPath = location.pathname;
+
+    // Check if current path should be blocked based on portal mode
+    const getBlockedResourceInfo = () => {
+        // Block /apis routes in MCP_ONLY mode
+        if (portalMode === PORTAL_MODES.MCP_ONLY && currentPath.startsWith('/apis')) {
+            return {
+                blocked: true,
+                title: 'APIs Not Available',
+                body: 'API access is not available in this portal mode.',
+            };
+        }
+
+        // Block /mcp-servers routes in API_ONLY mode
+        if (portalMode === PORTAL_MODES.API_ONLY && currentPath.startsWith('/mcp-servers')) {
+            return {
+                blocked: true,
+                title: 'MCP Servers Not Available',
+                body: 'MCP Server access is not available in this portal mode.',
+            };
+        }
+
+        return { blocked: false };
+    };
+
+    const blockedInfo = getBlockedResourceInfo();
+
+    if (blockedInfo.blocked) {
+        return (
+            <ResourceNotFound
+                message={{
+                    title: blockedInfo.title,
+                    body: blockedInfo.body,
+                }}
+            />
+        );
+    }
+
+    return children;
+};
+
+PortalModeRouteGuard.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default PortalModeRouteGuard;

--- a/portals/devportal/src/main/webapp/source/src/app/utils/PortalModeUtils.js
+++ b/portals/devportal/src/main/webapp/source/src/app/utils/PortalModeUtils.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useSettingsContext } from 'AppComponents/Shared/SettingsContext';
+
+/**
+ * Portal mode constants
+ */
+export const PORTAL_MODES = {
+    HYBRID: 'HYBRID',
+    API_ONLY: 'API_ONLY',
+    MCP_ONLY: 'MCP_ONLY',
+};
+
+/**
+ * Extracts portal mode from settings response
+ * @param {Object} settings - Settings response body
+ * @returns {string} Portal mode
+ */
+export const extractPortalMode = (settings) => {
+    // Check if devportalMode exists in settings
+    if (settings && settings.devportalMode) {
+        const mode = settings.devportalMode.toUpperCase();
+        if (Object.values(PORTAL_MODES).includes(mode)) {
+            return mode;
+        }
+    }
+
+    // Default to HYBRID if devportalMode is not set or invalid
+    return PORTAL_MODES.HYBRID;
+};
+
+/**
+ * Checks if APIs are accessible in the current portal mode
+ * @param {string} portalMode - Current portal mode
+ * @returns {boolean} True if APIs are accessible
+ */
+export const areApisAccessible = (portalMode) => {
+    return portalMode === PORTAL_MODES.HYBRID || portalMode === PORTAL_MODES.API_ONLY;
+};
+
+/**
+ * Checks if MCP servers are accessible in the current portal mode
+ * @param {string} portalMode - Current portal mode
+ * @returns {boolean} True if MCP servers are accessible
+ */
+export const areMcpServersAccessible = (portalMode) => {
+    return portalMode === PORTAL_MODES.HYBRID || portalMode === PORTAL_MODES.MCP_ONLY;
+};
+
+/**
+ * Custom hook to get portal mode from settings context
+ * @returns {string} Portal mode
+ */
+export const usePortalMode = () => {
+    const { settings } = useSettingsContext();
+    return extractPortalMode(settings);
+};
+
+/**
+ * Custom hook to check if APIs are accessible
+ * @returns {boolean} True if APIs are accessible
+ */
+export const useAreApisAccessible = () => {
+    const portalMode = usePortalMode();
+    return areApisAccessible(portalMode);
+};
+
+/**
+ * Custom hook to check if MCP servers are accessible
+ * @returns {boolean} True if MCP servers are accessible
+ */
+export const useAreMcpServersAccessible = () => {
+    const portalMode = usePortalMode();
+    return areMcpServersAccessible(portalMode);
+};

--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -2219,6 +2219,7 @@
   "Publisher.Landing.delete.dialog.content": "{type} {name} will be deleted permanently. This action cannot be undone.",
   "Publisher.Landing.delete.dialog.delete": "Delete",
   "Publisher.Landing.delete.dialog.title": "Delete {type}",
+  "Publisher.Landing.description": "Let's get started!",
   "Publisher.Landing.error.title": "Error Loading Data",
   "Publisher.Landing.mcpServers.section.title": "MCP Servers",
   "Publisher.Landing.no.api.products.message": "No API Products found. Create your first API Product to get started.",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
@@ -20,6 +20,7 @@ import React, { Suspense, lazy } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import Progress from 'AppComponents/Shared/Progress';
 import AuthManager from 'AppData/AuthManager';
+import MCPRouteGuard from 'AppComponents/Shared/MCPRouteGuard';
 
 import Listing from './Listing/Listing';
 import APICreateWithAI from './Create/CreateAPIWithAI/APICreateWithAI';
@@ -72,7 +73,11 @@ const Apis = () => {
                 exact
                 path='/mcp-servers'
                 key={Date.now()}
-                render={(props) => <Listing {...props} isMCPServer />}
+                render={(props) => (
+                    <MCPRouteGuard>
+                        <Listing {...props} isMCPServer />
+                    </MCPRouteGuard>
+                )}
             />
             <Route path='/apis/search' render={(props) => <Listing {...props} isAPIProduct={false} />} />
             <Route path='/apis/create' component={DeferredAPICreateRoutes} />
@@ -87,7 +92,14 @@ const Apis = () => {
                     }
                 }}
             />
-            <Route path='/mcp-servers/create' component={DeferredAPICreateRoutes} />
+            <Route 
+                path='/mcp-servers/create' 
+                render={(props) => (
+                    <MCPRouteGuard>
+                        <DeferredAPICreateRoutes {...props} />
+                    </MCPRouteGuard>
+                )}
+            />
             <Route path='/apis/:apiUUID/' render={(props) => <DeferredDetails {...props} isAPIProduct={false} />} />
             <Route
                 path='/api-products/:apiProdUUID/'
@@ -97,7 +109,11 @@ const Apis = () => {
             />
             <Route
                 path='/mcp-servers/:mcpServerUUID/'
-                render={(props) => <DeferredDetails {...props} isMCPServer />}
+                render={(props) => (
+                    <MCPRouteGuard>
+                        <DeferredDetails {...props} isMCPServer />
+                    </MCPRouteGuard>
+                )}
             />
         </Switch>
     );

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -21,6 +21,7 @@ import { Route, Switch } from 'react-router-dom';
 import ResourceNotFound from 'AppComponents/Base/Errors/ResourceNotFound';
 import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import { Progress } from 'AppComponents/Shared';
+import MCPRouteGuard from 'AppComponents/Shared/MCPRouteGuard';
 import APILanding from 'AppComponents/Apis/Listing/Landing';
 import MCPServerLanding from 'AppComponents/MCPServers/Landing';
 import MCPServerCreateDefault from 'AppComponents/MCPServers/Create/MCPServerCreateDefault';
@@ -164,22 +165,38 @@ function APICreateRoutes() {
                 <Route
                     exact
                     path='/mcp-servers/create'
-                    component={MCPServerLanding}
+                    render={(props) => (
+                        <MCPRouteGuard>
+                            <MCPServerLanding {...props} />
+                        </MCPRouteGuard>
+                    )}
                 />
                 <Route
                     path='/mcp-servers/create/import-api-definition'
-                    component={WithSomeValue(MCPServerCreateDefault, { multiGateway: apiTypes?.ws
-                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                    render={(props) => (
+                        <MCPRouteGuard>
+                            {WithSomeValue(MCPServerCreateDefault, { multiGateway: apiTypes?.ws
+                                .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })(props)}
+                        </MCPRouteGuard>
+                    )}
                 />
                 <Route
                     path='/mcp-servers/create/mcp-from-existing-api'
-                    component={WithSomeValue(MCPServerCreateUsingExistingAPI, { multiGateway: apiTypes?.ws
-                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                    render={(props) => (
+                        <MCPRouteGuard>
+                            {WithSomeValue(MCPServerCreateUsingExistingAPI, { multiGateway: apiTypes?.ws
+                                .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })(props)}
+                        </MCPRouteGuard>
+                    )}
                 />
                 <Route
                     path='/mcp-servers/create/mcp-proxy-from-endpoint'
-                    component={WithSomeValue(MCPServerCreateProxy, { multiGateway: apiTypes?.ws
-                        .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })}
+                    render={(props) => (
+                        <MCPRouteGuard>
+                            {WithSomeValue(MCPServerCreateProxy, { multiGateway: apiTypes?.ws
+                                .filter(t=>gatewayTypes.includes(t)).map(type => gatewayDetails[type]) })(props)}
+                        </MCPRouteGuard>
+                    )}
                 />
                 <Route component={ResourceNotFound} />
             </Switch>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/APIDetailsTopMenu.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/components/APIDetailsTopMenu.jsx
@@ -512,7 +512,7 @@ const APIDetailsTopMenu = (props) => {
                         </Typography>
                     </a>
                 )}
-                {api.type === 'HTTP' && (() => {
+                {(settings && settings.isMCPSupportEnabled) && api.type === 'HTTP' && (() => {
                     const mcpServerUrl = `/mcp-servers/create/mcp-from-existing-api?apiId=${api.id}`;
                     return (
                         <>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFound.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFound.jsx
@@ -10,7 +10,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY   
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
@@ -26,11 +26,14 @@ import { Link } from 'react-router-dom';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 import Image404 from './Custom404Image';
 
 const ResourceNotFound = (props) => {
     const { response } = props;
     const { message = {} } = props;
+    const { data: settings } = usePublisherSettings();
+    const isMCPSupportEnabled = settings && settings.isMCPSupportEnabled;
 
     return <>
         <Container maxWidth='md'>
@@ -68,14 +71,16 @@ const ResourceNotFound = (props) => {
                                             />
                                         </Button>
                                     </Link>
-                                    <Link to='/mcp-servers/' style={{ marginRight: 8 }}>
-                                        <Button variant='contained' color='primary'>
-                                            <FormattedMessage
-                                                id='Base.Errors.ResourceNotFound.mcp.server.list'
-                                                defaultMessage='MCP Server List'
-                                            />
-                                        </Button>
-                                    </Link>
+                                    {isMCPSupportEnabled && (
+                                        <Link to='/mcp-servers/' style={{ marginRight: 8 }}>
+                                            <Button variant='contained' color='primary'>
+                                                <FormattedMessage
+                                                    id='Base.Errors.ResourceNotFound.mcp.server.list'
+                                                    defaultMessage='MCP Server List'
+                                                />
+                                            </Button>
+                                        </Link>
+                                    )}
                                     <Link to='/api-products/'>
                                         <Button variant='contained' color='primary'>
                                             <FormattedMessage

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFoundError.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Errors/ResourceNotFoundError.tsx
@@ -26,6 +26,7 @@ import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Image404 from './Custom404Image';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
 
 interface ResourceNotFoundErrorProps {
     message?: {
@@ -35,6 +36,8 @@ interface ResourceNotFoundErrorProps {
 }
 
 const ResourceNotFoundError: FC<ResourceNotFoundErrorProps> = ({ message }) => {
+    const { data: settings } = usePublisherSettings();
+    const isMCPSupportEnabled = settings && (settings as any).isMCPSupportEnabled;
 
     return (
         <>
@@ -77,14 +80,16 @@ const ResourceNotFoundError: FC<ResourceNotFoundErrorProps> = ({ message }) => {
                                                 />
                                             </Button>
                                         </Link>
-                                        <Link to='/mcp-servers/' style={{ marginRight: 8 }}>
-                                            <Button variant='contained' color='primary'>
-                                                <FormattedMessage
-                                                    id='Base.Errors.ResourceNotFound.mcp.server.list'
-                                                    defaultMessage='MCP Server List'
-                                                />
-                                            </Button>
-                                        </Link>
+                                        {isMCPSupportEnabled && (
+                                            <Link to='/mcp-servers/' style={{ marginRight: 8 }}>
+                                                <Button variant='contained' color='primary'>
+                                                    <FormattedMessage
+                                                        id='Base.Errors.ResourceNotFound.mcp.server.list'
+                                                        defaultMessage='MCP Server List'
+                                                    />
+                                                </Button>
+                                            </Link>
+                                        )}
                                         <Link to='/api-products/'>
                                             <Button variant='contained' color='primary'>
                                                 <FormattedMessage

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
@@ -63,6 +63,7 @@ function GlobalNavLinks(props) {
     const theme = useTheme();
     const intl = useIntl();
     const { data: settings } = usePublisherSettings();
+    const isMCPSupportEnabled = settings && settings.isMCPSupportEnabled;
     const [gateway, setGatewayType] = useState(true);
     
     const getGatewayType = () => {
@@ -114,20 +115,22 @@ function GlobalNavLinks(props) {
                         defaultMessage='APIs'
                     />
                 </GlobalNavLink>
-                <GlobalNavLink
-                    to='/mcp-servers'
-                    type='mcp-servers'
-                    title={intl.formatMessage({
-                        id: 'Base.Header.navbar.GlobalNavBar.title.mcp.servers',
-                        defaultMessage: 'MCP Servers',
-                    })}
-                    active={selected === 'mcp-servers'}
-                >
-                    <FormattedMessage
-                        id='Base.Header.navbar.GlobalNavBar.mcp.servers'
-                        defaultMessage='MCP Servers'
-                    />
-                </GlobalNavLink>
+                {isMCPSupportEnabled && (
+                    <GlobalNavLink
+                        to='/mcp-servers'
+                        type='mcp-servers'
+                        title={intl.formatMessage({
+                            id: 'Base.Header.navbar.GlobalNavBar.title.mcp.servers',
+                            defaultMessage: 'MCP Servers',
+                        })}
+                        active={selected === 'mcp-servers'}
+                    >
+                        <FormattedMessage
+                            id='Base.Header.navbar.GlobalNavBar.mcp.servers'
+                            defaultMessage='MCP Servers'
+                        />
+                    </GlobalNavLink>
+                )}
                 {gateway && (settings && !settings.portalConfigurationOnlyModeEnabled) && (
                     <div>
                         <GlobalNavLink

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/MCPRouteGuard.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/MCPRouteGuard.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ResourceNotFoundError from 'AppComponents/Base/Errors/ResourceNotFoundError';
+import { usePublisherSettings } from 'AppComponents/Shared/AppContext';
+
+/**
+ * Route guard component that checks if MCP support is enabled
+ * If MCP support is disabled, it renders a 404 page
+ * @param {Object} props - Component props
+ * @param {React.Component} props.children - Child component to render if MCP is enabled
+ * @returns {JSX.Element} Component or 404 page
+ */
+const MCPRouteGuard = ({ children }) => {
+    const { data: settings } = usePublisherSettings();
+    const isMCPSupportEnabled = settings && settings.isMCPSupportEnabled;
+
+    if (!isMCPSupportEnabled) {
+        const resourceNotFoundMessage = {
+            title: 'MCP Support Disabled',
+            body: 'MCP support is not enabled in this environment.',
+        };
+        return <ResourceNotFoundError message={resourceNotFoundMessage} />;
+    }
+
+    return children;
+};
+
+MCPRouteGuard.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default MCPRouteGuard;


### PR DESCRIPTION
### Purpose

This PR handles the MCP Server support enabled and disabled flows.

#### [Publisher Portal]

- When MCP Support is **disabled**

<img width="1437" height="744" alt="image" src="https://github.com/user-attachments/assets/9ff35ee4-d9fb-4768-9f90-ec518ad12182" />

- When MCP Support is **enabled**
<img width="1437" height="744" alt="image" src="https://github.com/user-attachments/assets/2687f797-ff4b-4ad2-96f3-8f095f1c4954" />

#### [Developer Portal]
There are 3 portal modes that need to be taken into consideration. Namely, `API_ONLY`, `MCP_ONLY` and `HYBRID`.

- HYBRID mode

<img width="1437" height="744" alt="image" src="https://github.com/user-attachments/assets/186b44e0-9006-4abb-9dbb-d95e5f505563" />

- API_ONLY mode

<img width="1437" height="590" alt="image" src="https://github.com/user-attachments/assets/4eb16d2a-89f6-481d-8e41-db4bdf486632" />

- MCP_ONLY mode

<img width="1437" height="744" alt="image" src="https://github.com/user-attachments/assets/eafcf326-abec-4bdf-a94c-f3d9f6006278" />

