### PR TITLE
Add gateway table sorting and fix MCP route remounting issue

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGatewayInstances.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGatewayInstances.jsx
@@ -140,6 +140,10 @@ export default function ListGatewayInstances({
         viewColumns: false,
         customToolbar: false,
         responsive: 'stacked',
+        sortOrder: {
+            name: 'lastActive',
+            direction: 'desc',
+        },
         textLabels: {
             body: {
                 noMatch: intl.formatMessage({

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -1201,7 +1201,7 @@ class Details extends Component {
                                     />
                                     <Route
                                         path={Details.subPaths.ENVIRONMENTS_MCP}
-                                        component={() => <Environments api={api} />}
+                                        render={(props) => <Environments {...props} api={api} />}
                                     />
                                     <Route
                                         path={Details.subPaths.OPERATIONS}


### PR DESCRIPTION
## Summary
This PR adds default sorting functionality to the Gateway Instances table and fixes a route props issue for MCP environments to prevent unnecessary component remounting.

## Changes Made
### 🔧 Gateway Instances Table Enhancement
- Added default sorting by **Last Active** column in descending order
- Most recently active gateways now appear at the top by default
- Users can still manually sort by any column as needed

### 🐛 MCP Route Fix  
- Fixed route props passing for MCP environments page to avoid unmount and remount cycles
- Changed from `component` to `render` prop to prevent component recreation during API deployment polling

**Related Issues:**
- [wso2-apim-internal#9923](https://github.com/wso2-enterprise/wso2-apim-internal/issues/9923)
