### PR TITLE
Fix overview links not working issue for MCP servers created using an existing API

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -178,9 +178,9 @@ export default function CustomizedStepper() {
     const [isMandatoryPropertiesAvailable, setIsMandatoryPropertiesAvailable] = useState(false);
     const [deploymentsAvailable, setDeploymentsAvailable] = useState(false);
     const [isEndpointSecurityConfigured, setIsEndpointSecurityConfigured] = useState(false);
-    const isMCPServer = api.apiType === MCPServer.CONSTS.MCP;
     const [isMCPEndpointAvailable, setMCPEndpointAvailable] = useState(false);
     const [MCPEndpointLoading, setMCPEndpointLoading] = useState(true);
+    const isMCPServer = api.apiType === MCPServer.CONSTS.MCP;
     const isPrototypedAvailable = api.apiType !== API.CONSTS.APIProduct
         && api.endpointConfig !== null
         && api.endpointConfig.implementation_status === 'prototyped';
@@ -196,23 +196,45 @@ export default function CustomizedStepper() {
 
     useEffect(() => {
         if (isMCPServer) {
-            setMCPEndpointLoading(true);
-            MCPServer.getMCPServerEndpoints(api.id)
-                .then((response) => {
-                    const fetchedEndpoints = response.body;
-                    if (fetchedEndpoints && fetchedEndpoints.length > 0) {
-                        setMCPEndpointAvailable(true);
-                    } else {
-                        setMCPEndpointAvailable(false);
-                    }
-                })
-                .catch((error) => {
-                    console.error('Error fetching MCP server endpoints:', error);
-                    setMCPEndpointAvailable(false);
-                })
-                .finally(() => {
+            if (api.isMCPServerFromExistingAPI()) {
+                // EXISTING_API subtype
+                const underlyingApiId = api.operations[0]
+                    && api.operations[0].apiOperationMapping?.apiId;
+                if (underlyingApiId) {
+                    const propmisedApi = API.get(underlyingApiId);
+                    propmisedApi
+                        .then((apiObj) => {
+                            if (apiObj.endpointConfig !== null) {
+                                setMCPEndpointAvailable(true);
+                            } else {
+                                setMCPEndpointAvailable(false);
+                            }
+                        })
+                        .finally(() => {
+                            setMCPEndpointLoading(false);
+                        });
+                } else {
                     setMCPEndpointLoading(false);
-                });
+                }
+            } else {
+                // DIRECT_BACKEND and SERVER_PROXY subtypes
+                MCPServer.getMCPServerEndpoints(api.id)
+                    .then((response) => {
+                        const fetchedEndpoints = response.body;
+                        if (fetchedEndpoints && fetchedEndpoints.length > 0) {
+                            setMCPEndpointAvailable(true);
+                        } else {
+                            setMCPEndpointAvailable(false);
+                        }
+                    })
+                    .catch((error) => {
+                        console.error('Error fetching MCP server endpoints:', error);
+                        setMCPEndpointAvailable(false);
+                    })
+                    .finally(() => {
+                        setMCPEndpointLoading(false);
+                    });
+            }
         } else {
             setMCPEndpointLoading(false);
         }
@@ -305,7 +327,7 @@ export default function CustomizedStepper() {
                     result = await api.getRevisionsWithEnv(api.isRevision ? api.revisionedApiId : api.id);
                 }
 
-                if (api.apiType === API.CONSTS.APIProduct || isMCPServer) {
+                if (api.apiType === API.CONSTS.APIProduct) {
                     setDeploymentsAvailable(result.body.count > 0);
                 } else {
                     let hasApprovedDeployment = false;
@@ -375,9 +397,11 @@ export default function CustomizedStepper() {
     }, [api]);
 
     /**
- * Update the LifeCycle state of the API
- *
- */
+     * Update the LifeCycle state of the API
+     *
+     * @param {string} apiId - The ID of the API
+     * @param {string} state - The new lifecycle state
+     */
     function updateLCStateOfAPI(apiId, state) {
         setUpdating(true);
         const promisedUpdate = isMCPServer ? MCPServer.updateLcState(apiId, state) : api.updateLcState(apiId, state);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -199,8 +199,7 @@ export default function CustomizedStepper() {
             setMCPEndpointLoading(true);
             if (api.isMCPServerFromExistingAPI()) {
                 // EXISTING_API subtype
-                const underlyingApiId = api.operations[0]
-                    && api.operations[0].apiOperationMapping?.apiId;
+                const underlyingApiId = api.operations[0]?.apiOperationMapping?.apiId;
                 if (underlyingApiId) {
                     const propmisedApi = API.get(underlyingApiId);
                     propmisedApi

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -179,7 +179,7 @@ export default function CustomizedStepper() {
     const [deploymentsAvailable, setDeploymentsAvailable] = useState(false);
     const [isEndpointSecurityConfigured, setIsEndpointSecurityConfigured] = useState(false);
     const [isMCPEndpointAvailable, setMCPEndpointAvailable] = useState(false);
-    const [MCPEndpointLoading, setMCPEndpointLoading] = useState(true);
+    const [MCPEndpointLoading, setMCPEndpointLoading] = useState(false);
     const isMCPServer = api.apiType === MCPServer.CONSTS.MCP;
     const isPrototypedAvailable = api.apiType !== API.CONSTS.APIProduct
         && api.endpointConfig !== null
@@ -196,6 +196,7 @@ export default function CustomizedStepper() {
 
     useEffect(() => {
         if (isMCPServer) {
+            setMCPEndpointLoading(true);
             if (api.isMCPServerFromExistingAPI()) {
                 // EXISTING_API subtype
                 const underlyingApiId = api.operations[0]
@@ -209,6 +210,10 @@ export default function CustomizedStepper() {
                             } else {
                                 setMCPEndpointAvailable(false);
                             }
+                        })
+                        .catch((error) => {
+                            console.error('Error fetching underlying API:', error);
+                            setMCPEndpointAvailable(false);
                         })
                         .finally(() => {
                             setMCPEndpointLoading(false);
@@ -235,8 +240,6 @@ export default function CustomizedStepper() {
                         setMCPEndpointLoading(false);
                     });
             }
-        } else {
-            setMCPEndpointLoading(false);
         }
     }, [isMCPServer, api.id]);
 


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/4154

<img width="1436" height="599" alt="image" src="https://github.com/user-attachments/assets/df53909a-6bd6-4958-a67b-2b50b161160c" />

<img width="1436" height="599" alt="image" src="https://github.com/user-attachments/assets/702fbbd5-0617-4fde-8e3f-97e4b98f7d5d" />

This pull request refactors the `CustomizedStepper` component to improve handling of MCP servers created using an existing API, particularly with respect to endpoint detection and deployment logic. The changes enhance the logic for checking endpoint availability, and clarify deployment checks.

### MCP Server Endpoint Handling

* Refactored the logic for MCP server endpoints in `useEffect`: now distinguishes between EXISTING_API subtype (fetches underlying API and checks its endpoint config) and DIRECT_BACKEND/SERVER_PROXY subtypes (uses `getMCPServerEndpoints`). This ensures endpoint checks are accurate based on the MCP API subtype. [[1]](diffhunk://#diff-a2ea58fe0845e79d8f97cbff0b5b4386a94888288da2e1c90d6d0c39405518ebL199-R220) [[2]](diffhunk://#diff-a2ea58fe0845e79d8f97cbff0b5b4386a94888288da2e1c90d6d0c39405518ebR237)

### Deployment Availability Logic

* Updated deployment availability check: now only excludes MCP server APIs from deployment checks, allowing more precise control and avoiding unnecessary deployment checks for MCP APIs.
