### PR TITLE
Add configurable limit to display throttling policies in publisher portal

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/SelectPolicies.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/SelectPolicies.jsx
@@ -9,6 +9,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { FormattedMessage } from 'react-intl';
 import API from 'AppData/api';
 import CONSTS from 'AppData/Constants';
+import Config from 'Config';
 
 const PREFIX = 'SelectPolicies';
 
@@ -38,9 +39,10 @@ export default function SelectPolicies(props) {
         onChange, policies: selectedPolicies, multiple, helperText, isAPIProduct, validate,
     } = props;
     const [policies, setPolicies] = useState({});
+    const { throttlingPolicyLimit } = Config.app;
 
     useEffect(() => {
-        API.policies('subscription').then((response) => setPolicies(response.body));
+        API.policies('subscription',throttlingPolicyLimit).then((response) => setPolicies(response.body));
     }, []);
     const handleValidateAndChange = ({ target: { value, name } }) => {
         validate('policies', value);


### PR DESCRIPTION
## Purpose
> The pagination limit is set at 25 by default and stops the viewer from being able to see all throttling policies when attempting to configure Mutual SSL

## Approach
> Configured the selecting policies function to use the 'throttlingPolicyLimit' value defined in the settings.js file for the publisher portal

Related issue: https://github.com/wso2/api-manager/issues/4075