### PR TITLE
Fix default values not working for gateway configurations.

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/GatewayConfiguration.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/GatewayConfiguration.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { styled } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -42,6 +42,15 @@ export default function GatewayConfiguration(props) {
         gatewayConfigurations, additionalProperties, setAdditionalProperties,
     } = props;
 
+    // Populate default values in additional properties when loading
+    useEffect(() => {
+        for (const gatewayConfiguration of gatewayConfigurations) {
+            if (gatewayConfiguration.default) {
+                setAdditionalProperties(gatewayConfiguration.name, gatewayConfiguration.default);
+            }
+        }
+    }, [gatewayConfigurations]);
+
     const onChange = (e) => {
         const { name, value } = e.target;
         setAdditionalProperties(name, value);
@@ -53,6 +62,8 @@ export default function GatewayConfiguration(props) {
         let value = '';
         if (additionalProperties[gatewayConfiguration.name]) {
             value = additionalProperties[gatewayConfiguration.name];
+        } else if (gatewayConfiguration.default) {
+            value = gatewayConfiguration.default;
         }
         if (gatewayConfiguration.type === 'options') {
             return (


### PR DESCRIPTION
When we define the Gateway Configurations via a List of `ConfigurationDTO` objects, we can define default values for configurations. But those default values are not reflected properly in the UI and not sent to the backend.

This fix will populate the request body configurations and the UI text field with the default values if available.