### PR TITLE
Set logoutSessionStateAppender to empty

### DIFF
--- a/portals/admin/src/main/webapp/site/public/conf/settings.json
+++ b/portals/admin/src/main/webapp/site/public/conf/settings.json
@@ -19,7 +19,7 @@
       "enabled": true,
       "timeout": 2000
     },
-    "logoutSessionStateAppender" : "OIDC" ,
+    "logoutSessionStateAppender" : "" ,
     "docUrl": "https://apim.docs.wso2.com/en/4.6.0/"
   }
 }

--- a/portals/devportal/src/main/webapp/site/public/theme/settings.json
+++ b/portals/devportal/src/main/webapp/site/public/theme/settings.json
@@ -15,7 +15,7 @@
             "enabled": true,
             "timeout": 4000
         },
-        "logoutSessionStateAppender" : "OIDC" ,
+        "logoutSessionStateAppender" : "" ,
         "propertyDisplaySuffix": "__display",
         "markdown": {
             "skipHtml": true,

--- a/portals/publisher/src/main/webapp/site/public/conf/settings.json
+++ b/portals/publisher/src/main/webapp/site/public/conf/settings.json
@@ -16,7 +16,7 @@
             "enabled": true,
             "timeout": 4000
         },
-        "logoutSessionStateAppender" : "OIDC" ,
+        "logoutSessionStateAppender" : "" ,
         "throttlingPolicyLimit": 80,
         "operationPolicyCount": 500,
         "documentCount": 1000,


### PR DESCRIPTION
## Purpose
Related to: https://github.com/wso2/api-manager/issues/4105
OIDC Federated Logout Endpoint Not Invoked When Skip Logout Consent Is Enabled

## Approach
Before APIM 4.4.0, logoutSessionStateAppender was set to an empty value. Change this to "OIDC" as it is required for the B2B feature. Afterward, revert logoutSessionStateAppender back to an empty value ("").