### PR TITLE
Fix search result rendering issues in publisher and developer portals

### DIFF
--- a/portals/devportal/src/main/webapp/WEB-INF/web.xml
+++ b/portals/devportal/src/main/webapp/WEB-INF/web.xml
@@ -111,6 +111,7 @@
         <url-pattern>/settings/*</url-pattern>
         <url-pattern>/applications/*</url-pattern>
         <url-pattern>/logout/*</url-pattern>
+        <url-pattern>/search</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>logout</servlet-name>

--- a/portals/devportal/src/main/webapp/source/src/app/AppRouts.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/AppRouts.jsx
@@ -162,6 +162,14 @@ function AppRouts(props) {
                         }
                     }}
                 />
+                <Route
+                    path='/search'
+                    render={(routeProps) => (
+                        <PortalModeRouteGuard>
+                            <Apis {...routeProps} />
+                        </PortalModeRouteGuard>
+                    )}
+                />
                 <Route component={PageNotFound} />
             </Switch>
         </Suspense>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Apis.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Apis.jsx
@@ -48,7 +48,7 @@ function Apis() {
                 )}
             />
             <Route
-                path='/apis/search'
+                path='/search'
                 render={(props) => (
                     <CommonListing {...props} />)}
             />

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -334,9 +334,23 @@ class CommonListingLegacy extends React.Component {
 
         // Detect if we're on MCP servers route or APIs route
         const isMCPServersRoute = window.location.pathname.includes('/mcp-servers');
-        const title = isMCPServersRoute ? 'MCP Servers' : 'APIs';
-        const titleId = isMCPServersRoute ? 'MCPServers.Listing.Listing.mcpservers.main' : 'Apis.Listing.Listing.apis.main';
-        const iconType = isMCPServersRoute ? 'mcp-server' : 'api';
+        const isSearchRoute = window.location.pathname.includes('/search');
+        let title;
+        let titleId;
+        let iconType;
+        if (isMCPServersRoute) {
+            title = 'MCP Servers';
+            titleId = 'MCPServers.Listing.Listing.mcpservers.main';
+            iconType = 'mcp-server';
+        } else if (isSearchRoute) {
+            title = 'Unified Search';
+            titleId = 'Apis.Listing.Listing.search.main';
+            iconType = 'api';
+        } else {
+            title = 'APIs';
+            titleId = 'Apis.Listing.Listing.apis.main';
+            iconType = 'api';
+        }
 
         if (search && searchQuery !== null) {
             // For the tagWise search

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -345,7 +345,6 @@ class CommonListingLegacy extends React.Component {
         } else if (isSearchRoute) {
             title = 'Unified Search';
             titleId = 'Apis.Listing.Listing.search.main';
-            iconType = 'api';
         } else {
             title = 'APIs';
             titleId = 'Apis.Listing.Listing.apis.main';
@@ -417,10 +416,16 @@ class CommonListingLegacy extends React.Component {
                     id='commonListing'
                 >
                     <div className={classes.appBar} id='commonListingAppBar'>
-                        <div className={classNames(classes.mainIconWrapper, 'main-icon-wrapper')}>
-                            <CustomIcon strokeColor={strokeColorMain} width={42} height={42} icon={iconType} />
-                        </div>
-                        <div className={classes.mainTitleWrapper} id='mainTitleWrapper'>
+                        {!isSearchRoute && (
+                            <div className={classNames(classes.mainIconWrapper, 'main-icon-wrapper')}>
+                                <CustomIcon strokeColor={strokeColorMain} width={42} height={42} icon={iconType} />
+                            </div>
+                        )}
+                        <div
+                            className={classNames(classes.mainTitleWrapper, 'main-title-wrapper')}
+                            id='mainTitleWrapper'
+                            style={isSearchRoute ? { paddingLeft: '32px' } : {}}
+                        >
                             <Typography variant='h4' component='h1' className={classes.mainTitle}>
                                 <FormattedMessage defaultMessage={title} id={titleId} />
                             </Typography>

--- a/portals/devportal/src/main/webapp/source/src/app/components/Base/Header/Search/HeaderSearch.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Base/Header/Search/HeaderSearch.jsx
@@ -159,7 +159,7 @@ class HeaderSearch extends React.Component {
          if (event.key === 'Enter' && !this.suggestionSelected) {
              const { history } = this.props;
              const { lcstate } = this.state;
-             history.push('/apis/search?query=' + buildSearchQuery(event.target.value, lcstate));
+             history.push('/search?query=' + buildSearchQuery(event.target.value, lcstate));
          }
          this.suggestionSelected = false;
      }
@@ -216,7 +216,7 @@ class HeaderSearch extends React.Component {
          });
          const { history } = this.props;
          if (event.target.value) {
-             history.push('/apis/search?query=' + buildSearchQuery(searchText, event.target.value));
+             history.push('/search?query=' + buildSearchQuery(searchText, event.target.value));
          } else {
              history.push('/apis/');
          }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Base/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Base/index.jsx
@@ -322,7 +322,10 @@ class LayoutLegacy extends React.Component {
 
     detectCurrentMenu = (location) => {
         const { pathname } = location;
-        if (/\/apis$/g.test(pathname) || /\/apis\//g.test(pathname)) {
+        if (/\/search$/g.test(pathname) || /\/search\//g.test(pathname)) {
+            // For search results, don't select any tab to show it's a separate search view
+            this.setState({ selected: null });
+        } else if (/\/apis$/g.test(pathname) || /\/apis\//g.test(pathname)) {
             this.setState({ selected: 'apis' });
         } else if (/\/mcp-servers$/g.test(pathname) || /\/mcp-servers\//g.test(pathname)) {
             this.setState({ selected: 'mcp-servers' });

--- a/portals/devportal/src/main/webapp/source/src/app/components/MCPServers/MCPServers.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/MCPServers/MCPServers.jsx
@@ -32,11 +32,6 @@ const MCPServers = () => {
                     <CommonListing {...props} />)}
             />
             <Route
-                path='/mcp-servers/search'
-                render={(props) => (
-                    <CommonListing {...props} />)}
-            />
-            <Route
                 path='/mcp-servers/:serverUuid/'
                 render={(props) => (
                     <Details {...props} />)}

--- a/portals/publisher/src/main/webapp/WEB-INF/web.xml
+++ b/portals/publisher/src/main/webapp/WEB-INF/web.xml
@@ -134,6 +134,7 @@
         <url-pattern>/login/*</url-pattern>
         <url-pattern>/logout/*</url-pattern>
         <url-pattern>/error-pages/*</url-pattern>
+        <url-pattern>/search</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>logout</servlet-name>

--- a/portals/publisher/src/main/webapp/source/src/app/ProtectedApp.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/ProtectedApp.jsx
@@ -220,6 +220,7 @@ export default class Protected extends Component {
                                 >
                                     <Switch>
                                         <Route path='/' exact component={PublisherLanding} />
+                                        <Route path='/search' component={DeferredAPIs} />
                                         <Route path='/apis' component={DeferredAPIs} />
                                         <Route path='/api-products' component={DeferredAPIs} />
                                         <Route path='/mcp-servers' component={DeferredAPIs} />

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Apis.jsx
@@ -79,7 +79,12 @@ const Apis = () => {
                     </MCPRouteGuard>
                 )}
             />
-            <Route path='/apis/search' render={(props) => <Listing {...props} isAPIProduct={false} />} />
+            <Route
+                exact
+                path='/search'
+                key={Date.now()}
+                render={(props) => <Listing {...props} isAPIProduct={false} />}
+            />
             <Route path='/apis/create' component={DeferredAPICreateRoutes} />
             <Route path='/apis/design-assistant' component={DefferedAIApiCreateRoutes} />
             <Route

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/headersearch/HeaderSearch.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/headersearch/HeaderSearch.jsx
@@ -156,7 +156,7 @@ class HeaderSearch extends React.Component {
     onKeyDown(event) {
         if (event.key === 'Enter' && !this.suggestionSelected) {
             const { history } = this.props;
-            history.push('/apis/search?query=' + buildSearchQuery(event.target.value));
+            history.push('/search?query=' + buildSearchQuery(event.target.value));
         }
         this.suggestionSelected = false;
     }


### PR DESCRIPTION
### Purpose

- Related issue: https://github.com/wso2/api-manager/issues/3978

This pull request introduces a unified `/search` route for both the DevPortal and Publisher portals, replacing previous `/apis/search` and `/mcp-servers/search` endpoints. The changes ensure that search results are now accessed via `/search`, streamline routing logic, and update UI components to reflect the new search view.

**Unified Search Routing and UI Updates**

* Added `/search` servlet mapping in both `devportal` and `publisher` `web.xml` files to support the new unified search endpoint. [[1]](diffhunk://#diff-a884529b8dc829e3a8de30c51f69a0481d57699c5d4943f66c803b9dee9e4ff2R114) [[2]](diffhunk://#diff-11070c476af89b747a66f5eddf5dcae113c673bc638545535cf837a165a770e4R137)
* Updated React routing in `AppRouts.jsx`, `ProtectedApp.jsx`, and related components to route `/search` to the appropriate listing and search components, replacing `/apis/search` and `/mcp-servers/search`. [[1]](diffhunk://#diff-cd9f165cf1089b5f90b1bf829980623a9e3edf5415ff7ea0be0f549674167b34R165-R172) [[2]](diffhunk://#diff-b7a4a39197387be60e8e20117b2ac48ae405817f90a2806e160490ce22cc7019R223) [[3]](diffhunk://#diff-2ac8ada40e0518e52da5a62143c76a86ba39ceef1993dded647de7c3fe231f1cL82-R87) [[4]](diffhunk://#diff-8e8099a3d2a32d4218b5895f87abf60a42164505e94f2302bc93c70cf0040519L34-L38)
* Refactored search navigation logic in header search components to use `/search` instead of `/apis/search`, ensuring consistency in search queries across the portals. [[1]](diffhunk://#diff-460da55bc69fb81b13a2d807802e0e123239b9feb4bfe070d9aa86092c96e5dbL162-R162) [[2]](diffhunk://#diff-460da55bc69fb81b13a2d807802e0e123239b9feb4bfe070d9aa86092c96e5dbL219-R219) [[3]](diffhunk://#diff-357c1b600b1359fcd1de500931fe744cbc116394a45ec775cb517ad1e9220f68L159-R159)
* Enhanced UI logic in `CommonListing.jsx` to display a distinct "Unified Search" title and icon when on the `/search` route, differentiating it from the APIs and MCP Servers views.
* Updated menu selection logic to avoid highlighting any tab when viewing search results, emphasizing that `/search` is a separate view.

Refer to the below attached screeshots for the search result views:

- Developer portal
<img width="1425" height="792" alt="image" src="https://github.com/user-attachments/assets/b6d18919-b8cc-4637-9fc4-c2d6382688bf" />

- Publisher portal
<img width="1425" height="792" alt="image" src="https://github.com/user-attachments/assets/09862047-8a6d-46c0-8fe1-1aeaf4afc47f" />
