### PR TITLE
Hide Irrelevant Gateway Connector Configurations for Kong Gateway Kubernetes Deployment

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -920,6 +920,7 @@ function AddEditGWEnvironment(props) {
                                         setAdditionalProperties={setAdditionalProperties}
                                         hasErrors={hasErrors}
                                         validating={validating}
+                                        gatewayType={gatewayType}
                                     />
                                 </Box>
                             </Grid>


### PR DESCRIPTION
## Description:

This pull request addresses the issue where additional, unnecessary input fields are shown in the "Gateway Connector Configurations" section when the Gateway Environment Type is set to "Kong Gateway" and the Deployment Type is "Kubernetes" in the Admin Portal.

## Fixes:

UI now dynamically shows irrelevant configuration fields when "Kong Gateway" and "Standalone" deployment are selected.
Improves user experience by only displaying configuration options applicable to the selected gateway and deployment type.

## UI

<img width="826" height="530" alt="Screenshot 2025-09-02 at 09 48 35" src="https://github.com/user-attachments/assets/016b96a0-09b3-4cad-8b10-38fea90d8780" />
<img width="832" height="539" alt="Screenshot 2025-09-02 at 09 48 52" src="https://github.com/user-attachments/assets/df54b923-14d6-468b-b041-d6397bc6e279" />
<img width="829" height="796" alt="Screenshot 2025-09-02 at 09 49 02" src="https://github.com/user-attachments/assets/45157b7d-6763-47fd-843f-d139e15932c2" />

Issue:

- Fixes: https://github.com/wso2/api-manager/issues/4204