### PR TITLE
Fix helper text in MCP server creation forms

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -617,9 +617,12 @@ export default function DefaultAPIForm(props) {
                                             <FormattedMessage
                                                 id={'Apis.Create.Components.DefaultAPIForm.api.product.'
                                                     + 'actual.context.helper'}
-                                                defaultMessage={'API Product will be exposed in {actualContext}'
-                                                    + 'context at the gateway'}
-                                                values={{ actualContext: actualContext(api) }}
+                                                defaultMessage={'{type} will be exposed via {actualContext}'
+                                                    + ' at the gateway'}
+                                                values={{
+                                                    actualContext: actualContext(api),
+                                                    type: isAPIProduct ? 'API Product' : 'MCP Server'
+                                                }}
                                             />
                                         )
                                     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/DesignConfigurations.jsx
@@ -331,11 +331,6 @@ function configReducer(state, configAction) {
                 display: true,
             };
             
-            // Debug logging
-            console.log(`[DEBUG] Updating ${action} with value: "${value}" for MCP server: ${isMCPServer}`);
-            console.log(`[DEBUG] nextState.type:`, nextState.type);
-            console.log(`[DEBUG] MCPServer.CONSTS.MCP:`, MCPServer.CONSTS.MCP);
-            
             if (isMCPServer) {
                 // Handle additionalPropertiesMap for MCP servers
                 if (!nextState.additionalPropertiesMap) {
@@ -350,9 +345,6 @@ function configReducer(state, configAction) {
                 
                 // Update the virtual additionalProperties array for UI compatibility (clean rebuild)
                 nextState.additionalProperties = Object.values(nextState.additionalPropertiesMap);
-                
-                console.log(`[DEBUG] Updated additionalPropertiesMap:`, nextState.additionalPropertiesMap);
-                console.log(`[DEBUG] Updated additionalProperties:`, nextState.additionalProperties);
             } else {
                 // Handle additionalProperties for regular APIs
                 const targetProperty = nextState.additionalProperties.find((property) => property.name === action);
@@ -440,13 +432,7 @@ export default function DesignConfigurations() {
             const githubProps = apiConfig.additionalProperties.filter((prop) => prop.name === 'github_repo');
             githubProp = githubProps.find(prop => prop.display === true) || githubProps[githubProps.length - 1];
         }
-        
-        console.log(`[DEBUG] useMemo - isMCPServer:`, isMCPServer);
-        console.log(`[DEBUG] useMemo - additionalProperties:`, apiConfig.additionalProperties);
-        console.log(`[DEBUG] useMemo - additionalPropertiesMap:`, apiConfig.additionalPropertiesMap);
-        console.log(`[DEBUG] useMemo - slackURLProperty:`, slackProp);
-        console.log(`[DEBUG] useMemo - githubURLProperty:`, githubProp);
-        
+
         return [slackProp, githubProp];
     }, [apiConfig.additionalProperties, apiConfig.additionalPropertiesMap, api.apiType]);
     const invalidTagsExist = apiConfig.tags.find((tag) => {


### PR DESCRIPTION
### Purpose

This pull request primarily focuses on improving user-facing messaging for MCP servers and API Products, and cleaning up the codebase by removing unnecessary debug logging from the API configuration components.

User experience improvements:

* Updated the `DefaultAPIForm` component to display a more accurate message that distinguishes between "API Product" and "MCP Server" in the gateway context, using the `type` variable to dynamically set the description.

Codebase clean-up:

* Removed debug logging statements from the `configReducer` function in `DesignConfigurations.jsx` to reduce console noise and improve code readability. [[1]](diffhunk://#diff-d652f547c3df6c8d3fa58ba5b4d81556cbf1fc8580ac333025d8ff308d235df8L334-L338) [[2]](diffhunk://#diff-d652f547c3df6c8d3fa58ba5b4d81556cbf1fc8580ac333025d8ff308d235df8L353-L355)
* Removed debug logging from the memoized property selection logic in the `DesignConfigurations` component, further streamlining the code.