### PR TITLE
Display REST chip on API products in devportal

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/ApiThumbClassic.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/APICards/ApiThumbClassic.jsx
@@ -313,8 +313,9 @@ class ApiThumbClassicLegacy extends React.Component {
                 icon = getTypeIcon('MCP');
             }
         } else if (api.type === 'APIPRODUCT') {
-            // No API Product chip in devportal
-            return null;
+            // In devportal, we show API Products as normal APIs
+            label = getTypeChipLabel('HTTP');
+            icon = getTypeIcon('HTTP');
         } else {
             // In search route, the apiType comes as `transportType`
             // In non-search (listing) route, the apiType comes as `type`


### PR DESCRIPTION
### Purpose
Display REST chip on API products in devportal as there are no separation between products and apis in devportal.

### Approach
Display the REST chip

### Screenshots

<img width="644" height="184" alt="image" src="https://github.com/user-attachments/assets/5ebf0d6d-b68e-457a-96ae-9311581d1a52" />
