### PR TITLE
Gateway environment urls are not being reflected accurately for WebSocket APIs

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiConsole.jsx
@@ -97,6 +97,16 @@ export default function AsyncApiConsole() {
     const user = AuthManager.getUser();
 
     useEffect(() => {
+        if (selectedEnvironment && environmentObject.length > 0) {
+            const env = environmentObject.find(
+                (e) => e.environmentName === selectedEnvironment,
+            );
+            if (env && env.URLs) {
+                setURLs(env.URLs);
+            }
+        }
+    }, [selectedEnvironment, environmentObject]);
+    useEffect(() => {
         const apiID = api.id;
         const apiClient = new Api();
         const promiseAPI = apiClient.getAPIById(apiID);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/AsyncApiUI.jsx
@@ -84,6 +84,14 @@ export default function AsyncApiUI(props) {
     const [endPoint, setEndpoint] = useState(initialEndpoint);
 
     useEffect(() => {
+      let newInitialEndpoint = URLs && URLs.http;
+      if (api.type === CONSTANTS.API_TYPES.WS) {
+        newInitialEndpoint = URLs && URLs.ws;
+      }
+      setEndpoint(newInitialEndpoint);
+    }, [URLs, api.type]);
+
+    useEffect(() => {
         const apiID = api.id;
         const apiClient = new Api();
         const promisedTopics = apiClient.getAllTopics(apiID);
@@ -116,13 +124,14 @@ export default function AsyncApiUI(props) {
         return token;
     }
 
-    function generateGenericWHSubscriptionCurl(subscription) {
+    function generateGenericWHSubscriptionCurl(subscription, customEndpoint) {
         const {
             topic, callback, secret, mode, lease,
         } = subscription;
         const token = generateAccessToken();
+        const endpoint = customEndpoint || endPoint;
         if (mode === 'subscribe') {
-            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}'`;
+            let curl = `curl -X POST '${endpoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}'`;
             if (secret) {
                 curl += ` -d 'hub.secret=${secret}'`;
             }
@@ -136,9 +145,9 @@ export default function AsyncApiUI(props) {
             }
             return curl;
         } else {
-            let curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X POST '${endpoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H 'Authorization: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                curl = `curl -X POST '${endPoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X POST '${endpoint}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'hub.topic=${encodeURIComponent(topic)}' -d 'hub.callback=${encodeURIComponent(callback)}' -d 'hub.mode=${mode}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         }
@@ -153,52 +162,55 @@ export default function AsyncApiUI(props) {
         return topicName;
     }
 
-    function generateWSSubscriptionCommand(topic) {
+    function generateWSSubscriptionCommand(topic, customEndpoint) {
         const token = generateAccessToken();
+        const endpoint = customEndpoint || endPoint;
         if (topic.name.includes('*')) {
-            let wscat = `wscat -c '${endPoint}' -H '${securitySchemeType === 'API-KEY' ? 'apikey' : 'Authorization'}: ${token}'`;
+            let wscat = `wscat -c '${endpoint}' -H '${securitySchemeType === 'API-KEY' ? 'apikey' : 'Authorization'}: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                wscat = `wscat -c '${endPoint}' -H '${authorizationHeader}: ${token}'`;
+                wscat = `wscat -c '${endpoint}' -H '${authorizationHeader}: ${token}'`;
             }
             return wscat;
         } else {
-            let wscat = `wscat -c '${endPoint}/${getTopicName(topic)}' -H '${securitySchemeType === 'API-KEY' ? 'apikey': 'Authorization'}: ${token}'`;
+            let wscat = `wscat -c '${endpoint}/${getTopicName(topic)}' -H '${securitySchemeType === 'API-KEY' ? 'apikey': 'Authorization'}: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                wscat = `wscat -c '${endPoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
+                wscat = `wscat -c '${endpoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
             }
             return wscat;
         }
     }
 
-    function generateSSESubscriptionCommand(topic) {
+    function generateSSESubscriptionCommand(topic, customEndpoint) {
         const token = generateAccessToken();
+        const endpoint = customEndpoint || endPoint;
         if (topic.name.includes('*')) {
-            let curl = `curl -X GET '${endPoint}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X GET '${endpoint}' -H 'Authorization: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                curl = `curl -X GET '${endPoint}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X GET '${endpoint}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         } else {
-            let curl = `curl -X GET '${endPoint}/${getTopicName(topic)}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X GET '${endpoint}/${getTopicName(topic)}' -H 'Authorization: ${token}'`;
             if (isAdvertised && authorizationHeader !== '') {
-                curl = `curl -X GET '${endPoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X GET '${endpoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         }
     }
 
-    function generateASYNCSubscriptionCommand(topic) {
+    function generateASYNCSubscriptionCommand(topic, customEndpoint) {
         const token = generateAccessToken();
+        const endpoint = customEndpoint || endPoint;
         if (topic.name.includes('*')) {
-            let curl = `curl -X GET '${endPoint}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X GET '${endpoint}' -H 'Authorization: ${token}'`;
             if (authorizationHeader !== '') {
-                curl = `curl -X GET '${endPoint}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X GET '${endpoint}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         } else {
-            let curl = `curl -X GET '${endPoint}/${getTopicName(topic)}' -H 'Authorization: ${token}'`;
+            let curl = `curl -X GET '${endpoint}/${getTopicName(topic)}' -H 'Authorization: ${token}'`;
             if (authorizationHeader !== '') {
-                curl = `curl -X GET '${endPoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
+                curl = `curl -X GET '${endpoint}/${getTopicName(topic)}' -H '${authorizationHeader}: ${token}'`;
             }
             return curl;
         }
@@ -230,12 +242,14 @@ export default function AsyncApiUI(props) {
                     <WebhookSubscriptionUI
                         topic={topic}
                         generateGenericWHSubscriptionCurl={generateGenericWHSubscriptionCurl}
+                        endPoint={endPoint}
                         expandable
                     />
                 ))}
                 {api.type === CONSTANTS.API_TYPES.SSE && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateSSESubscriptionCommand}
+                        endPoint={endPoint}
                         topic={topic}
                         expandable
                     />
@@ -243,6 +257,7 @@ export default function AsyncApiUI(props) {
                 {api.type === CONSTANTS.API_TYPES.WS && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateWSSubscriptionCommand}
+                        endPoint={endPoint}
                         topic={topic}
                         expandable
                     />
@@ -250,6 +265,7 @@ export default function AsyncApiUI(props) {
                 {api.type === CONSTANTS.API_TYPES.ASYNC && allTopics.list.map((topic, index) => (
                     <GenericSubscriptionUI
                         generateGenericSubscriptionCommand={generateASYNCSubscriptionCommand}
+                        endPoint={endPoint}
                         topic={topic}
                         expandable={expandable}
                     />

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/GenericSubscriptionUI.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -37,9 +37,15 @@ export default function GenericSubscriptionUI(props) {
     const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
     const theme = useTheme();
     const backgroundColor = theme.custom.resourceChipColors[trimmedVerb];
-    const { generateGenericSubscriptionCommand, topic, expandable } = props;
-    const [command, setCommand] = useState(generateGenericSubscriptionCommand(topic));
+    // eslint-disable-next-line react/prop-types
+    const {
+        generateGenericSubscriptionCommand, topic, expandable, endPoint,
+    } = props;
+    const [command, setCommand] = useState(generateGenericSubscriptionCommand(topic, endPoint));
 
+    useEffect(() => {
+        setCommand(generateGenericSubscriptionCommand(topic, endPoint));
+    }, [endPoint, topic, generateGenericSubscriptionCommand]);
     const handleClick = () => {
         setCommand(generateGenericSubscriptionCommand(topic));
     };

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/WebhookSubscriptionUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/AsyncApiConsole/WebhookSubscriptionUI.jsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useState, useReducer } from 'react';
+import React, { useState, useReducer, useEffect } from 'react';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -44,7 +44,7 @@ function WebhookSubscriptionUI(props) {
     const trimmedVerb = verb === 'publish' || verb === 'subscribe' ? verb.substr(0, 3) : verb;
     const theme = useTheme();
     const backgroundColor = theme.custom.resourceChipColors[trimmedVerb];
-    const { generateGenericWHSubscriptionCurl, topic } = props;
+    const { generateGenericWHSubscriptionCurl, topic, endPoint } = props;
     const initialSubscriptionState = {
         topic: topic.name,
         secret: null,
@@ -56,6 +56,9 @@ function WebhookSubscriptionUI(props) {
     const [formError, setFormError] = useState(false);
     const [state, dispatch] = useReducer(reducer, initialSubscriptionState);
 
+    useEffect(() => {
+        setCurl(generateGenericWHSubscriptionCurl(topic, endPoint));
+    }, [endPoint, topic, generateGenericWHSubscriptionCurl]);
     const handleClick = () => {
         if (!state.callback || state.callback.length < 1) {
             setFormError(true);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
@@ -499,7 +499,7 @@ function TryOutController(props) {
         switch (name) {
             case 'selectedEnvironment':
                 setSelectedEnvironment(value, true);
-                if (api.type !== 'GRAPHQL') {
+                if (api.type !== 'GRAPHQL' && api.type !== 'WS' && api.type !== 'SSE' && api.type !== 'WEBSUB') {
                     updateSwagger(value);
                 }
                 if (environmentObject) {


### PR DESCRIPTION
This pull request introduces improvements to how endpoint URLs are managed and propagated across the Async API Console components in the developer portal. The main changes ensure that the correct endpoint is dynamically selected and passed down to subscription command generators and UI components, supporting different API types and environments. Additionally, the subscription command generators are refactored to accept custom endpoints, making the UI more responsive to environment changes.

**Endpoint Management and Propagation:**

* Updated `AsyncApiConsole.jsx` to watch for changes in the selected environment and update the available URLs accordingly.
* In `AsyncApiUI.jsx`, added a `useEffect` to update the endpoint (`endPoint`) based on the selected API type and URLs, ensuring the correct protocol (HTTP, WS, etc.) is used.
* Modified the rendering of subscription UI components in `AsyncApiUI.jsx` to pass the current `endPoint` as a prop, ensuring all child components use the correct endpoint.

**Subscription Command Generation Refactoring:**

* Refactored all subscription command generator functions in `AsyncApiUI.jsx` to accept an optional `customEndpoint` parameter, defaulting to the current `endPoint` if not provided. This makes the commands flexible and responsive to endpoint changes. 

**UI Component Updates for Endpoint Awareness:**

* Updated `GenericSubscriptionUI.jsx` and `WebhookSubscriptionUI.jsx` to accept `endPoint` as a prop and use `useEffect` to update the displayed command whenever the endpoint or topic changes. This ensures the UI always shows commands with the correct endpoint. 

**Miscellaneous:**

* Adjusted the logic in `TryOutController.jsx` to avoid updating Swagger for unsupported API types (WS, SSE, WEBSUB, etc.).
