### PR TITLE
Fix issue with API save within the runtime configurations page

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -580,6 +580,7 @@ export default function RuntimeConfiguration() {
             getValidationError();
         }
         setIsUpdating(true);
+        delete apiConfig.apiType;
         updateAPI(apiConfig)
             .catch((error) => {
                 if (error.response) {
@@ -610,6 +611,7 @@ export default function RuntimeConfiguration() {
             getValidationError();
         }
         setIsUpdating(true);
+        delete apiConfig.apiType;
         updateAPI(apiConfig)
             .catch((error) => {
                 if (error.response) {


### PR DESCRIPTION
#### Purpose

This pull request makes a minor update to the `RuntimeConfiguration` component. The main change is the removal of the `apiType` property from the `apiConfig` object before calling the `updateAPI` function, which helps ensure only the intended configuration data is sent during updates.

* Removed the `apiType` property from the `apiConfig` object before updating the API in the `RuntimeConfiguration` component (`RuntimeConfiguration.jsx`). [[1]](diffhunk://#diff-ef823f021e800ad34a772a4b2d7359930a703f3a36ba035fbf18b4a23a22c6b4R583) [[2]](diffhunk://#diff-ef823f021e800ad34a772a4b2d7359930a703f3a36ba035fbf18b4a23a22c6b4R614)