### PR TITLE
Remove new tag from AWS gateway

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -66,7 +66,7 @@ let gatewayDetails = {
         value: 'AWS',
         name: 'AWS Gateway', 
         description: 'API gateway offered by AWS cloud.', 
-        isNew: true 
+        isNew: false 
     }
 };
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
@@ -82,7 +82,7 @@ const ApiCreateWithAI = () => {
             value: 'AWS',
             name: 'AWS Gateway',
             description: 'API gateway offered by AWS cloud.',
-            isNew: true
+            isNew: false
         }
     };
 


### PR DESCRIPTION
## Purpose

This pull request makes a small update to the API gateway options in the UI. The change updates the `isNew` flag for the AWS Gateway option from `true` to `false` in both the API creation routes and the AI-assisted API creation component. This ensures that AWS Gateway is no longer highlighted as a newly added option.