### PR TITLE
Fix tool page alignment issues

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/MCPServers/Details/Tools/components/ToolDetails.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/MCPServers/Details/Tools/components/ToolDetails.jsx
@@ -89,9 +89,22 @@ const Root = styled('div')(({ theme }) => {
             },
             transition: 'box-shadow 0.2s ease-in-out',
             overflow: 'hidden',
-            width: `calc(100% - ${theme.spacing(2)})`,
-            maxWidth: `calc(100% - ${theme.spacing(2)})`,
-            boxSizing: 'border-box'
+            width: `calc(100% - ${theme.spacing(2)}) !important`,
+            maxWidth: `calc(100% - ${theme.spacing(2)}) !important`,
+            minWidth: `calc(100% - ${theme.spacing(2)}) !important`,
+            boxSizing: 'border-box',
+            position: 'relative',
+            left: 0,
+            right: 0,
+            '&.Mui-expanded': {
+                margin: theme.spacing(1),
+                width: `calc(100% - ${theme.spacing(2)}) !important`,
+                maxWidth: `calc(100% - ${theme.spacing(2)}) !important`,
+                minWidth: `calc(100% - ${theme.spacing(2)}) !important`,
+                position: 'relative',
+                left: 0,
+                right: 0
+            }
         },
         [`& .${classes.accordionContainer}.markedForDelete`]: {
             opacity: 0.5,


### PR DESCRIPTION
#### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/4141
- Resolves: https://github.com/wso2/api-manager/issues/4157

This pull request makes several improvements to the Tools page of MCP Servers, including:
- Tool name truncating if the length is too long
- Aligning all descriptions vertically
- Update the verb chip styling

<img width="1431" height="725" alt="image" src="https://github.com/user-attachments/assets/d8b38b83-e91b-45c0-b563-51851f0bfc07" />

Notice the UI when the accordion is expanded (the misalignment issue that was reported is fixed via this PR).

<img width="1431" height="725" alt="image" src="https://github.com/user-attachments/assets/bb1ef1fe-1682-41fa-b863-9af8b8ab57d4" />
