### PR TITLE
Removing react-tagcloud dependency from Devportal

### DIFF
--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -67,11 +67,10 @@
                 "react-router": "^5.3.4",
                 "react-router-dom": "^5.3.4",
                 "react-syntax-highlighter": "^15.6.1",
-                "react-tagcloud": "^2.3.1",
                 "remark-gfm": "^3.0.1",
                 "stream-browserify": "^3.0.0",
                 "swagger-client": "^3.35.6",
-                "swagger-ui-react": "^5.27.1",
+                "swagger-ui-react": "^5.29.0",
                 "url": "^0.11.3",
                 "xml-formatter": "^3.6.2"
             },
@@ -22239,11 +22238,6 @@
                 "safe-buffer": "^5.1.0"
             }
         },
-        "node_modules/randomcolor": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.6.2.tgz",
-            "integrity": "sha512-Mn6TbyYpFgwFuQ8KJKqf3bqqY9O1y37/0jgSK/61PUxV4QfIMv0+K2ioq8DfOjkBslcjwSzRfIDEXfzA9aCx7A=="
-        },
         "node_modules/randomfill": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
@@ -23053,20 +23047,6 @@
             },
             "peerDependencies": {
                 "react": ">= 0.14.0"
-            }
-        },
-        "node_modules/react-tagcloud": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/react-tagcloud/-/react-tagcloud-2.3.3.tgz",
-            "integrity": "sha512-4E2lTU7wYU0bisi2x3xInueufHzYFkSuqoKsY0Ky8U4Ki60StVX0MicYtsiScvY2QcFbSULWt6evbEwYVKXl4g==",
-            "dependencies": {
-                "prop-types": "^15.6.2",
-                "randomcolor": "^0.6.2",
-                "seedrandom": "^3.0.5",
-                "shuffle-array": "^1.0.1"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0"
             }
         },
         "node_modules/react-test-renderer": {
@@ -24384,11 +24364,6 @@
             "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
             "integrity": "sha512-xvTNwcbeDayXotnV32zLb3duQsP+4XosHpb/F+tu6VzEZFmIjzPdNk6/O+QOOx5XTh08KL2ufdXeCO33p380pQ=="
         },
-        "node_modules/seedrandom": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
-        },
         "node_modules/select-hose": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -24790,11 +24765,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
             "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
-        },
-        "node_modules/shuffle-array": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/shuffle-array/-/shuffle-array-1.0.1.tgz",
-            "integrity": "sha512-0TFRU8zVQaLatWKr0/czo19VyPNgb/a3sBc1GAjVfivfzEGaS54vueNgtAu/8/pW7EM/VF5fwq9zgpLdGyRmVw=="
         },
         "node_modules/side-channel": {
             "version": "1.1.0",

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -86,7 +86,6 @@
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "react-syntax-highlighter": "^15.6.1",
-        "react-tagcloud": "^2.3.1",
         "remark-gfm": "^3.0.1",
         "stream-browserify": "^3.0.0",
         "swagger-client": "^3.35.6",


### PR DESCRIPTION
Following the improvements to the api categories and tag section [pull/1099](https://github.com/wso2/apim-apps/pull/1099) we are no longer using react-tagcloud in devportal.