### PR TITLE
Bump axios version to 1.12.2 across all portals

### DIFF
--- a/portals/admin/src/main/webapp/package-lock.json
+++ b/portals/admin/src/main/webapp/package-lock.json
@@ -6122,9 +6122,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",

--- a/portals/devportal/src/main/webapp/package-lock.json
+++ b/portals/devportal/src/main/webapp/package-lock.json
@@ -27,7 +27,7 @@
                 "ajv": "^8.12.0",
                 "async-mutex": "^0.5.0",
                 "autosuggest-highlight": "^3.3.4",
-                "axios": "^0.30.0",
+                "axios": "^1.12.2",
                 "base64url": "3.0.1",
                 "btoa": "^1.2.1",
                 "caniuse-api": "^3.0.0",
@@ -7914,17 +7914,6 @@
                 "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.40 <1.0.0-rc.0"
             }
         },
-        "node_modules/@swagger-api/apidom-reference/node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -9583,12 +9572,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.30.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.1.tgz",
-            "integrity": "sha512-2XabsR1u0/B6OoKy57/xJmPkQiUvdoV93oW4ww+Xjee7C2er/O5U77lvqycDkT2VQDtfjYcjw8ZV8GDaoqwjHQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
             }

--- a/portals/devportal/src/main/webapp/package.json
+++ b/portals/devportal/src/main/webapp/package.json
@@ -46,7 +46,7 @@
         "ajv": "^8.12.0",
         "async-mutex": "^0.5.0",
         "autosuggest-highlight": "^3.3.4",
-        "axios": "^0.30.0",
+        "axios": "^1.12.2",
         "base64url": "3.0.1",
         "btoa": "^1.2.1",
         "caniuse-api": "^3.0.0",

--- a/portals/publisher/src/main/webapp/package-lock.json
+++ b/portals/publisher/src/main/webapp/package-lock.json
@@ -10074,9 +10074,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",


### PR DESCRIPTION
### Purpose
Upgrade `axios` to v1.12.2

### Approach
- Previously, we were using `axios@0.30.x` as a direct dependency in the DevPortal, while `axios@1.x` was being pulled in as a transitive dependency across all three portals.
- We've now updated the direct dependency to `axios@1.x`, ensuring that only the `1.x` version is used moving forward.

Note: There is no official migration guide, but I followed this community resource [1]. No coding changes were required based on the doc. 

Note 2: There are a few usages of `axios` in the `AuthManager` and `ConfigManager` in the devportal, but these are no longer used in the latest version. We can further verify this and remove the direct `axios` dependency if it's no longer needed.

[1] https://github.com/bmuenzenmeyer/axios-1.0.0-migration-guide?tab=readme-ov-file