### PR TITLE
Fix lifecycle state chip rendering issue in search results

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/APICards/ApiThumbClassic.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/APICards/ApiThumbClassic.jsx
@@ -335,6 +335,10 @@ class APIThumb extends Component {
 
         overviewPath = getBasePath(api.apiType) + api.id + '/overview';
 
+        if (!api.lifeCycleStatus) {
+            api.lifeCycleStatus = api.status;
+        }
+        
         let lifecycleState;
         if (api.apiType === API.CONSTS.APIProduct) {
             lifecycleState = api.state === 'PROTOTYPED' ? 'PRE-RELEASED' : api.state;
@@ -344,9 +348,6 @@ class APIThumb extends Component {
             lifecycleState = api.lifeCycleStatus === 'PROTOTYPED' ? 'PRE-RELEASED' : api.lifeCycleStatus;
         }
 
-        if (!api.lifeCycleStatus) {
-            api.lifeCycleStatus = api.status;
-        }
 
         // Helper function to render ribbon content
         const renderRibbon = () => {

--- a/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
+++ b/tests/cypress/integration/publisher/011-lifecycle/04-depricate-old-versions.spec.js
@@ -100,10 +100,6 @@ describe("Depricate old versions of api before publishing", () => {
           publisherComonPage.waitUntillPublisherLoadingSpinnerExit();
           cy.get("#searchQuery").type(apiName).type("{enter}");
           cy.wait(10000);
-          cy.get(`div[data-testid="card-action-${apiName}1.0.0"]`, {
-            timeout: Cypress.config().largeTimeout,
-          }).click();
-          cy.wait(3000);
           cy.get(`div[data-testid="card-${apiName}1.0.0"]`, {
             timeout: Cypress.config().largeTimeout,
           })

--- a/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
+++ b/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
@@ -139,8 +139,6 @@ describe("Publish thirdparty api", () => {
             
 
                 cy.get(`div[data-testid="card-${apiName}1.0.0"]`, { timeout: Cypress.config().largeTimeout })
-                    .wait(2000)
-                    .trigger('mouseover')
                     .should('contain.text', 'PUBLISHED')
                     .click();
                     


### PR DESCRIPTION
### Purpose
Previously, in publisher portal unified search results, the lifecyclestate of the APIs were not loading unless the card is hovered. Purpose of this PR is to fix that issue.
Fixes https://github.com/wso2/api-manager/issues/4052

### Approach
Corrected the ordering of the lifecycle state handling logic.
Updated the tests accordingly

### Screenshots
N/A