### PR TITLE
Add read_only gateway mode filtering for create API UIs

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/AddEditGWEnvironment.jsx
@@ -287,6 +287,17 @@ function AddEditGWEnvironment(props) {
         dispatch({ field: e.target.name, value: e.target.value });
     };
 
+    useEffect(() => {
+        if (!supportedModes?.includes(gatewayMode) && supportedModes?.length > 0) {
+            onChange({
+                target: {
+                    name: 'gatewayMode',
+                    value: supportedModes[0],
+                },
+            });
+        }
+    }, [supportedModes, gatewayMode, onChange]);
+
     /* const getBorderColor = (gatewayTypeNew) => {
         return gatewayType === gatewayTypeNew
             ? '2px solid #1976D2'

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -96,17 +96,16 @@ function APICreateRoutes() {
         if (!isLoading) {
             setApiTypes(publisherSettings.gatewayFeatureCatalog.apiTypes);
             const data = publisherSettings.gatewayTypes;
-            const modes = publisherSettings.supportedGatewayModes;
-            const updatedData = data.map(item => {
+            const settingsEnvList = publisherSettings.environment;
+            const filteredEnvironments = settingsEnvList ? settingsEnvList
+                .filter(env => env?.mode !== 'READ_ONLY') : [];
+            const distinctGatewayTypes = [...new Set(filteredEnvironments.map(env => env.gatewayType))];
+            const commonGatewayTypes = distinctGatewayTypes.filter(type => data.includes(type));
+            const updatedData = commonGatewayTypes.map(item => {
                 if (item === "Regular") return "wso2/synapse";
                 if (item === "APK") return "wso2/apk";
                 return item;
-            })
-                .filter(item => {
-                    const modeList = modes[item];
-                    // Filter out any gateway which has only 'READ_ONLY' mode supported
-                    return !(modeList?.length === 1 && modeList[0] === 'READ_ONLY');
-                });
+            });
             setGatewayTypes(updatedData);
 
             const customGateways = {};

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APICreateRoutes.jsx
@@ -67,6 +67,12 @@ let gatewayDetails = {
         name: 'AWS Gateway', 
         description: 'API gateway offered by AWS cloud.', 
         isNew: false 
+    },
+    'Azure': { 
+        value: 'Azure',
+        name: 'Azure Gateway', 
+        description: 'API gateway offered by Azure cloud.', 
+        isNew: false 
     }
 };
 
@@ -90,11 +96,17 @@ function APICreateRoutes() {
         if (!isLoading) {
             setApiTypes(publisherSettings.gatewayFeatureCatalog.apiTypes);
             const data = publisherSettings.gatewayTypes;
+            const modes = publisherSettings.supportedGatewayModes;
             const updatedData = data.map(item => {
                 if (item === "Regular") return "wso2/synapse";
                 if (item === "APK") return "wso2/apk";
                 return item;
-            });
+            })
+                .filter(item => {
+                    const modeList = modes[item];
+                    // Filter out any gateway which has only 'READ_ONLY' mode supported
+                    return !(modeList?.length === 1 && modeList[0] === 'READ_ONLY');
+                });
             setGatewayTypes(updatedData);
 
             const customGateways = {};

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -169,12 +169,6 @@ export default function DefaultAPIForm(props) {
     const [statusCode, setStatusCode] = useState('');
     const [isUpdating, setUpdating] = useState(false);
     const [isErrorCode, setIsErrorCode] = useState(false);
-    const [gatewayToEnvMap, setGatewayToEnvMap] = useState({
-        'wso2/synapse': true,
-        'wso2/apk': true,
-        'AWS': true,
-        'Azure': true,
-    });
     const iff = (condition, then, otherwise) => (condition ? then : otherwise);
 
     const getBorderColor = (gatewayType) => {
@@ -198,27 +192,6 @@ export default function DefaultAPIForm(props) {
                     }
                 });
             }
-
-            const settingsEnvList = settings?.environment;
-            multiGateway.forEach((gateway) => {
-                if (settings?.gatewayTypes.length >= 2 && Object
-                    .values(gatewayTypeMap).includes(gateway.value)) {
-                    for (const env of settingsEnvList) {
-                        const tmpEnv = gatewayTypeMap[env.gatewayType];
-                        if (tmpEnv === gateway.value) {
-                            setGatewayToEnvMap((prevMap) => ({
-                                ...prevMap,
-                                [gateway.value]: true,
-                            }));
-                            break;
-                        }
-                        setGatewayToEnvMap((prevMap) => ({
-                            ...prevMap,
-                            [gateway.value]: false,
-                        }));
-                    }
-                }
-            });
         }
 
     }, []);
@@ -821,7 +794,6 @@ export default function DefaultAPIForm(props) {
                                                     value={gateway.value}
                                                     className={classes.radioOutline}
                                                     control={<Radio />}
-                                                    disabled={!gatewayToEnvMap[gateway.value]}
                                                     label={(
                                                         <div>
                                                             <span>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Components/DefaultAPIForm.jsx
@@ -39,6 +39,7 @@ const gatewayTypeMap = {
     'Regular': 'wso2/synapse',
     'APK': 'wso2/apk',
     'AWS': 'AWS',
+    'Azure' :'Azure',
 }
 
 const classes = {
@@ -172,6 +173,7 @@ export default function DefaultAPIForm(props) {
         'wso2/synapse': true,
         'wso2/apk': true,
         'AWS': true,
+        'Azure': true,
     });
     const iff = (condition, then, otherwise) => (condition ? then : otherwise);
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
@@ -83,6 +83,12 @@ const ApiCreateWithAI = () => {
             name: 'AWS Gateway',
             description: 'API gateway offered by AWS cloud.',
             isNew: false
+        },
+        'Azure': {
+            value: 'Azure',
+            name: 'Azure Gateway',
+            description: 'API gateway offered by Azure cloud.',
+            isNew: false
         }
     };
 
@@ -112,10 +118,16 @@ const ApiCreateWithAI = () => {
         if (!isLoading) {
             const apiTypes = settings.gatewayFeatureCatalog.apiTypes;
             const data = settings.gatewayTypes;
+            const modes = settings.supportedGatewayModes;
             const gatewayTypes = data.map(item => {
                 if (item === "Regular") return "wso2/synapse";
                 if (item === "APK") return "wso2/apk";
                 return item;
+            })
+            .filter(item => {
+                const modeList = modes[item];
+                // Filter out any gateway which has only 'READ_ONLY' mode supported
+                return !(modeList?.length === 1 && modeList[0] === 'READ_ONLY');
             });
 
             const customGateways = {};

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/CreateAPIWithAI/APICreateWithAI.jsx
@@ -118,16 +118,15 @@ const ApiCreateWithAI = () => {
         if (!isLoading) {
             const apiTypes = settings.gatewayFeatureCatalog.apiTypes;
             const data = settings.gatewayTypes;
-            const modes = settings.supportedGatewayModes;
-            const gatewayTypes = data.map(item => {
+            const settingsEnvList = settings.environment;
+            const filteredEnvironments = settingsEnvList ? settingsEnvList
+                .filter(env => env?.mode !== 'READ_ONLY') : [];
+            const distinctGatewayTypes = [...new Set(filteredEnvironments.map(env => env.gatewayType))];
+            const commonGatewayTypes = distinctGatewayTypes.filter(type => data.includes(type));
+            const gatewayTypes = commonGatewayTypes.map(item => {
                 if (item === "Regular") return "wso2/synapse";
                 if (item === "APK") return "wso2/apk";
                 return item;
-            })
-            .filter(item => {
-                const modeList = modes[item];
-                // Filter out any gateway which has only 'READ_ONLY' mode supported
-                return !(modeList?.length === 1 && modeList[0] === 'READ_ONLY');
             });
 
             const customGateways = {};

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/Default/APICreateDefault.jsx
@@ -42,6 +42,7 @@ const gatewayTypeMap = {
     'Regular': 'wso2/synapse',
     'APK': 'wso2/apk',
     'AWS': 'AWS',
+    'Azure': 'Azure',
 };
 
 const getPolicies = async () => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/DeploymentOnbording.jsx
@@ -180,6 +180,9 @@ export default function DeploymentOnboarding(props) {
                 case 'solace':
                     gatewayType = 'Solace';
                     break;
+                case 'Azure':
+                    gatewayType = 'Azure';
+                    break;
                 default:
                     if (gatewayTypes.includes(api.gatewayType)) {
                         gatewayType = api.gatewayType;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -555,6 +555,9 @@ export default function Environments() {
                     case 'AWS':
                         gatewayType = 'AWS';
                         break;
+                    case 'Azure':
+                        gatewayType = 'Azure';
+                        break;
                     default:
                         if (settings.gatewayTypes.includes(api.gatewayType)) {
                             gatewayType = api.gatewayType;


### PR DESCRIPTION
This PR adds read_only gateway mode filtering for create API UIs.

Related PR - https://github.com/wso2/carbon-apimgt/pull/13422

When there are no environments with 'WRITE_ONLY' or 'READ_WRITE' modes other than Universal gateway, the UI looks like below. The API will be deployed to Universal Gateway by default.

**Admin Portal View**
<img width="1910" height="883" alt="Screenshot 2025-09-26 at 19 06 37" src="https://github.com/user-attachments/assets/7aac216a-0ad3-43a0-a587-1b2f94ec2dff" />
**Publisher portal Create API View**
<img width="1917" height="876" alt="Screenshot 2025-09-26 at 19 06 53" src="https://github.com/user-attachments/assets/3eaeaf67-3eb4-448f-bf7d-d3339fcc56a9" />

When there are environments with at least one of 'WRITE_ONLY' or 'READ_WRITE' modes, the UI looks like below.

**Admin Portal View**
<img width="1912" height="881" alt="Screenshot 2025-09-26 at 19 06 13" src="https://github.com/user-attachments/assets/2d492980-e011-43d2-a677-711d23717225" />
**Publisher portal Create API View**
<img width="961" height="424" alt="Screenshot 2025-09-26 at 19 05 42" src="https://github.com/user-attachments/assets/10b9201a-b7ec-42c5-8a1f-f38006ce0d7b" />
