### PR TITLE
Update moesif analytics link

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/data/defaultTheme.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/defaultTheme.js
@@ -135,7 +135,7 @@ export default {
         leftMenuTextStyle: 'capitalize',
         leftMenuAnalytics: {
             enable: true, // If `false`, External link to Moesif Basic Analytics icon will be removed/hidden in nav bar
-            link: 'https://www.moesif.com/moesif-basic',
+            link: 'https://www.moesif.com/wrap/basic?onboard=true',
         },
         resourceChipColors: { // https://github.com/swagger-api/swagger-ui/blob/master/src/style/_variables.scss#L45-L52
             get: '#61affe',


### PR DESCRIPTION
This pull request makes a minor update to the analytics link in the default theme configuration. The link for the left menu analytics now points to a new onboarding URL.

- Changed the `leftMenuAnalytics.link` in `defaultTheme.js` to use `https://www.moesif.com/wrap/basic?onboard=true` instead of the previous URL.