### PR TITLE
Base64 encode env ID path param in case special chars exist

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGatewayInstances.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGatewayInstances.jsx
@@ -67,12 +67,19 @@ export default function ListGatewayInstances({
         EXPIRED: 'error',
     };
 
+    const needsEncoding = (str) => /[^A-Za-z0-9]/.test(str);
+
     const fetchData = () => {
         setLoading(true);
         setError(null);
         setGateways([]);
         const restApi = new API();
-        restApi.getEnvironmentGateways(environmentId)
+        // Encode the environment ID if it contains special characters
+        let encodedEnvId = environmentId;
+        if (needsEncoding(environmentId)) {
+            encodedEnvId = btoa(environmentId);
+        }
+        restApi.getEnvironmentGateways(encodedEnvId)
             .then((result) => {
                 if (result.body && Array.isArray(result.body.list)) {
                     setGateways(result.body.list);


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4368

- Env ID path param value is base 64 endcoded in case the param value contains any special characters 

Related backend improvement : https://github.com/wso2/carbon-apimgt/pull/13433