### PR TITLE
Fix MCP backend security configuration issues

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/MCPServers/Details/Endpoints/AddEditEndpoint.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/MCPServers/Details/Endpoints/AddEditEndpoint.jsx
@@ -498,16 +498,29 @@ const AddEditEndpoint = ({
     };
 
     const saveEndpointSecurityConfig = (endpointSecurityObj) => {
-        setEndpointSecurityConfig(endpointSecurityObj);
+        const { type } = endpointSecurityObj;
+        let newEndpointSecurityObj = endpointSecurityObj;
+        const secretPlaceholder = '******';
+        newEndpointSecurityObj.clientSecret = newEndpointSecurityObj.clientSecret
+            === secretPlaceholder ? '' : newEndpointSecurityObj.clientSecret;
+        newEndpointSecurityObj.password = newEndpointSecurityObj.password
+            === secretPlaceholder ? '' : newEndpointSecurityObj.password;
+        if (type === 'NONE') {
+            newEndpointSecurityObj = { ...CONSTS.DEFAULT_ENDPOINT_SECURITY, type };
+        } else {
+            newEndpointSecurityObj.enabled = true;
+        }
+
+        setEndpointSecurityConfig(newEndpointSecurityObj);
         if (endpointType === CONSTS.DEPLOYMENT_STAGE.production) {
             dispatch({
                 field: 'updateProductionEndpointSecurity',
-                value: endpointSecurityObj,
+                value: newEndpointSecurityObj,
             });
         } else {
             dispatch({
                 field: 'updateSandboxEndpointSecurity',
-                value: endpointSecurityObj,
+                value: newEndpointSecurityObj,
             });
         }
         setEndpointSecurityConfigOpen(false);


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/4376

This pull request refines the handling of endpoint security configuration in the `AddEditEndpoint` component. The main improvement is ensuring that sensitive fields like `clientSecret` and `password` are not unintentionally overwritten with placeholder values, and that the security object is properly reset or enabled based on the selected security type.

**Endpoint security configuration improvements:**

* Updated `saveEndpointSecurityConfig` to clear placeholder values (`'******'`) for `clientSecret` and `password`, preventing accidental storage of placeholders.
* Ensured that when the security type is `'NONE'`, the configuration resets to default values, and for other types, the `enabled` flag is set to `true`.
* Updated Redux dispatches to use the modified security object, ensuring consistent state updates for both production and sandbox endpoints.