### PR TITLE
Fix SSE API endpoints page NPE by excluding SSE from Swagger fetch

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -724,7 +724,7 @@ function Endpoints(props) {
     };
 
     useEffect(() => {
-        if (api.type !== 'WS' && !api.isMCPServer()) {
+        if (!['WS', 'SSE'].includes(api.type) && !api.isMCPServer()) {
             api.getSwagger(apiObject.id).then((resp) => {
                 setSwagger(resp.obj);
             }).catch((err) => {


### PR DESCRIPTION
## Description
Fixes a NullPointerException that occurs when trying to access the Endpoints page of Server-Sent Events (SSE) APIs in the API Publisher.

## Root Cause
The code was incorrectly attempting to fetch Swagger definitions for SSE APIs using the REST API Swagger retrieval method (`api.getSwagger()`). This caused a NPE in `OASParserUtil.getSwaggerVersion()` when the parser tried to process a null/invalid specification returned for the SSE API.

## Solution
Extended the existing condition that excludes WebSocket APIs from Swagger fetching to also exclude SSE APIs:
- **Before:** `api.type !== 'WS'` 
- **After:** `!['WS', 'SSE'].includes(api.type)`

## Impact
- SSE API Endpoints pages now load without errors
- Maintains existing functionality for all other API types

## Related Issue
- https://github.com/wso2/api-manager/issues/4139