### PR TITLE
Handle failing scenarios of third party API UI test

### DIFF
--- a/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
+++ b/tests/cypress/integration/publisher/018-third-party-api/00-publish-third-party-api.spec.js
@@ -20,7 +20,7 @@ import Utils from "@support/utils";
 import PublisherComonPage from "../../../support/pages/publisher/PublisherComonPage";
 import DevportalComonPage from "../../../support/pages/devportal/DevportalComonPage";
 const publisherComonPage = new PublisherComonPage();
-const devportalComonPage = new PublisherComonPage();
+const devportalComonPage = new DevportalComonPage();
 
 let apiId ;
 let apiName;
@@ -152,6 +152,8 @@ describe("Publish thirdparty api", () => {
             });
     });
     afterEach(function () {
+        cy.logoutFromPublisher();
+        cy.logoutFromDevportal();
         cy.log("deleting api ", apiId);
         cy.loginToPublisher(publisher, password);
         publisherComonPage.waitUntillPublisherLoadingSpinnerExit();


### PR DESCRIPTION
### Issue
The afterEach hook of third party API was failing due to an authentication issue. So if the test fails, it cannot delete the API correctly. It might affect the other tests. 

### Approach
Add force logout to the afterEach hook

### Preview
N/A