### PR TITLE
Fix provide oauth keys button

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -290,8 +290,7 @@ class TokenManager extends React.Component {
     handleClickRemove = (keyMappingId) => {
         const {
             selectedTab, keyType, intl,
-        } = this.props;
-        
+        } = this.props; 
         this.application
             .then((application) => {
                 return application.removeKeys(keyType, selectedTab, keyMappingId);
@@ -414,7 +413,6 @@ class TokenManager extends React.Component {
 
                     // Check if keys actually exist for this tab and keyType
                     const hasKeysForCurrentTab = keys.size > 0 && keys.get(selectedTab) && keys.get(selectedTab).keyType === keyType;
-
                     if (hasKeysForCurrentTab) {
                         const {
                             callbackUrl, supportedGrantTypes, additionalProperties, mode,
@@ -1409,4 +1407,3 @@ TokenManager.propTypes = {
 };
 
 export default injectIntl((TokenManager));
-cd C:\Users\User\Downloads\apim-apps

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -291,6 +291,7 @@ class TokenManager extends React.Component {
         const {
             selectedTab, keyType, intl,
         } = this.props;
+        
         this.application
             .then((application) => {
                 return application.removeKeys(keyType, selectedTab, keyMappingId);
@@ -411,7 +412,10 @@ class TokenManager extends React.Component {
                     const keys = response[1];
                     const { keyRequest } = this.state;
 
-                    if (keys.size > 0 && keys.get(selectedTab) && keys.get(selectedTab).keyType === keyType) {
+                    // Check if keys actually exist for this tab and keyType
+                    const hasKeysForCurrentTab = keys.size > 0 && keys.get(selectedTab) && keys.get(selectedTab).keyType === keyType;
+
+                    if (hasKeysForCurrentTab) {
                         const {
                             callbackUrl, supportedGrantTypes, additionalProperties, mode,
                         } = keys.get(selectedTab);
@@ -447,6 +451,8 @@ class TokenManager extends React.Component {
                             },
                             keyManagers: responseKeyManagerList,
                             selectedTab,
+                            importDisabled: false, 
+                            mode: null,            
                         });
                     }
                 })
@@ -1403,3 +1409,4 @@ TokenManager.propTypes = {
 };
 
 export default injectIntl((TokenManager));
+cd C:\Users\User\Downloads\apim-apps

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx
@@ -290,7 +290,7 @@ class TokenManager extends React.Component {
     handleClickRemove = (keyMappingId) => {
         const {
             selectedTab, keyType, intl,
-        } = this.props; 
+        } = this.props;
         this.application
             .then((application) => {
                 return application.removeKeys(keyType, selectedTab, keyMappingId);


### PR DESCRIPTION
## Description
Fixes the issue where the "Provide Existing OAuth Keys" button remains disabled after removing keys until the page is refreshed.

## Problem
When users click "Remove Keys", the button state is not properly updated in the UI. The `importDisabled` and `mode` states remain set to their previous values, causing the button to stay disabled. The button only becomes enabled after a manual page refresh when `loadApplication()` fetches the current state from the backend.

## Root Cause
The `loadApplication()` method in `TokenManager.jsx` was not setting `importDisabled: false` and `mode: null` in the else block (when no keys exist). This caused the button to remain in its previous disabled state after key removal.

## Solution
Modified the `loadApplication()` method to:
- Extract the key existence check into a descriptive `hasKeysForCurrentTab` variable for better readability
- Set `importDisabled: false` in the else block to enable the button when no keys exist
- Set `mode: null` in the else block to reset the mode state
- This allows the button to become clickable immediately after key removal without requiring a page refresh

## Changes Made
**File:** `portals/devportal/src/main/webapp/source/src/app/components/Shared/AppsAndKeys/TokenManager.jsx`

- Added descriptive comment for the key existence check
- Extracted condition into `hasKeysForCurrentTab` constant
- Added `importDisabled: false` to state update when no keys exist
- Added `mode: null` to state update when no keys exist

## Testing Done
- Tested with Resident Key Manager (default)
- Verified button enables immediately after clicking "Remove Keys" without page refresh
- Confirmed "Provide Existing OAuth Keys" dialog opens correctly
- Verified API returns correct empty keys response `{"count":0,"list":[]}`
- Confirmed the fix works for both Production and Sandbox keys

Uploading [Devportal]- WSO2 APIM - Personal - Microsoft​ Edge 2025-10-02 17-20-39.mp4…

)

## Impact
This fix improves the user experience by providing immediate feedback when keys are removed, eliminating the need for manual page refreshes.

Fixes wso2/api-manager#4281