### PR TITLE
Fix: Adjust button text casing in Dev Portal (#3858)

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
+++ b/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
@@ -40,6 +40,21 @@ const DefaultConfigurations = {
             color: '#666',
         },
     },
+    overrides: {
+        MuiOutlinedInput: {
+            root: {
+                borderColor: '#444',
+            },
+            notchedOutline: {
+                borderColor: '#444',
+            },
+        },
+        MuiButton: {
+            root: {
+                textTransform: 'none',
+            },
+        },
+    },
     custom: {
         contentAreaWidth: 1240,
         backgroundImage: '', // Add a watermark background to the content area of the page. Example ( '/devportal/site/public/images/back-light.png')
@@ -395,16 +410,6 @@ const DefaultConfigurations = {
             backgroundColor: '#89b7d1',
         },
         showSwaggerDescriptionOnOverview: false,
-        overrides: {
-            MuiOutlinedInput: {
-                root: {
-                    borderColor: '#444',
-                },
-                notchedOutline: {
-                    borderColor: '#444',
-                },
-            },
-        },
     },
 };
 


### PR DESCRIPTION
Resolves #3858

What was the problem?
In the Devportal theme, all MuiButton components were rendering their text in ALL CAPS, regardless of the casing used in the code (e.g., "Title Case"). This was due to the default text-transform: uppercase style in Material-UI not being overridden.

How was this fixed?
This pull request corrects the issue by moving the overrides block from its incorrect location inside the custom theme object to the top level of the DefaultConfigurations object in defaultTheme.js.
Specifically, the MuiButton override with textTransform: 'none' is now correctly structured to be recognized by the Material-UI theme engine, ensuring that button text is displayed exactly as it is written.

How to test this:
Navigate to any page in the Devportal that contains a button (e.g., the Try Out button in API overview page).
Verify that the button text is now displayed in title case, not in all caps. For example, a button with the text "Try Out" should appear as "Try Out", not "TRY OUT".