### PR TITLE
Fix: Default radio button for Mock Implementation endpoints when adding Mock endpoint.

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -188,6 +188,10 @@ function Endpoints(props) {
             }
             case 'endpointImplementationType': { // set implementation status
                 const { endpointType, implementationType } = value;
+                if(endpointType === 'INLINE' || endpointType === 'MOCKED_OAS') {
+                    const tmpconfig = createEndpointConfig('prototyped');
+                    return { ...initState, endpointConfig: tmpconfig, endpointImplementationType: endpointType};
+                }
                 const config = createEndpointConfig(endpointType);
                 if (endpointType === 'prototyped') {
                     if (implementationType === 'mock') {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/Endpoints.jsx
@@ -188,19 +188,16 @@ function Endpoints(props) {
             }
             case 'endpointImplementationType': { // set implementation status
                 const { endpointType, implementationType } = value;
-                if(endpointType === 'INLINE' || endpointType === 'MOCKED_OAS') {
-                    const tmpconfig = createEndpointConfig('prototyped');
-                    return { ...initState, endpointConfig: tmpconfig, endpointImplementationType: endpointType};
-                }
                 const config = createEndpointConfig(endpointType);
-                if (endpointType === 'prototyped') {
+                if (endpointType === 'INLINE' || endpointType === 'MOCKED_OAS') {
+                    const tmpconfig = createEndpointConfig('prototyped');
                     if (implementationType === 'mock') {
                         api.generateMockScripts(api.id).then((res) => { // generates mock/sample payloads
                             setSwagger(res.obj);
                         });
-                        return { ...initState, endpointConfig: config, endpointImplementationType: 'INLINE' };
+                        return { ...initState, endpointConfig: tmpconfig, endpointImplementationType: endpointType };
                     }
-                    return { ...initState, endpointConfig: config, endpointImplementationType: 'ENDPOINT' };
+                    return { ...initState, endpointConfig: tmpconfig, endpointImplementationType: 'ENDPOINT' };
                 }
                 return { ...initState, endpointConfig: config };
             }


### PR DESCRIPTION
Resolves wso2/api-manager#3680

**What was the problem?**
When a user added a "Mock Implementation" for an API endpoint, the UI would incorrectly select the "Dynamic Endpoints" radio button by default on the subsequent configuration page.
This was due to the createEndpointConfig utility function lacking a specific case to handle the 'INLINE' endpoint type. As a result, it fell through to the default case, generating a configuration that the UI interpreted as a "Dynamic Endpoint".

**How was this fixed?**
This pull request implements a complete fix by addressing the issue at all three relevant points in the code, ensuring 'INLINE' endpoints are handled correctly and consistently.
Updated the Reducer (Endpoints.jsx): The reducer's 'endpointImplementationType' case was modified to explicitly handle an endpointType of 'INLINE'. It now correctly sets endpointImplementationType: 'INLINE' in the state and triggers the mock script generation, resolving the primary bug.
Added 'INLINE' Case (endpointUtils.js): A new case for 'INLINE' was added to the createEndpointConfig function. This ensures a valid, prototyped configuration is generated, preventing the system from falling back to a 'default' config.
Removed Workaround (EndpointOverview.jsx): The inconsistent logic that mapped 'INLINE' to 'prototyped' within the component has been removed. The component now calls createEndpointConfig with the correct 'INLINE' type directly, centralizing the configuration logic.

**How to test this:**
Log in to the Publisher portal and create an API without endpoints.
navigate to an API's Endpoints section under API Configurations.
Under the Mock Implementation card, click the Add button.
On the endpoint configuration page, verify that the "Mock Implementation" radio button is now correctly selected by default (and not "Dynamic Endpoints").