### PR TITLE
Improvements to create and publish api product error handling

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APIProduct/APIProductCreateWrapper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APIProduct/APIProductCreateWrapper.jsx
@@ -248,8 +248,7 @@ export default function ApiProductCreateWrapper(props) {
                         defaultMessage: 'Something went wrong while adding the API Product',
                     }))
                 }
-            }
-            );
+            })
     };
 
     const createAndPublishAPIProduct = () => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APIProduct/APIProductCreateWrapper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/APIProduct/APIProductCreateWrapper.jsx
@@ -228,23 +228,28 @@ export default function ApiProductCreateWrapper(props) {
                 return apiProduct;
             })
             .catch((error) => {
-                if (error.response) {
-                    Alert.error(error.response.body.description);
-                } else {
-                    Alert.error(intl.formatMessage({
-                        id: 'Apis.APIProductCreateWrapper.error.errorMessage.create.api.product',
-                        defaultMessage: 'Something went wrong while adding the API Product',
-                    }));
-                }
+                throw error;
             })
             .finally(() => setCreating(false));
         return promisedCreatedAPIProduct.finally(() => setCreating(false));
     };
 
     const createAPIProductOnly = () => {
-        createAPIProduct().then((apiProduct) => {
-            history.push(`/api-products/${apiProduct.id}/overview`);
-        });
+        createAPIProduct()
+            .then((apiProduct) => {
+                history.push(`/api-products/${apiProduct.id}/overview`);
+            })
+            .catch((error) => {
+                if (error.response) {
+                    Alert.error(error.response.body.description);
+                } else {
+                    Alert.error(intl.formatMessage({
+                        id: 'Apis.APIProductCreateWrapper.error.errorMessage.create.api.product',
+                        defaultMessage: 'Something went wrong while adding the API Product',
+                    }))
+                }
+            }
+            );
     };
 
     const createAndPublishAPIProduct = () => {
@@ -252,10 +257,6 @@ export default function ApiProductCreateWrapper(props) {
         createAPIProduct()
             .then((apiProduct) => {
                 setIsRevisioning(true);
-                Alert.info(intl.formatMessage({
-                    id: 'Apis.Create.APIProduct.APIProductCreateWrapper.created.success',
-                    defaultMessage: 'API Product created successfully',
-                }));
                 const body = {
                     description: 'Initial Revision',
                 };
@@ -329,7 +330,6 @@ export default function ApiProductCreateWrapper(props) {
                             })
                             .finally(() => {
                                 setIsPublishing(false);
-                                setIsPublishButtonClicked(false);
                             });
                     })
                     .catch((error) => {
@@ -354,7 +354,10 @@ export default function ApiProductCreateWrapper(props) {
                     }))
                 }
             })
-            .finally(() => setCreating(false));
+            .finally(() => {
+                setCreating(false);
+                setIsPublishButtonClicked(false);
+            });
     };
 
     return <>


### PR DESCRIPTION
### Purpose

Following is the current behaviour of `create & publish` API product.
1. For errors,

-  In the flow, `createAndPublishAPIProduct`  invokes  `createAPIProduct()`
- .catch() inside `createAPIProduct `handles the error but does not rethrow it
-  Therefore .then() in `createAndPublishAPIProduct `still gets called
-  This results in alerting unwanted success alert and state issues in button as it set `setIsRevisioning(true)`

<img width="1512" height="982" alt="Screenshot 2025-10-16 at 11 39 49" src="https://github.com/user-attachments/assets/9cba6896-bf89-4371-a9d2-0da101f1c5a7" />


2. For sucess,

- Duplicate product creation success alerts are coming as both  `createAndPublishAPIProduct`  and  `createAPIProduct()` have defined them
<img width="1512" height="982" alt="Screenshot 2025-10-16 at 11 43 56" src="https://github.com/user-attachments/assets/5a48c690-867b-43ae-92ff-4cafb46721a0" />

### Approach

- Let `createAPIProduct()` throw the errors so that both `createAndPublishAPIProduct` and ` createAPIProductOnly` can handle them
- Remove duplicate success alert from `createAndPublishAPIProduct` 
- Make the state changes at right place


Fixes wso2/api-manager/issues/4461

