### PR TITLE
Add e2e and unit tests for Key Manager Configuration Constraints feature

### DIFF
--- a/portals/devportal/src/main/webapp/source/Tests/Unit/constraintValidator.test.js
+++ b/portals/devportal/src/main/webapp/source/Tests/Unit/constraintValidator.test.js
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import validateConstraint, { VALIDATOR_TYPES, getConstraintHint } from 'AppComponents/Shared/AppsAndKeys/constraintValidator';
+
+const mockIntl = {
+    formatMessage: (msg, values) => {
+        let { defaultMessage } = msg;
+        if (values) {
+            Object.keys(values).forEach((key) => {
+                defaultMessage = defaultMessage.replace(`{${key}}`, values[key]);
+            });
+        }
+        return defaultMessage;
+    },
+};
+
+const mockMessages = {
+    rangeMin: { defaultMessage: 'Value must be at least {min}' },
+    rangeMax: { defaultMessage: 'Value must be at most {max}' },
+    rangeInvalid: { defaultMessage: 'Value must be a number between {min} and {max}' },
+    regexInvalid: { defaultMessage: 'Value must match the required pattern: {pattern}' },
+};
+
+describe('constraintValidator', () => {
+    describe('validateConstraint', () => {
+        describe('MIN validation', () => {
+            const constraint = {
+                type: VALIDATOR_TYPES.MIN,
+                value: { min: 10 },
+            };
+
+            it('should return valid for value greater than min', () => {
+                const result = validateConstraint('15', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return valid for value equal to min', () => {
+                const result = validateConstraint('10', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return invalid for value less than min', () => {
+                const result = validateConstraint('5', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+                expect(result.message).toBe('Value must be at least 10');
+            });
+
+            it('should return invalid for non-numeric value', () => {
+                const result = validateConstraint('abc', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+            });
+
+            it('should return invalid for empty value', () => {
+                const result = validateConstraint('', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+            });
+
+            it('should handle negative numbers correctly', () => {
+                const negConstraint = { type: VALIDATOR_TYPES.MIN, value: { min: -5 } };
+                expect(validateConstraint('-3', negConstraint, mockIntl, mockMessages).valid).toBe(true);
+                expect(validateConstraint('-10', negConstraint, mockIntl, mockMessages).valid).toBe(false);
+            });
+
+            it('should handle decimal numbers correctly', () => {
+                const decConstraint = { type: VALIDATOR_TYPES.MIN, value: { min: 5.5 } };
+                expect(validateConstraint('5.6', decConstraint, mockIntl, mockMessages).valid).toBe(true);
+                expect(validateConstraint('5.4', decConstraint, mockIntl, mockMessages).valid).toBe(false);
+            });
+        });
+
+        describe('MAX validation', () => {
+            const constraint = {
+                type: VALIDATOR_TYPES.MAX,
+                value: { max: 100 },
+            };
+
+            it('should return valid for value less than max', () => {
+                const result = validateConstraint('50', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return valid for value equal to max', () => {
+                const result = validateConstraint('100', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return invalid for value greater than max', () => {
+                const result = validateConstraint('150', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+                expect(result.message).toBe('Value must be at most 100');
+            });
+
+            it('should handle zero correctly', () => {
+                const zeroConstraint = { type: VALIDATOR_TYPES.MAX, value: { max: 0 } };
+                expect(validateConstraint('-1', zeroConstraint, mockIntl, mockMessages).valid).toBe(true);
+                expect(validateConstraint('0', zeroConstraint, mockIntl, mockMessages).valid).toBe(true);
+                expect(validateConstraint('1', zeroConstraint, mockIntl, mockMessages).valid).toBe(false);
+            });
+        });
+
+        describe('RANGE validation', () => {
+            const constraint = {
+                type: VALIDATOR_TYPES.RANGE,
+                value: { min: 10, max: 20 },
+            };
+
+            it('should return valid for value within range', () => {
+                const result = validateConstraint('15', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return valid for value at min bound', () => {
+                const result = validateConstraint('10', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return valid for value at max bound', () => {
+                const result = validateConstraint('20', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return invalid for value below min', () => {
+                const result = validateConstraint('5', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+                expect(result.message).toBe('Value must be a number between 10 and 20');
+            });
+
+            it('should return invalid for value above max', () => {
+                const result = validateConstraint('25', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+                expect(result.message).toBe('Value must be a number between 10 and 20');
+            });
+
+            it('should return invalid for non-numeric value', () => {
+                const result = validateConstraint('abc', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+            });
+        });
+
+        describe('REGEX validation', () => {
+            const constraint = {
+                type: VALIDATOR_TYPES.REGEX,
+                value: { pattern: '^[0-9]+$' },
+            };
+
+            it('should return valid for matching value', () => {
+                const result = validateConstraint('123', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return invalid for non-matching value', () => {
+                const result = validateConstraint('abc', constraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(false);
+                expect(result.message).toBe('Value must match the required pattern: ^[0-9]+$');
+            });
+
+            it('should return valid if regex pattern is invalid (to prevent app crash)', () => {
+                const badConstraint = { type: VALIDATOR_TYPES.REGEX, value: { pattern: '[' } };
+                const result = validateConstraint('any', badConstraint, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+        });
+
+        describe('Edge Cases', () => {
+            it('should return valid if no constraint is provided', () => {
+                const result = validateConstraint('val', null, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+
+            it('should return valid if constraint type is unknown', () => {
+                const result = validateConstraint('val', { type: 'UNKNOWN' }, mockIntl, mockMessages);
+                expect(result.valid).toBe(true);
+            });
+        });
+    });
+
+    describe('getConstraintHint', () => {
+        it('should return empty string for missing arguments', () => {
+            expect(getConstraintHint(null, mockIntl, mockMessages)).toBe('');
+            expect(getConstraintHint({}, mockIntl, mockMessages)).toBe('');
+        });
+
+        it('should return correct hint for MIN', () => {
+            const constraint = { type: VALIDATOR_TYPES.MIN, value: { min: 5 } };
+            expect(getConstraintHint(constraint, mockIntl, mockMessages)).toBe('Value must be at least 5');
+        });
+
+        it('should return correct hint for MAX', () => {
+            const constraint = { type: VALIDATOR_TYPES.MAX, value: { max: 50 } };
+            expect(getConstraintHint(constraint, mockIntl, mockMessages)).toBe('Value must be at most 50');
+        });
+
+        it('should return correct hint for RANGE', () => {
+            const constraint = { type: VALIDATOR_TYPES.RANGE, value: { min: 5, max: 10 } };
+            expect(getConstraintHint(constraint, mockIntl, mockMessages)).toBe('Value must be a number between 5 and 10');
+        });
+
+        it('should return correct hint for REGEX', () => {
+            const constraint = { type: VALIDATOR_TYPES.REGEX, value: { pattern: '.*' } };
+            expect(getConstraintHint(constraint, mockIntl, mockMessages)).toBe('Value must match the required pattern: .*');
+        });
+
+        it('should return empty string for unknown type', () => {
+            const constraint = { type: 'UNKNOWN', value: { some: 'val' } };
+            expect(getConstraintHint(constraint, mockIntl, mockMessages)).toBe('');
+        });
+    });
+});

--- a/portals/devportal/src/main/webapp/source/Tests/Unit/constraintValidator.test.js
+++ b/portals/devportal/src/main/webapp/source/Tests/Unit/constraintValidator.test.js
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -29,7 +29,6 @@ const mockIntl = {
         return defaultMessage;
     },
 };
-
 const mockMessages = {
     rangeMin: { defaultMessage: 'Value must be at least {min}' },
     rangeMax: { defaultMessage: 'Value must be at most {max}' },

--- a/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
+++ b/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may turn a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from '@support/utils';
+
+describe('Key Manager Constraints (Admin & DevPortal)', () => {
+    const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+    const kmName = 'ConstraintsTestKM';
+    const appName = Utils.generateName();
+    const wellKnownUrl = 'https://localhost:9443/oauth2/token/.well-known/openid-configuration';
+    const kmUsername = 'admin';
+    const kmPassword = 'admin';
+    const scopeManagementEndpoint = 'https://localhost:9443/api/identity/oauth2/v1.0/scopes';
+    const maxConstraintValues = {
+        appToken: '3600',
+        userToken: '7200',
+        refreshToken: '86400',
+        idToken: '3600',
+    };
+    const CONSTRAINT_LABELS = {
+        appToken: 'Maximum Application Access Token Expiry Time',
+        userToken: 'Maximum User Access Token Expiry Time',
+        refreshToken: 'Maximum Refresh Token Expiry Time',
+        idToken: 'Maximum ID Token Expiry Time',
+    };
+    const getConstraintWrapper = (label) => {
+        return cy.contains('p', label, { timeout: 10000 })
+            .scrollIntoView({ offset: { top: -100, left: 0 } })
+            .parent() 
+            .parent();
+    };
+    const toggleConstraintOn = (label) => {
+        getConstraintWrapper(label)
+            .find('input[type="checkbox"]')
+            .check({ force: true });
+        getConstraintWrapper(label)
+            .find('input[type="checkbox"]')
+            .should('be.checked');
+    };
+    const getNumericInput = (label) => {
+        return getConstraintWrapper(label).find('input[type="text"]');
+    };
+    const expandConstraintsSection = () => {
+        cy.get('#KeyManagers\\.AddEditKeyManager\\.app\\.config\\.constraints\\.header', {
+            timeout: Cypress.config().largeTimeout,
+        }).scrollIntoView({ offset: { top: -100, left: 0 } }).click();
+    };
+
+    it('1. should create a WSO2 IS Key Manager in Admin portal and set constraints', () => {
+        cy.loginToAdmin(carbonUsername, carbonPassword);
+        cy.get('[data-testid="Key Managers"]', { timeout: Cypress.config().largeTimeout }).click();
+    
+        // Click Add Key Manager
+        cy.get('[data-testid="add-key-manager-button"]', { timeout: Cypress.config().largeTimeout }).click();
+
+        // Fill Basic Info
+        cy.get('input[name="name"]', { timeout: Cypress.config().largeTimeout }).type(kmName);
+        cy.get('input[name="displayName"]').type(`${kmName}`);
+        cy.get('[data-testid="key-manager-type-select"]').click();
+        cy.get('li[data-value="WSO2-IS"]').click();
+        cy.get('input[name="wellKnownEndpoint"]').type(wellKnownUrl);
+        cy.intercept('**/key-managers/discover').as('importConfig');
+        cy.get('#import-button').contains('Import').click();
+        cy.wait('@importConfig', { timeout: 3000 }).then(() => {
+            cy.get('input[name="Username"]').type(kmUsername);
+            cy.get('input[name="Password"]').type(kmPassword);
+            cy.get('input[name="scopeManagementEndpoint"]').clear().type(scopeManagementEndpoint);
+            cy.get('[data-testid="key-manager-permission-select"]').click();
+            cy.get('li[data-value="PUBLIC"]').click();
+            cy.get('#KeyManagers\\.AddEditKeyManager\\.app\\.config\\.constraints\\.header')
+                .scrollIntoView({ offset: { top: -100, left: 0 } })
+                .should('be.visible');
+            expandConstraintsSection();
+
+            toggleConstraintOn(CONSTRAINT_LABELS.appToken);
+            getNumericInput(CONSTRAINT_LABELS.appToken).clear().type(maxConstraintValues.appToken);
+
+            toggleConstraintOn(CONSTRAINT_LABELS.userToken);
+            getNumericInput(CONSTRAINT_LABELS.userToken).clear().type(maxConstraintValues.userToken);
+
+            toggleConstraintOn(CONSTRAINT_LABELS.refreshToken);
+            getNumericInput(CONSTRAINT_LABELS.refreshToken).clear().type(maxConstraintValues.refreshToken);
+
+            toggleConstraintOn(CONSTRAINT_LABELS.idToken);
+            getNumericInput(CONSTRAINT_LABELS.idToken).clear().type(maxConstraintValues.idToken);
+
+            // Save new KM
+            cy.intercept('POST', '**/key-managers').as('createKM');
+            cy.get('#keymanager-add')
+                .scrollIntoView({ offset: { top: -200, left: 0 } })
+                .contains('Add')
+                .click({ force: true });
+            cy.wait('@createKM', { timeout: 15000 }).its('response.statusCode').should('eq', 201);
+        });
+    });
+
+    it('2. should enforce the configured constraints in the DevPortal', () => {
+        cy.loginToDevportal(carbonUsername, carbonPassword);
+        cy.createApp(appName, 'E2E test for constraints');
+        
+        // Navigate to OAuth keys generation tab
+        cy.get('#production-keys-oauth', { timeout: Cypress.config().largeTimeout }).click();
+        cy.get(`#${kmName}`, { timeout: Cypress.config().largeTimeout })
+            .scrollIntoView({ offset: { top: -100, left: 0 } })
+            .should('be.visible')
+            .click({ force: true });
+
+        // Function to check a specific DevPortal Max constraint
+        const verifyMaxConstraint = (inputId, maxAllowedValue) => {
+            const inputSelector = `#${inputId}`; 
+            cy.get(inputSelector, { timeout: Cypress.config().largeTimeout })
+                .scrollIntoView({ offset: { top: -150, left: 0 } })
+                .should('be.visible')
+                .clear({ force: true })
+                .type('99999999', { force: true }); 
+            cy.get(inputSelector).blur();
+
+            // Error helper text
+            cy.get(inputSelector)
+                .parent()
+                .parent()
+                .find('p.Mui-error', { timeout: 10000 })
+                .scrollIntoView({ offset: { top: -150, left: 0 } })
+                .should('be.visible')
+                .and('contain.text', maxAllowedValue);
+
+            // Correcting the value
+            cy.get(inputSelector)
+                .clear({ force: true })
+                .type(maxAllowedValue, { force: true });
+
+            cy.get(inputSelector).blur();
+            cy.get(inputSelector)
+                .parent()
+                .parent()
+                .find('p.Mui-error')
+                .should('not.exist');
+        };
+        verifyMaxConstraint('application_access_token_expiry_time', maxConstraintValues.appToken);
+        verifyMaxConstraint('user_access_token_expiry_time', maxConstraintValues.userToken);
+        verifyMaxConstraint('refresh_token_expiry_time', maxConstraintValues.refreshToken);
+        verifyMaxConstraint('id_token_expiry_time', maxConstraintValues.idToken);
+        cy.deleteApp(appName);
+    });
+
+    after(() => {
+        cy.visit('/admin/settings/key-managers/');
+        cy.get('td > div', { timeout: Cypress.config().largeTimeout })
+            .contains(kmName)
+            .scrollIntoView({ offset: { top: -100, left: 0 } })
+            .should('be.visible');
+        cy.contains('tr', kmName).within(() => {
+            cy.get('[aria-label="key-manager-delete-icon"]').click({ force: true });
+        });
+        cy.intercept('DELETE', '**/key-managers/**').as('deleteKM');
+        cy.get('[data-testid="form-dialog-base-save-btn"]', { timeout: 10000 })
+            .should('be.visible')
+            .click({ force: true });
+        cy.wait('@deleteKM', { timeout: 15000 }).its('response.statusCode').should('eq', 200);
+    });
+});

--- a/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
+++ b/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
@@ -20,7 +20,7 @@ import Utils from '@support/utils';
 
 describe('Key Manager Constraints (Admin & DevPortal)', () => {
     const { carbonUsername, carbonPassword } = Utils.getUserInfo();
-    const kmName = 'ConstraintsTestKM';
+    const kmName = `ConstraintsTestKM-${Utils.generateName()}`;
     const appName = Utils.generateName();
     const wellKnownUrl = 'https://localhost:9443/oauth2/token/.well-known/openid-configuration';
     const kmUsername = 'admin';
@@ -160,17 +160,21 @@ describe('Key Manager Constraints (Admin & DevPortal)', () => {
 
     after(() => {
         cy.visit('/admin/settings/key-managers/');
-        cy.get('td > div', { timeout: Cypress.config().largeTimeout })
-            .contains(kmName)
-            .scrollIntoView({ offset: { top: -100, left: 0 } })
-            .should('be.visible');
-        cy.contains('tr', kmName).within(() => {
-            cy.get('[aria-label="key-manager-delete-icon"]').click({ force: true });
+        // Guard deletion: only delete when the KM row is actually present so a
+        // failed creation test does not mask its own error with a teardown failure.
+        cy.get('td > div', { timeout: Cypress.config().largeTimeout }).then(($els) => {
+            const kmExists = Array.from($els).some((el) => el.textContent.includes(kmName));
+            if (kmExists) {
+                // Register the intercept before triggering the click to avoid a race condition.
+                cy.intercept('DELETE', '**/key-managers/**').as('deleteKM');
+                cy.contains('tr', kmName).within(() => {
+                    cy.get('[aria-label="key-manager-delete-icon"]').click({ force: true });
+                });
+                cy.get('[data-testid="form-dialog-base-save-btn"]', { timeout: 10000 })
+                    .should('be.visible')
+                    .click({ force: true });
+                cy.wait('@deleteKM', { timeout: 15000 }).its('response.statusCode').should('eq', 200);
+            }
         });
-        cy.intercept('DELETE', '**/key-managers/**').as('deleteKM');
-        cy.get('[data-testid="form-dialog-base-save-btn"]', { timeout: 10000 })
-            .should('be.visible')
-            .click({ force: true });
-        cy.wait('@deleteKM', { timeout: 15000 }).its('response.statusCode').should('eq', 200);
     });
 });

--- a/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
+++ b/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
@@ -4,7 +4,7 @@
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * You may turn a copy of the License at
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
+++ b/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
@@ -56,9 +56,6 @@ describe('Key Manager Constraints (Admin & DevPortal)', () => {
         return getConstraintWrapper(label).find('input[type="text"]');
     };
     const expandConstraintsSection = () => {
-        cy.get('#KeyManagers\\.AddEditKeyManager\\.claim\\.mappings\\.header', {
-            timeout: Cypress.config().largeTimeout,
-        }).scrollIntoView({ offset: { top: -100, left: 0 } }).should('be.visible');
         cy.get('#KeyManagers\\.AddEditKeyManager\\.app\\.config\\.constraints\\.header', {
             timeout: Cypress.config().largeTimeout,
         }).scrollIntoView({ offset: { top: -100, left: 0 } }).click();

--- a/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
+++ b/tests/cypress/integration/e2e/keyManagerConstraints/00-WSO2-IS-km-constraints.spec.js
@@ -56,6 +56,9 @@ describe('Key Manager Constraints (Admin & DevPortal)', () => {
         return getConstraintWrapper(label).find('input[type="text"]');
     };
     const expandConstraintsSection = () => {
+        cy.get('#KeyManagers\\.AddEditKeyManager\\.claim\\.mappings\\.header', {
+            timeout: Cypress.config().largeTimeout,
+        }).scrollIntoView({ offset: { top: -100, left: 0 } }).should('be.visible');
         cy.get('#KeyManagers\\.AddEditKeyManager\\.app\\.config\\.constraints\\.header', {
             timeout: Cypress.config().largeTimeout,
         }).scrollIntoView({ offset: { top: -100, left: 0 } }).click();


### PR DESCRIPTION
## Purpose 

$Subject

Fixes
- https://github.com/wso2/api-manager/issues/4734

## Description
Adds `00-WSO2-IS-km-constraints.spec.js` (E2E) and `constraintValidator.test.js`(Unit).

E2E: Covers 
- Creation of a WSO2-IS type key manager in Admin Portal with constraints
- Creation of an application in DevPortal
- Verify the creation of OAuth2 tokens using test values that adhere to and violate the specified constraints.
- Remove created application and the key manager

Unit: Covers MIN, MAX, RANGE, REGEX validation scenarios and edge cases.

## Related PRs
- https://github.com/wso2/apim-apps/pull/1246

## Related Issues
- https://github.com/wso2/api-manager/issues/4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for constraint validation covering MIN, MAX, RANGE, and REGEX validators, including edge cases (non-numeric, empty, negative, decimal), unknown/missing constraints, invalid regex handling, and hint message verification.
  * Added end-to-end tests for Key Manager constraint workflows: create/configure key manager, apply and enforce constraint settings, validate numeric input and error messaging during app/key generation, and automated cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->