### PR TITLE
Fix Connector Configurations hidden after switching from Token Exchange type

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/KeyManagers/AddEditKeyManager.jsx
@@ -287,6 +287,9 @@ function AddEditKeyManager(props) {
         if (keyManagerType === 'tokenExchange') {
             setEnableDirectToken(false);
             setEnableExchangeToken(true);
+        } else {
+            setEnableDirectToken(true);
+            setEnableExchangeToken(false);
         }
         if (settings.keyManagerConfiguration) {
             settings.keyManagerConfiguration.map(({


### PR DESCRIPTION
## Summary
- When switching the Key Manager type from "Token Exchange" back to another type (e.g., WSO2 Identity Server), the Connector Configurations section remained hidden
- Root cause: `enableDirectToken` was set to `false` when Token Exchange was selected, but never restored to `true` when switching away
- Added `else` branch in `updateKeyManagerConnectorConfiguration` to reset `enableDirectToken=true` and `enableExchangeToken=false` for non-Token Exchange types

Fixes: https://github.com/wso2/api-manager/issues/4852

## Test plan
- [x] Reproduced the bug with Playwright automation before fix
- [x] Verified the fix with Playwright — Connector Configurations correctly reappears after switching back from Token Exchange
- [ ] Manual testing: Admin Portal > Key Managers > Add > Select WSO2-IS > Switch to Token Exchange > Switch back > Verify Connector Configurations is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed key manager configuration to properly set token exchange flags for non-exchange token manager types during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->