### PR TITLE
fix monaco find widget icons not rendering in API Definition view

### DIFF
--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -201,10 +201,16 @@ module.exports = (env, argv) => {
                 },
                 {
                     test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
-                    loader: 'url-loader',
-                    options: {
-                        limit: 8192,
-                    },
+                    type: 'javascript/auto',
+                    use: [
+                        {
+                            loader: 'url-loader',
+                            options: {
+                                limit: 8192,
+                                esModule: false,
+                            },
+                        },
+                    ],
                 },
                 // Until we migrate to webpack 5 https://github.com/jantimon/html-webpack-plugin/issues/1483 ~tmkb
                 // This is added to generate the index.jsp from a hbs template file including the hashed bundle file


### PR DESCRIPTION
## Summary
- Fixes the bug where the Monaco editor find widget (Ctrl+F) in the API Definition page shows empty boxes instead of icons for match-case, whole-word, regex, prev/next and close
- Root cause: in webpack 5, `monaco-editor-webpack-plugin`'s internal `asset/resource` rule was intercepting `.ttf` and css-loader was receiving url-loader's default ES module export and stringifying it as `[object Module]` inside the `@font-face` `src` URL, so the codicon font failed to load
- Fix in `portals/publisher/src/main/webapp/webpack.config.js`:
  - Added `type: 'javascript/auto'` on the font/asset rule so `monaco-editor-webpack-plugin`'s internal `asset/resource` rule does not hijack `.ttf`
  - Added `esModule: false` so url-loader emits a CommonJS string that css-loader can embed directly in `url(...)`
  - Kept `limit: 8192` unchanged so codicon.ttf (~105 KiB) is still emitted as a separate cacheable file, not inlined

## Related Issue
- Fixes https://github.com/wso2/api-manager/issues/4714

## Test plan
- [x] Open Publisher → any API → API Definition
- [x] Press Ctrl+F inside the editor
- [x] Verify the find widget shows proper icons (Aa, ab, .*, ↑, ↓, ×) instead of empty boxes
- [x] In DevTools console, `document.fonts.check('16px codicon')` returns `true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for asset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->