### PR TITLE
[UI][Admin Portal] Improve validation feedback in Governance Action Dialog

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/Governance/Policies/ActionConfigDialog.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/Governance/Policies/ActionConfigDialog.jsx
@@ -34,6 +34,7 @@ import {
     Radio,
     Grid,
     Alert,
+    FormHelperText,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -51,6 +52,7 @@ export default function ActionConfigDialog({
             info: CONSTS.GOVERNANCE_ACTIONS.NOTIFY,
         },
     });
+    const [isSubmitted, setIsSubmitted] = useState(false);
 
     useEffect(() => {
         setFormState(editAction || {
@@ -76,8 +78,11 @@ export default function ActionConfigDialog({
     };
 
     const handleSave = () => {
-        onSave(formState);
-        handleClose(); // Reset the form after saving
+        setIsSubmitted(true);
+        if (isValid()) {
+            onSave(formState);
+            handleClose(); // Reset the form after saving
+        }
     };
 
     const isValid = () => {
@@ -101,7 +106,11 @@ export default function ActionConfigDialog({
             </DialogTitle>
             <DialogContent sx={{ p: 3 }}>
                 <Box mb={3} mt={1}>
-                    <FormControl fullWidth size='small'>
+                    <FormControl
+                        fullWidth
+                        size='small'
+                        error={isSubmitted && !formState.governedState}
+                    >
                         <InputLabel>
                             <FormattedMessage
                                 id='Governance.Policies.AddEdit.enforcement.state.label'
@@ -148,6 +157,14 @@ export default function ActionConfigDialog({
                                 </MenuItem>
                             ))}
                         </Select>
+                        {isSubmitted && !formState.governedState && (
+                            <FormHelperText>
+                                <FormattedMessage
+                                    id='Governance.Policies.AddEdit.enforcement.state.required'
+                                    defaultMessage='This field is required'
+                                />
+                            </FormHelperText>
+                        )}
                     </FormControl>
                 </Box>
 


### PR DESCRIPTION
### Problem
In the Admin Portal governance policy configuration, the "Action Configuration" dialog disables the "Save" button when mandatory fields (like "Governed State") are missing, but it fails to provide visual feedback or error messages to the user. This creates a confusing user experience where the user has to guess why they cannot proceed.

### Solution
Implemented inline validation feedback for the "Governed State" field:
- Added `isSubmitted` state to track when the user first attempts to save.
- Updated `FormControl` to display an `error` state and a `FormHelperText` when validation fails.
- Used `FormattedMessage` for localized error messages, adhering to WSO2 standards.

### Impact
Improves the usability and self-service capability of the Governance features in the Admin Portal by providing immediate, clear feedback during configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form validation now properly prevents saving when required fields are empty.
  * Visual error indicators are displayed for unfilled required fields during submission attempts.
  * Added helpful messages to guide users when completing the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->