### PR TITLE
Improve publisher deployment status handling and DevPortal auth UX

### DIFF
--- a/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGWEnviornments.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/GatewayEnvironments/ListGWEnviornments.jsx
@@ -455,7 +455,7 @@ export default function ListGWEnviornments() {
     };
 
     const renderGatewayType = (gatewayType) => {
-        if (gatewayType === 'APIPlatform') {
+        if (gatewayType === CONSTS.API_PLATFORM_GATEWAY) {
             return intl.formatMessage({
                 id: 'Gateways.AddEditGateway.title.platform',
                 defaultMessage: 'API Platform Gateway',

--- a/portals/admin/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/admin/src/main/webapp/source/src/app/data/Constants.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/** Carbon APIConstants.WSO2_API_PLATFORM_GATEWAY wire value. */
+const API_PLATFORM_GATEWAY = 'APIPlatform';
+
 const CONSTS = {
     API: 'API',
     APIProduct: 'APIProduct',
@@ -123,10 +126,11 @@ const CONSTS = {
         BLOCK: 'BLOCK',
         NOTIFY: 'NOTIFY',
     },
+    API_PLATFORM_GATEWAY,
     GATEWAY_TYPE: {
         regular: 'Regular',
         apk: 'APK',
-        apiPlatform: 'APIPlatform',
+        apiPlatform: API_PLATFORM_GATEWAY,
     },
 };
 

--- a/portals/devportal/src/main/webapp/site/public/locales/en.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/en.json
@@ -22,7 +22,6 @@
   "Apis.Details.APIConsole.GenerateCurl.downloadAria": "Download generated cURL as a file",
   "Apis.Details.APIConsole.GenerateCurl.noLiveResponseBody": "No response body. Execute the cURL command to capture the gateway response.",
   "Apis.Details.APIConsole.GenerateCurl.noLiveResponseDetail": "Not applicable. This try-out does not send the request; run the generated cURL in your environment to see status and body.",
-  "Apis.Details.APIConsole.GenerateCurl.oauthBasicHint": "Placeholders are used for OAuth and Basic credentials. Replace <ACCESS_TOKEN> or <BASE64_CREDENTIALS> with the values from the Access Token field or your Basic credentials in try-out.",
   "Apis.Details.APIConsole.GenerateCurl.requestUrlHeading": "Request URL",
   "Apis.Details.APIConsole.GenerateCurl.responseBodyHeading": "Response body",
   "Apis.Details.APIConsole.GenerateCurl.responseHeadersHeading": "Response headers",

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -40,7 +40,6 @@ import { ApiContext } from '../ApiContext';
 import Progress from '../../../Shared/Progress';
 import Api from '../../../../data/api';
 import SwaggerUI from './SwaggerUI';
-import isPlatformGatewayApi from './platformGateway';
 import TryOutController from '../../../Shared/ApiTryOut/TryOutController';
 import Application from '../../../../data/Application';
 
@@ -534,13 +533,7 @@ class ApiConsole extends React.Component {
         if (api && api.securityScheme) {
             isApiKeyEnabled = api.securityScheme.includes('api_key');
             if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
-                if (isPlatformGatewayApi(api)) {
-                    // API Platform / Universal only: honor Publisher API Key policy header name
-                    authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
-                } else {
-                    // Classic gateway — unchanged behavior (must not regress non-platform flows)
-                    authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
-                }
+                authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
             }
         }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -535,8 +535,10 @@ class ApiConsole extends React.Component {
             isApiKeyEnabled = api.securityScheme.includes('api_key');
             if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
                 if (isPlatformGatewayApi(api)) {
-                    authorizationHeader = 'ApiKey';
+                    // API Platform / Universal only: honor Publisher API Key policy header name
+                    authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
                 } else {
+                    // Classic gateway — unchanged behavior (must not regress non-platform flows)
                     authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
                 }
             }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/GenerateCurlExecute.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/GenerateCurlExecute.jsx
@@ -270,9 +270,7 @@ class GenerateCurlExecute extends Component {
                 method,
                 operation,
             });
-            const getScheme = this.props.getSecuritySchemeType;
-            const securitySchemeType = typeof getScheme === 'function' ? getScheme() : 'OAUTH';
-            const curlText = requestObjectToCurl(mutated, securitySchemeType);
+            const curlText = requestObjectToCurl(mutated);
             const requestUrl = mutated && mutated.url ? String(mutated.url) : '';
             this.setState({
                 curlText,
@@ -300,7 +298,6 @@ class GenerateCurlExecute extends Component {
     render() {
         const {
             disabled,
-            getSecuritySchemeType,
             intl,
         } = this.props;
         const copyTooltip = intl.formatMessage({
@@ -318,8 +315,6 @@ class GenerateCurlExecute extends Component {
         const {
             curlText, requestUrl, busy, error, copyDone,
         } = this.state;
-        const scheme = typeof getSecuritySchemeType === 'function' ? getSecuritySchemeType() : 'OAUTH';
-        const showAuthPlaceholderHint = curlText && (scheme === 'OAUTH' || scheme === 'BASIC');
         const hasOutput = Boolean(curlText);
 
         return (
@@ -490,16 +485,6 @@ class GenerateCurlExecute extends Component {
                                     —
                                 </pre>
                             </div>
-                            {showAuthPlaceholderHint && (
-                                <p className='small' style={{ marginTop: 8, opacity: 0.85 }}>
-                                    <FormattedMessage
-                                        id='Apis.Details.APIConsole.GenerateCurl.oauthBasicHint'
-                                        defaultMessage={'Placeholders are used for OAuth and Basic credentials. '
-                                            + 'Replace <ACCESS_TOKEN> or <BASE64_CREDENTIALS> with the values from '
-                                            + 'the Access Token field or your Basic credentials in try-out.'}
-                                    />
-                                </p>
-                            )}
                         </div>
                     </div>
                 )}

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/SwaggerUI.jsx
@@ -6,13 +6,12 @@ import CustomPadLock from './CustomPadLock';
 import GenerateCurlExecute from './GenerateCurlExecute';
 import isPlatformGatewayApi from './platformGateway';
 
-const generateCurlTryoutPlugin = (getSecuritySchemeType) => ({
+const generateCurlTryoutPlugin = () => ({
     wrapComponents: {
         execute: (_, system) => (props) => (
             <GenerateCurlExecute
                 {...props}
                 getSystem={system.getSystem}
-                getSecuritySchemeType={getSecuritySchemeType}
             />
         ),
     },
@@ -62,19 +61,29 @@ const SwaggerUI = (props) => {
             const { context } = api;
             const currentSecuritySchemeType = securitySchemeRef.current;
             const currentAuthHeader = authorizationHeaderRef.current;
+            const rawToken = accessTokenProvider();
+            const token = (rawToken === undefined || rawToken === null) ? '' : String(rawToken).trim();
+            const hasToken = token !== '' && token.toLowerCase() !== 'undefined' && token.toLowerCase() !== 'null';
+            req.headers = req.headers || {};
             const patternToCheck = `${context}/*`;
             if (currentSecuritySchemeType === 'API-KEY') {
-                req.headers[currentAuthHeader] = accessTokenProvider();
-            } else if (currentSecuritySchemeType === 'BASIC') {
-                req.headers[currentAuthHeader] = 'Basic ' + accessTokenProvider();
-            } else if (currentSecuritySchemeType === 'TEST') {
-                req.headers[currentAuthHeader] = accessTokenProvider();
-            } else if (api.advertiseInfo && api.advertiseInfo.advertised) {
-                if (currentAuthHeader) {
-                    req.headers[currentAuthHeader] = accessTokenProvider();
+                if (currentAuthHeader && hasToken) {
+                    req.headers[currentAuthHeader] = token;
                 }
-            } else {
-                req.headers[currentAuthHeader] = 'Bearer ' + accessTokenProvider();
+            } else if (currentSecuritySchemeType === 'BASIC') {
+                if (currentAuthHeader && hasToken) {
+                    req.headers[currentAuthHeader] = `Basic ${token}`;
+                }
+            } else if (currentSecuritySchemeType === 'TEST') {
+                if (currentAuthHeader && hasToken) {
+                    req.headers[currentAuthHeader] = token;
+                }
+            } else if (api.advertiseInfo && api.advertiseInfo.advertised) {
+                if (currentAuthHeader && hasToken) {
+                    req.headers[currentAuthHeader] = token;
+                }
+            } else if (currentAuthHeader && hasToken) {
+                req.headers[currentAuthHeader] = `Bearer ${token}`;
             }
             if (url.endsWith(patternToCheck)) {
                 req.url = url.substring(0, url.length - 2);
@@ -88,7 +97,7 @@ const SwaggerUI = (props) => {
         plugins: [
             disableAuthorizeAndInfoPlugin(spec),
             ...(isPlatformGatewayApi(api)
-                ? [generateCurlTryoutPlugin(() => securitySchemeRef.current)]
+                ? [generateCurlTryoutPlugin()]
                 : []),
         ],
     };

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/buildTryoutCurlRequest.js
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/buildTryoutCurlRequest.js
@@ -162,10 +162,9 @@ function escapeShellSingleQuotes(value) {
 
 /**
  * @param {object} req mutated request from swagger-client (url, method, headers, body, ...)
- * @param {string} [securitySchemeType] Try-out security: OAUTH, API-KEY, BASIC (OAuth/Basic use placeholders).
  * @returns {string}
  */
-export function requestObjectToCurl(req, securitySchemeType) {
+export function requestObjectToCurl(req) {
     const method = (req.method || 'GET').toUpperCase();
     const url = req.url || '';
     const lines = [`curl -X '${method}'`, `  '${escapeShellSingleQuotes(url)}'`];
@@ -174,17 +173,6 @@ export function requestObjectToCurl(req, securitySchemeType) {
     Object.keys(headers).forEach((key) => {
         const val = headers[key];
         if (val === undefined || val === null || val === '') {
-            return;
-        }
-        const lowerKey = key.toLowerCase();
-        if (lowerKey === 'authorization') {
-            let displayVal = val;
-            if (securitySchemeType === 'OAUTH') {
-                displayVal = 'Bearer <ACCESS_TOKEN>';
-            } else if (securitySchemeType === 'BASIC') {
-                displayVal = 'Basic <BASE64_CREDENTIALS>';
-            }
-            lines.push(`  -H '${escapeShellSingleQuotes(`Authorization: ${displayVal}`)}'`);
             return;
         }
         lines.push(`  -H '${escapeShellSingleQuotes(`${key}: ${val}`)}'`);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/platformGateway.js
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/platformGateway.js
@@ -16,13 +16,18 @@
  * under the License.
  */
 
+import CONSTS from 'AppData/Constants';
+
 /**
- * APIs deployed to the API Platform / Universal gateway use gatewayType "Universal"
- * (see org.wso2.carbon.apimgt.api.APIConstants.WSO2_API_PLATFORM_GATEWAY).
+ * APIs deployed to the API Platform gateway use gateway type `APIPlatform` (see CONSTS.API_PLATFORM_GATEWAY).
  *
  * @param {object|null|undefined} api DevPortal API object
- * @returns {boolean}
+ * @returns {boolean} true when the API uses the API Platform gateway type
  */
 export default function isPlatformGatewayApi(api) {
-    return Boolean(api && api.gatewayType === 'APIPlatform');
+    if (!api || api.gatewayType == null || typeof api.gatewayType !== 'string') {
+        return false;
+    }
+    const gt = api.gatewayType;
+    return gt === CONSTS.API_PLATFORM_GATEWAY || gt.toUpperCase() === 'APIPLATFORM';
 }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
@@ -640,7 +640,16 @@ function TryOutController(props) {
     const isPrototypedAPI = lifeCycleStatus === 'prototyped';
     const isPublished = lifeCycleStatus === 'published';
     const showSecurityType = isPublished || isPrototypedAPI;
-    const hasSupportedSecurityScheme = isApiKeyEnabled || isBasicAuthEnabled || isOAuthEnabled || isTestKeyEnabled;
+    let selectedSchemeEnabled = false;
+    if (securitySchemeType === 'API-KEY') {
+        selectedSchemeEnabled = isApiKeyEnabled;
+    } else if (securitySchemeType === 'BASIC') {
+        selectedSchemeEnabled = isBasicAuthEnabled;
+    } else if (securitySchemeType === 'TEST') {
+        selectedSchemeEnabled = isTestKeyEnabled;
+    } else {
+        selectedSchemeEnabled = isOAuthEnabled;
+    }
 
     const authHeader = `${authorizationHeader}: ${prefix}`;
 
@@ -972,7 +981,7 @@ function TryOutController(props) {
                                     </>
                                 )}
                                 {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
-                                    && hasSupportedSecurityScheme && (
+                                    && selectedSchemeEnabled && (
                                     <TextField
                                         fullWidth
                                         margin='normal'
@@ -1024,7 +1033,7 @@ function TryOutController(props) {
                                 )}
                                 {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
                                 && securitySchemeType !== 'API-KEY'
-                                && selectedKMObject && hasSupportedSecurityScheme && (
+                                && selectedKMObject && selectedSchemeEnabled && (
                                     <>
                                         <Button
                                             onClick={securitySchemeType === 'API-KEY' ? generateApiKey

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
@@ -50,6 +50,7 @@ import CONSTANTS from '../../../data/Constants';
 import SelectAppPanel from './SelectAppPanel';
 import { isMultipleClientSecretsEnabled } from 'AppComponents/Shared/AppsAndKeys/Secrets/util';
 import Alert from 'AppComponents/Shared/Alert';
+import isPlatformGatewayApi from '../../Apis/Details/ApiConsole/platformGateway';
 
 const PREFIX = 'TryOutController';
 
@@ -194,6 +195,7 @@ function TryOutController(props) {
     const apiID = api.id;
     const restApi = new Api();
     const user = AuthManager.getUser();
+    const isPlatformGateway = isPlatformGatewayApi(api);
     const isSubValidationDisabled = api.tiers && api.tiers.length === 1
             && api.tiers[0].tierName.includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN);
 
@@ -608,10 +610,23 @@ function TryOutController(props) {
     let authorizationHeader = api.authorizationHeader ? api.authorizationHeader : 'Authorization';
     let prefix = 'Bearer';
     if (api && api.securityScheme) {
-        isApiKeyEnabled = api.securityScheme.includes('api_key');
-        isBasicAuthEnabled = api.securityScheme.includes('basic_auth');
-        isOAuthEnabled = api.securityScheme.includes('oauth2');
-        isTestKeyEnabled = api.securityScheme.includes('test_auth');
+        const securitySchemeValues = Array.isArray(api.securityScheme)
+            ? api.securityScheme
+            : (typeof api.securityScheme === 'string'
+                ? api.securityScheme.split(',')
+                : [api.securityScheme]);
+        const securitySchemes = new Set(
+            securitySchemeValues.map((s) => String(s).trim().toLowerCase()).filter(Boolean),
+        );
+        isApiKeyEnabled = securitySchemes.has('api_key');
+        isBasicAuthEnabled = securitySchemes.has('basic_auth');
+        isOAuthEnabled = securitySchemes.has('oauth2');
+        isTestKeyEnabled = securitySchemes.has('test_auth');
+        if (isPlatformGateway) {
+            // For Platform APIs, only show OAuth/API Key when mapped headers are available from hub policies.
+            isApiKeyEnabled = isApiKeyEnabled && !!api.apiKeyHeader;
+            isOAuthEnabled = isOAuthEnabled && !!api.authorizationHeader;
+        }
         if (isApiKeyEnabled && securitySchemeType === 'API-KEY') {
             authorizationHeader = api.apiKeyHeader ? api.apiKeyHeader : 'ApiKey';
             prefix = '';
@@ -621,9 +636,11 @@ function TryOutController(props) {
             prefix = '';
         }
     }
-    const isPrototypedAPI = api.lifeCycleStatus && api.lifeCycleStatus.toLowerCase() === 'prototyped';
-    const isPublished = api.lifeCycleStatus.toLowerCase() === 'published';
+    const lifeCycleStatus = (api.lifeCycleStatus || '').toLowerCase();
+    const isPrototypedAPI = lifeCycleStatus === 'prototyped';
+    const isPublished = lifeCycleStatus === 'published';
     const showSecurityType = isPublished || isPrototypedAPI;
+    const hasSupportedSecurityScheme = isApiKeyEnabled || isBasicAuthEnabled || isOAuthEnabled || isTestKeyEnabled;
 
     const authHeader = `${authorizationHeader}: ${prefix}`;
 
@@ -773,7 +790,8 @@ function TryOutController(props) {
                         )}
                     {subscriptions && subscriptions.length === 0 && securitySchemeType !== 'TEST'
                     && securitySchemeType !== 'BASIC' && (api.gatewayVendor === 'wso2' || !api.gatewayVendor)
-                        && (!api.advertiseInfo || !api.advertiseInfo.advertised) && !isSubValidationDisabled ? (
+                        && (!api.advertiseInfo || !api.advertiseInfo.advertised)
+                        && !isSubValidationDisabled && !isPlatformGateway ? (
                             <Grid x={8} md={6} className={classes.tokenType} item>
                                 <Box mb={1} alignItems='center'>
                                     <Typography variant='body1'>
@@ -791,7 +809,8 @@ function TryOutController(props) {
                             </Grid>
                         ) : (
                             (!ksGenerated && securitySchemeType === 'OAUTH') && (!api.advertiseInfo
-                                || !api.advertiseInfo.advertised) && (api.gatewayVendor === 'wso2' || !api.gatewayVendor) && (
+                                || !api.advertiseInfo.advertised) && (api.gatewayVendor === 'wso2' || !api.gatewayVendor)
+                                && !isPlatformGateway && (
                                 <Grid x={8} md={6} className={classes.tokenType} item>
                                     <Box mb={1} alignItems='center'>
                                         <Typography variant='body1'>
@@ -952,7 +971,8 @@ function TryOutController(props) {
                                         </Grid>
                                     </>
                                 )}
-                                {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST' && (
+                                {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
+                                    && hasSupportedSecurityScheme && (
                                     <TextField
                                         fullWidth
                                         margin='normal'
@@ -1004,7 +1024,7 @@ function TryOutController(props) {
                                 )}
                                 {securitySchemeType !== 'BASIC' && securitySchemeType !== 'TEST'
                                 && securitySchemeType !== 'API-KEY'
-                                && selectedKMObject && (
+                                && selectedKMObject && hasSupportedSecurityScheme && (
                                     <>
                                         <Button
                                             onClick={securitySchemeType === 'API-KEY' ? generateApiKey

--- a/portals/devportal/src/main/webapp/source/src/app/data/Constants.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/Constants.jsx
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/** Carbon APIConstants.WSO2_API_PLATFORM_GATEWAY wire value. */
+const API_PLATFORM_GATEWAY = 'APIPlatform';
+
 const CONSTS = {
     HTTP_METHODS: ['get', 'put', 'post', 'delete', 'patch', 'head', 'options'],
     errorCodes: {
@@ -35,6 +38,7 @@ const CONSTS = {
         KEY_GENERATION: 'KEY_GENERATION',
         ADD_SECRET: 'ADD_SECRET',
     },
+    API_PLATFORM_GATEWAY,
 };
 
 export default CONSTS;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Configuration/RuntimeConfiguration.jsx
@@ -33,6 +33,7 @@ import Alert from 'AppComponents/Shared/Alert';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Api from 'AppData/api';
+import CONSTS from 'AppData/Constants';
 import MCPServer from 'AppData/MCPServer';
 import { APIContext } from 'AppComponents/Apis/Details/components/ApiContext';
 import { useAppContext, usePublisherSettings } from 'AppComponents/Shared/AppContext';
@@ -652,7 +653,7 @@ export default function RuntimeConfiguration() {
         return <Progress per={80} message='Loading app settings ...' />;
     }
 
-    if (api.gatewayType === 'APIPlatform') {
+    if (api.gatewayType === CONSTS.API_PLATFORM_GATEWAY) {
         const policiesPath = `${getBasePath(api.apiType)}${api.id}/policies`;
         return (
             <Root>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -2479,13 +2479,15 @@ export default function Environments() {
         if (!allEnvRevision) return false;
 
         const now = Date.now();
+        const anchoredStartTime = pollingStartTimeRef.current ?? now;
 
-        return allEnvRevision.some((revision) => revision.deploymentInfo?.some((env) => {
+        const hasPending = allEnvRevision.some((revision) => revision.deploymentInfo?.some((env) => {
             const failed = env.failedGatewayCount ?? 0;
             const deployed = env.deployedGatewayCount ?? 0;
             const live = env.liveGatewayCount ?? 0;
             const inTimeWindow = env.deployedTime == null
-                || now - env.deployedTime <= MAX_POLLING_DURATION_MS;
+                ? (now - anchoredStartTime <= MAX_POLLING_DURATION_MS)
+                : (now - env.deployedTime <= MAX_POLLING_DURATION_MS);
 
             const synapseStylePending = env.status !== 'CREATED'
                 && failed === 0
@@ -2503,17 +2505,28 @@ export default function Environments() {
 
             return synapseStylePending || universalStylePending;
         }));
+
+        if (hasPending && pollingStartTimeRef.current == null) {
+            pollingStartTimeRef.current = now;
+        } else if (!hasPending) {
+            pollingStartTimeRef.current = null;
+        }
+
+        return hasPending;
     };
     
     useEffect(() => {
         if (settings && settings.isGatewayNotificationEnabled === true) {
             if (hasPendingDeployment()) {
                 if (!pollingRef.current) {
-                    pollingStartTimeRef.current = Date.now();
+                    if (pollingStartTimeRef.current == null) {
+                        pollingStartTimeRef.current = Date.now();
+                    }
                     pollingRef.current = setInterval(() => {
                         if (Date.now() - pollingStartTimeRef.current > MAX_POLLING_DURATION_MS) {
                             clearInterval(pollingRef.current);
                             pollingRef.current = null;
+                            pollingStartTimeRef.current = null;
                             return;
                         }
                         getDeployedEnv(); // Updates allEnvRevision
@@ -2522,12 +2535,14 @@ export default function Environments() {
             } else if (pollingRef.current) {
                 clearInterval(pollingRef.current);
                 pollingRef.current = null;
+                pollingStartTimeRef.current = null;
             }
             return () => {
                 if (pollingRef.current) {
                     clearInterval(pollingRef.current);
                     pollingRef.current = null;
                 }
+                pollingStartTimeRef.current = null;
             };
         }
         return undefined;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -68,6 +68,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import API from 'AppData/api';
+import CONSTS from 'AppData/Constants';
 import MCPServer from 'AppData/MCPServer';
 import { ConfirmDialog } from 'AppComponents/Shared/index';
 import { useRevisionContext } from 'AppComponents/Shared/RevisionContext';
@@ -2252,7 +2253,9 @@ export default function Environments() {
      * for a given environment row using data from allEnvDeployments.
      * 
      * - If deployment data is available, shows status with success/fail counts and progress bar.
-     * - If no deployment data exists, shows "No Active Gateways" message.
+     * - Universal/API Platform may have liveGatewayCount 0 while deployment is pending (notify not yet SUCCESS);
+     *   then deploymentStatus is "Deployment Pending" and we still show the chip (not "No Active Gateways").
+     * - If no deployment data exists, shows "No Active Gateways" when not in that pending state.
      */
     function envDeploymentStatusComponent(row, allEnvDeployments) {
         const envDetails = allEnvDeployments[row.name]?.envDetails;
@@ -2262,7 +2265,8 @@ export default function Environments() {
             const deployed = envDetails.deployedGatewayCount;
             const total = envDetails.liveGatewayCount;
             const failed = envDetails.failedGatewayCount;
-            if (total) {
+            const showGatewayProgress = total > 0 || status === 'Deployment Pending';
+            if (showGatewayProgress) {
                 return (
                     <StyledTooltip
                         title={
@@ -2307,13 +2311,13 @@ export default function Environments() {
                                     <span>{total ?? '-'}</span>
                                 </Box>
                                 <LinearProgress
-                                    variant='determinate'
-                                    value={total ? (deployed / total) * 100 : 0}
+                                    variant={total > 0 ? 'determinate' : 'indeterminate'}
+                                    value={total > 0 ? (deployed / total) * 100 : 0}
                                     color={failed > 0 ? 'error' : 'primary'}
                                     sx={{ height: 6, borderRadius: 2, mb: 0.5 }}
                                 />
                                 <Typography fontWeight='light' variant='caption' display='block' textAlign='right'>
-                                    {total ? ((deployed / total) * 100).toFixed(0) : '0'}%
+                                    {total > 0 ? ((deployed / total) * 100).toFixed(0) : '—'}%
                                     &nbsp;
                                     <FormattedMessage
                                         id='Apis.Details.Environments.Environments.gateway.deployment.percent.deployed'
@@ -2473,20 +2477,32 @@ export default function Environments() {
      */
     const hasPendingDeployment = () => {
         if (!allEnvRevision) return false;
-    
+
         const now = Date.now();
-    
-        return allEnvRevision.some(revision =>
-            revision.deploymentInfo?.some(env =>
-                env.status !== 'CREATED' &&
-                env.failedGatewayCount === 0 &&
-                env.deployedGatewayCount < env.liveGatewayCount &&
-                (
-                    env.deployedTime == null || // allow null or undefined
-                    now - env.deployedTime <= MAX_POLLING_DURATION_MS
-                )
-            )
-        );
+
+        return allEnvRevision.some((revision) => revision.deploymentInfo?.some((env) => {
+            const failed = env.failedGatewayCount ?? 0;
+            const deployed = env.deployedGatewayCount ?? 0;
+            const live = env.liveGatewayCount ?? 0;
+            const inTimeWindow = env.deployedTime == null
+                || now - env.deployedTime <= MAX_POLLING_DURATION_MS;
+
+            const synapseStylePending = env.status !== 'CREATED'
+                && failed === 0
+                && deployed < live
+                && inTimeWindow;
+
+            // Universal / API Platform: live and deployed stay 0 until notify; use 0/0 + APPROVED + no success time
+            const universalStylePending = api.gatewayType === CONSTS.API_PLATFORM_GATEWAY
+                && env.status === 'APPROVED'
+                && failed === 0
+                && deployed === 0
+                && live === 0
+                && !env.successDeployedTime
+                && inTimeWindow;
+
+            return synapseStylePending || universalStylePending;
+        }));
     };
     
     useEffect(() => {
@@ -2539,7 +2555,7 @@ export default function Environments() {
     // allEnvDeployments represents all deployments of the API with mapping
     // environment -> {revision deployed to env, vhost deployed to env with revision}
     const allEnvDeployments = allEnvRevision ?
-        Utils.getAllEnvironmentDeployments(settings.environment, allEnvRevision) : null;
+        Utils.getAllEnvironmentDeployments(settings.environment, allEnvRevision, api.gatewayType) : null;
     const allEnvRevisionMapping = allEnvRevision ?
         Utils.getAllEnvironmentRevisions(settings.environment, allEnvRevision) : null;
 

--- a/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/Constants.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/** Carbon APIConstants.WSO2_API_PLATFORM_GATEWAY wire value. */
+const API_PLATFORM_GATEWAY = 'APIPlatform';
+
 const CONSTS = {
     API: 'API',
     APIProduct: 'APIProduct',
@@ -82,10 +85,11 @@ const CONSTS = {
         PRODUCTION: 'default_production_endpoint',
         SANDBOX: 'default_sandbox_endpoint',
     },
+    API_PLATFORM_GATEWAY,
     GATEWAY_TYPE: {
         synapse: 'Synapse',
         choreoConnect: 'ChoreoConnect',
-        apiPlatform: 'APIPlatform',
+        apiPlatform: API_PLATFORM_GATEWAY,
     },
     CREATE_API_GATEWAYS: {
         'wso2/synapse': {
@@ -113,7 +117,7 @@ const CONSTS = {
             isNew: false,
         },
         APIPlatform: {
-            value: 'APIPlatform',
+            value: API_PLATFORM_GATEWAY,
             name: 'API Platform Gateway',
             description: 'New lightweight, self-hosted API Platform gateway.',
             isNew: true,

--- a/portals/publisher/src/main/webapp/source/src/app/data/Utils.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/Utils.js
@@ -614,7 +614,7 @@ class Utils {
         return username;
     }
 
-    static getAllEnvironmentDeployments(environments, allEnvRevision) {
+    static getAllEnvironmentDeployments(environments, allEnvRevision, apiGatewayType) {
         // allEnvDeployments represents all deployments of the API with mapping
         // environment -> {revision deployed to env, vhost deployed to env with revision}
         const allEnvDeployments = [];
@@ -642,7 +642,7 @@ class Utils {
             }
             // Derive status and color based on gateway counts
             const updatedEnvDetails = envDetails
-                ? this.setDeploymentStatus(envDetails)
+                ? this.setDeploymentStatus(envDetails, apiGatewayType)
                 : null;
             allEnvDeployments[env.name] = { revision, vhost, disPlayDevportal, envDetails: updatedEnvDetails };
         });
@@ -653,7 +653,7 @@ class Utils {
      * Sets deployment status, color, and last updated time for envDetails.
      * @param {Object} envDetails
      */
-    static setDeploymentStatus(envDetails) {
+    static setDeploymentStatus(envDetails, apiGatewayType) {
         const deployed = envDetails.deployedGatewayCount ?? 0;
         const total = envDetails.liveGatewayCount ?? 0;
         const failed = envDetails.failedGatewayCount ?? 0;
@@ -666,6 +666,17 @@ class Utils {
         if (deployed > total || failed > total) {
             status = 'Inconsistent';
             color = 'error';
+        } else if (
+            apiGatewayType === CONSTS.API_PLATFORM_GATEWAY
+            && deployed === 0
+            && total === 0
+            && failed === 0
+            && envDetails.status === 'APPROVED'
+            && !successTime
+        ) {
+            // API Platform / Universal: backend keeps live === deployed === 0 until gateway notify SUCCESS
+            status = 'Deployment Pending';
+            color = 'default';
         } else if (total === 0) {
             status = 'No Gateways Configured';
         } else if (failed > 0) {


### PR DESCRIPTION
### Goal
Fixes: https://github.com/wso2/api-manager/issues/4961
Fixes: https://github.com/wso2/api-manager/issues/4962

### Approach
This pull request introduces several improvements and bug fixes related to API Platform Gateway support, try-out security scheme handling, and cURL generation in the DevPortal and Admin Portal. The main focus is on standardizing the gateway type constant, refining how security schemes are detected and displayed, and ensuring correct header handling for try-out and cURL generation.

**Gateway Type Standardization and Detection:**

* Introduced and consistently used the `API_PLATFORM_GATEWAY` constant in `CONSTS` for identifying API Platform Gateway APIs across the codebase, and updated detection logic in `isPlatformGatewayApi` to be more robust. [[1]](diffhunk://#diff-242c306b7353799c2ab3bcaa231719f877681df6dc2da1ecba8a1b869cb22d1fR17-R19) [[2]](diffhunk://#diff-242c306b7353799c2ab3bcaa231719f877681df6dc2da1ecba8a1b869cb22d1fR129-R133) [[3]](diffhunk://#diff-a9d327d2fe876d4e7d78b2998dd9c622c3e5d87918c865ee81a54230de53cb0aL458-R458) [[4]](diffhunk://#diff-a244ad3e3c8a83991a725f9d752b3e8b0bcb5fa656c150f6b146bdcdecba1f40R19-R32) [[5]](diffhunk://#diff-0a468d5f59c8e2b0c367693e632224ebaccfb0214627a12ba0fbe12ea0d95ed8R17-R19)

**Try-out Security Scheme Handling:**

* Improved detection and display of supported security schemes in `TryOutController.jsx`, ensuring that only valid schemes (with mapped headers) are shown for Platform Gateway APIs, and refined logic for when to show subscription/token UI elements. [[1]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5R198) [[2]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L611-R629) [[3]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L624-R643) [[4]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L776-R794) [[5]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L794-R813) [[6]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L955-R975) [[7]](diffhunk://#diff-590c4fc69a66336205a29f36a9a6db2fb3253a54a1457c188f26b569e48830f5L1007-R1027)

**cURL Generation and Try-out Header Handling:**

* Simplified cURL generation by removing placeholder values for OAuth/Basic credentials and no longer requiring the security scheme type to be passed to `requestObjectToCurl`. [[1]](diffhunk://#diff-f3f1c39449f0eedbd00d4bab4e0bb717ba4ce08b2f4411cf2fac73b48b0c69cdL165-R167) [[2]](diffhunk://#diff-f3f1c39449f0eedbd00d4bab4e0bb717ba4ce08b2f4411cf2fac73b48b0c69cdL179-L189) [[3]](diffhunk://#diff-b68ed8f0fcc9aa1a92d10e093f1a1f7c1430b88b9d29249e034fed1e5c8e2a3fL273-R273) [[4]](diffhunk://#diff-b68ed8f0fcc9aa1a92d10e093f1a1f7c1430b88b9d29249e034fed1e5c8e2a3fL303) [[5]](diffhunk://#diff-b68ed8f0fcc9aa1a92d10e093f1a1f7c1430b88b9d29249e034fed1e5c8e2a3fL321-L322) [[6]](diffhunk://#diff-b68ed8f0fcc9aa1a92d10e093f1a1f7c1430b88b9d29249e034fed1e5c8e2a3fL493-L502) [[7]](diffhunk://#diff-40cf50efaaada982225b27e9eb1a6b34e742a9dcce4dbfb35fb8b97df213dfbaL9-L15) [[8]](diffhunk://#diff-40cf50efaaada982225b27e9eb1a6b34e742a9dcce4dbfb35fb8b97df213dfbaL91-R100)

* Improved try-out request header population in `SwaggerUI.jsx` to avoid sending undefined/null/empty tokens and to only set headers when appropriate.

**Minor Cleanups:**

* Removed the unused OAuth/Basic credential placeholder hint from the UI and updated related localization strings. [[1]](diffhunk://#diff-325870046e8d911d477c325c5264fb065cd91def657c993a3220257e5b34044eL25) [[2]](diffhunk://#diff-b68ed8f0fcc9aa1a92d10e093f1a1f7c1430b88b9d29249e034fed1e5c8e2a3fL493-L502)

These changes collectively improve the reliability and clarity of the try-out feature, especially for APIs deployed on the API Platform Gateway.

### Updated UIs

**Publisher portal deployment status:**


https://github.com/user-attachments/assets/904fb06b-2ebf-425e-bb72-5a17b86714ad

**No security policies attached to the API:**

<img width="3456" height="3954" alt="screencapture-localhost-9443-devportal-apis-218b2ccb-f123-4e3a-a57d-7701c0ab6d2d-api-console-2026-04-20-17_11_36" src="https://github.com/user-attachments/assets/40d54dc2-ada6-465e-8cfc-319e8d8bfaa5" />

**Supports adding any name for APIKey:**

<img width="1728" height="938" alt="Screenshot 2026-04-20 at 5 15 42 PM" src="https://github.com/user-attachments/assets/e2e7cf04-4cd5-4341-bcfb-24a67286a58a" />


**Devportal replicates the same key name:**

<img width="3456" height="4406" alt="screencapture-localhost-9443-devportal-apis-218b2ccb-f123-4e3a-a57d-7701c0ab6d2d-api-console-2026-04-20-17_16_22" src="https://github.com/user-attachments/assets/2f2543d0-4433-4da1-9b31-2713eb603260" />


**JWT Auth policy attached:**

<img width="3456" height="4622" alt="screencapture-localhost-9443-devportal-apis-218b2ccb-f123-4e3a-a57d-7701c0ab6d2d-api-console-2026-04-20-17_21_24" src="https://github.com/user-attachments/assets/b3a43125-cb8d-4208-8385-7177d2efb5ae" />

**Basic Auth policy attached:**

<img width="3456" height="4516" alt="screencapture-localhost-9443-devportal-apis-218b2ccb-f123-4e3a-a57d-7701c0ab6d2d-api-console-2026-04-20-17_18_27" src="https://github.com/user-attachments/assets/d31bbfd8-7ff2-48f1-bc1a-fe06f1272cad" />


Related PR: https://github.com/wso2/carbon-apimgt/pull/13801#issue-4294009812




