### PR TITLE
[AM] Add compatibility for additionalPropertyMap for MCP servers

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -240,7 +240,7 @@ class LifeCycleUpdate extends Component {
                                 .map(property => property.Name);
                             if (requiredPropertyNames.length > 0) {
                                 this.setState({ isMandatoryPropertiesConfigured: true });
-                                if (api.additionalProperties !== undefined) {
+                                if (Array.isArray(api.additionalProperties)) {
                                     isMandatoryPropertiesAvailable = requiredPropertyNames.every(propertyName => {
                                         const property = api.additionalProperties.find(
                                             (prop) => prop.name === propertyName);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -232,18 +232,31 @@ class LifeCycleUpdate extends Component {
 
                 API.getSettings()
                     .then((response) => {
-                        const { customProperties } = response;
-                        let isMandatoryPropertiesAvailable;
+                        const customProperties = response?.customProperties ?? response?.body?.customProperties ?? [];
+                        let isMandatoryPropertiesAvailable = true;
                         if (customProperties && customProperties.length > 0) {
                             const requiredPropertyNames = customProperties
-                                .filter(property => property.Required)
-                                .map(property => property.Name);
+                                .filter(property => property && property.Required)
+                                .map(property => property.Name)
+                                .filter(Boolean);
                             if (requiredPropertyNames.length > 0) {
                                 this.setState({ isMandatoryPropertiesConfigured: true })
-                                isMandatoryPropertiesAvailable = requiredPropertyNames.every(propertyName => {
-                                    const property = api.additionalProperties.find(
-                                        prop => prop.name === propertyName);
-                                    return property && property.value !== '';
+                                isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
+                                    // APIs keep additionalProperties as an array: [{ name, value }, ...]
+                                    const addProps = api.additionalProperties;
+                                    if (Array.isArray(addProps)) {
+                                        const property = addProps.find((prop) => prop && prop.name === propertyName);
+                                        return !!(property && property.value !== '');
+                                    }
+
+                                    // MCP Servers keep additionalPropertiesMap as an object keyed by name.
+                                    const addPropsMap = api.additionalPropertiesMap;
+                                    if (addPropsMap && typeof addPropsMap === 'object') {
+                                        const property = addPropsMap[propertyName];
+                                        return !!(property && property.value !== '');
+                                    }
+
+                                    return false;
                                 });
                             } else {
                                 isMandatoryPropertiesAvailable = true;
@@ -251,7 +264,7 @@ class LifeCycleUpdate extends Component {
                         } else {
                             isMandatoryPropertiesAvailable = true;
                         }
-                        this.setState({ isMandatoryPropertiesAvailable });
+                        this.setState({ isMandatoryPropertiesAvailable, loading: false });
                         this.setState({ loading: false });
                     })
                     .catch((error) => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -265,7 +265,6 @@ class LifeCycleUpdate extends Component {
                             isMandatoryPropertiesAvailable = true;
                         }
                         this.setState({ isMandatoryPropertiesAvailable, loading: false });
-                        this.setState({ loading: false });
                     })
                     .catch((error) => {
                         console.error('Error fetching settings:', error);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -253,7 +253,11 @@ class LifeCycleUpdate extends Component {
                                         return !!(property && property.value !== '');
                                     });
                                 }
+                            } else {
+                                isMandatoryPropertiesAvailable = true;
                             }
+                        } else {
+                            isMandatoryPropertiesAvailable = true;
                         }
                         this.setState({ isMandatoryPropertiesAvailable });
                         this.setState({ loading: false });

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -236,26 +236,25 @@ class LifeCycleUpdate extends Component {
                         let isMandatoryPropertiesAvailable;
                         if (customProperties && customProperties.length > 0) {
                             const requiredPropertyNames = customProperties
-                                .filter((property) => property.Required)
-                                .map((property) => property.Name);
+                                .filter(property => property.Required)
+                                .map(property => property.Name);
                             if (requiredPropertyNames.length > 0) {
                                 this.setState({ isMandatoryPropertiesConfigured: true });
                                 if (api.additionalProperties !== undefined) {
-                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
+                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every(propertyName => {
                                         const property = api.additionalProperties.find(
                                             (prop) => prop.name === propertyName);
                                         return !!(property && property.value !== '');
                                     });
                                 } else {
                                     const addPropsMap = api.additionalPropertiesMap || {};
-                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
+                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every(propertyName => {
                                         const property = addPropsMap[propertyName];
                                         return !!(property && property.value !== '');
                                     });
                                 }
                             }
                         }
-
                         this.setState({ isMandatoryPropertiesAvailable });
                         this.setState({ loading: false });
                     })

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/LifeCycle/LifeCycleUpdate.jsx
@@ -232,39 +232,32 @@ class LifeCycleUpdate extends Component {
 
                 API.getSettings()
                     .then((response) => {
-                        const customProperties = response?.customProperties ?? response?.body?.customProperties ?? [];
-                        let isMandatoryPropertiesAvailable = true;
+                        const { customProperties } = response;
+                        let isMandatoryPropertiesAvailable;
                         if (customProperties && customProperties.length > 0) {
                             const requiredPropertyNames = customProperties
-                                .filter(property => property && property.Required)
-                                .map(property => property.Name)
-                                .filter(Boolean);
+                                .filter((property) => property.Required)
+                                .map((property) => property.Name);
                             if (requiredPropertyNames.length > 0) {
-                                this.setState({ isMandatoryPropertiesConfigured: true })
-                                isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
-                                    // APIs keep additionalProperties as an array: [{ name, value }, ...]
-                                    const addProps = api.additionalProperties;
-                                    if (Array.isArray(addProps)) {
-                                        const property = addProps.find((prop) => prop && prop.name === propertyName);
+                                this.setState({ isMandatoryPropertiesConfigured: true });
+                                if (api.additionalProperties !== undefined) {
+                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
+                                        const property = api.additionalProperties.find(
+                                            (prop) => prop.name === propertyName);
                                         return !!(property && property.value !== '');
-                                    }
-
-                                    // MCP Servers keep additionalPropertiesMap as an object keyed by name.
-                                    const addPropsMap = api.additionalPropertiesMap;
-                                    if (addPropsMap && typeof addPropsMap === 'object') {
+                                    });
+                                } else {
+                                    const addPropsMap = api.additionalPropertiesMap || {};
+                                    isMandatoryPropertiesAvailable = requiredPropertyNames.every((propertyName) => {
                                         const property = addPropsMap[propertyName];
                                         return !!(property && property.value !== '');
-                                    }
-
-                                    return false;
-                                });
-                            } else {
-                                isMandatoryPropertiesAvailable = true;
+                                    });
+                                }
                             }
-                        } else {
-                            isMandatoryPropertiesAvailable = true;
                         }
-                        this.setState({ isMandatoryPropertiesAvailable, loading: false });
+
+                        this.setState({ isMandatoryPropertiesAvailable });
+                        this.setState({ loading: false });
                     })
                     .catch((error) => {
                         console.error('Error fetching settings:', error);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -303,7 +303,7 @@ export default function CustomizedStepper() {
                         .filter(property => property.Required)
                         .map(property => property.Name);
                     if (requiredPropertyNames.length > 0) {
-                        if (api.additionalProperties !== undefined) {
+                        if (Array.isArray(api.additionalProperties))  {
                             setIsMandatoryPropertiesAvailable(requiredPropertyNames.every(propertyName => {
                                 const property = api.additionalProperties.find(
                                     prop => prop.name === propertyName);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -301,17 +301,17 @@ export default function CustomizedStepper() {
                 if (customProperties && customProperties.length > 0) {
                     const requiredPropertyNames = customProperties
                         .filter(property => property.Required)
-                        .map(property => property.Name)
+                        .map(property => property.Name);
                     if (requiredPropertyNames.length > 0) {
                         if (api.additionalProperties !== undefined) {
-                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
+                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every(propertyName => {
                                 const property = api.additionalProperties.find(
-                                    (prop) => prop.name === propertyName);
+                                    prop => prop.name === propertyName);
                                 return !!(property && property.value !== '');
                             }));
                         } else {
                             const addPropsMap = api.additionalPropertiesMap || {};
-                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
+                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every(propertyName => {
                                 const property = addPropsMap[propertyName];
                                 return !!(property && property.value !== '');
                             }));

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -297,28 +297,25 @@ export default function CustomizedStepper() {
     function validateMandatoryCustomProperties() {
         api.getSettings()
             .then((response) => {
-                const customProperties = response?.customProperties ?? response?.body?.customProperties ?? [];
-                if (Array.isArray(customProperties) && customProperties.length > 0) {
+                const { customProperties } = response;
+                if (customProperties && customProperties.length > 0) {
                     const requiredPropertyNames = customProperties
-                        .filter(property => property && property.Required)
+                        .filter(property => property.Required)
                         .map(property => property.Name)
-                        .filter(Boolean);
                     if (requiredPropertyNames.length > 0) {
-                        setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
-                            // APIs: additionalProperties is an array of { name, value }
-                            if (Array.isArray(api.additionalProperties)) {
-                                const property = api.additionalProperties.find((prop)=>prop&&prop.name===propertyName);
+                        if (api.additionalProperties !== undefined) {
+                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
+                                const property = api.additionalProperties.find(
+                                    (prop) => prop.name === propertyName);
                                 return !!(property && property.value !== '');
-                            }
-
-                            // MCP Servers: properties are stored in additionalPropertiesMap keyed by propertyName
-                            if (api.additionalPropertiesMap && typeof api.additionalPropertiesMap === 'object') {
-                                const property = api.additionalPropertiesMap[propertyName];
+                            }));
+                        } else {
+                            const addPropsMap = api.additionalPropertiesMap || {};
+                            setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
+                                const property = addPropsMap[propertyName];
                                 return !!(property && property.value !== '');
-                            }
-
-                            return false;
-                        }));
+                            }));
+                        }
                     } else {
                         setIsMandatoryPropertiesAvailable(true);
                     }

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -300,7 +300,7 @@ export default function CustomizedStepper() {
                 const customProperties = response?.customProperties ?? response?.body?.customProperties ?? [];
                 if (Array.isArray(customProperties) && customProperties.length > 0) {
                     const requiredPropertyNames = customProperties
-                        .filter(property => property &&  property.Required)
+                        .filter(property => property && property.Required)
                         .map(property => property.Name)
                         .filter(Boolean);
                     if (requiredPropertyNames.length > 0) {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/CustomizedStepper.jsx
@@ -297,15 +297,27 @@ export default function CustomizedStepper() {
     function validateMandatoryCustomProperties() {
         api.getSettings()
             .then((response) => {
-                const { customProperties } = response;
-                if (customProperties && customProperties.length > 0) {
+                const customProperties = response?.customProperties ?? response?.body?.customProperties ?? [];
+                if (Array.isArray(customProperties) && customProperties.length > 0) {
                     const requiredPropertyNames = customProperties
-                        .filter(property => property.Required)
-                        .map(property => property.Name);
+                        .filter(property => property &&  property.Required)
+                        .map(property => property.Name)
+                        .filter(Boolean);
                     if (requiredPropertyNames.length > 0) {
-                        setIsMandatoryPropertiesAvailable(requiredPropertyNames.every(propertyName => {
-                            const property = api.additionalProperties.find(prop => prop.name === propertyName);
-                            return property && property.value !== '';
+                        setIsMandatoryPropertiesAvailable(requiredPropertyNames.every((propertyName) => {
+                            // APIs: additionalProperties is an array of { name, value }
+                            if (Array.isArray(api.additionalProperties)) {
+                                const property = api.additionalProperties.find((prop)=>prop&&prop.name===propertyName);
+                                return !!(property && property.value !== '');
+                            }
+
+                            // MCP Servers: properties are stored in additionalPropertiesMap keyed by propertyName
+                            if (api.additionalPropertiesMap && typeof api.additionalPropertiesMap === 'object') {
+                                const property = api.additionalPropertiesMap[propertyName];
+                                return !!(property && property.value !== '');
+                            }
+
+                            return false;
                         }));
                     } else {
                         setIsMandatoryPropertiesAvailable(true);


### PR DESCRIPTION
## Purpose
This PR fixes a bug where the Publisher Lifecycle page would hang in a loading state for MCP Server APIs when tenant-level mandatory additional API properties are configured. The root cause was calling .find() on api.additionalProperties when that field was undefined for MCP servers (REST APIs always had an array). The PR adds defensive handling for both representations (array and additionalPropertiesMap) and ensures mandatory property validation no longer throws. It also includes: revision/deployment detection was improved to properly detect approved deployments (including the special handling used for API Products and null statuses), avoiding false negatives when determining whether the Publish actions should be enabled.
## Goals
Preventing direct .find() calls on potentially undefined values stops the JS runtime error and allows the Lifecycle page to finish loading.
Accurately detecting whether deployments exist (and whether one is APPROVED) ensures the UI enables or disables Publish controls correctly.

## Approach
- Validate endpoint availability for MCP servers without assuming additionalProperties exists.
- Parallelized and hardened fetch logic for revisions and endpoint checks.
- Added robust mandatory properties check that supports:
    - APIs where additionalProperties is an array of { name, value }
    - MCP servers where additionalPropertiesMap is an object keyed by property name
- Improved detection of approved deployments (consider null statuses that indicate API Products).
- Defensive validateMandatoryCustomProperties implementation that checks for both additionalProperties (array) and additionalPropertiesMap (object) and avoids calling .find() on undefined.
- Endpoint status check and MCP endpoint detection hardened to avoid transient loading errors.

Resolves: https://github.com/wso2/api-manager/issues/4698