### PR TITLE
Fix API documentation section limitation in the dev portal

### DIFF
--- a/portals/devportal/src/main/webapp/site/public/theme/settings.json
+++ b/portals/devportal/src/main/webapp/site/public/theme/settings.json
@@ -9,7 +9,7 @@
             "host": "localhost"
         },
         "subscriptionLimit": 1000,
-        "documentCount": 25,
+        "documentCount": 100,
         "subscribeApplicationLimit": 5000,
         "isPassive": true,
         "singleLogout": {

--- a/portals/devportal/src/main/webapp/site/public/theme/settings.json
+++ b/portals/devportal/src/main/webapp/site/public/theme/settings.json
@@ -9,6 +9,7 @@
             "host": "localhost"
         },
         "subscriptionLimit": 1000,
+        "documentCount": 1000,
         "subscribeApplicationLimit": 5000,
         "isPassive": true,
         "singleLogout": {

--- a/portals/devportal/src/main/webapp/site/public/theme/settings.json
+++ b/portals/devportal/src/main/webapp/site/public/theme/settings.json
@@ -9,7 +9,7 @@
             "host": "localhost"
         },
         "subscriptionLimit": 1000,
-        "documentCount": 1000,
+        "documentCount": 25,
         "subscribeApplicationLimit": 5000,
         "isPassive": true,
         "singleLogout": {

--- a/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
@@ -267,7 +267,7 @@ export default class MCPServer extends Resource {
      * @returns {Promise} - Promise resolving to the API response.
      */
     getDocuments(mcpServerId, callback = null) {
-        const limit = app.documentCount || 25;
+        const limit = app.documentCount || 100;
         const promise = this.client.then((client) => {
             return client.apis['MCP Server Documents'].getMCPServerDocuments(
                 { mcpServerId, limit },

--- a/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
@@ -267,7 +267,7 @@ export default class MCPServer extends Resource {
      * @returns {Promise} - Promise resolving to the API response.
      */
     getDocuments(mcpServerId, callback = null) {
-        const limit = app.documentCount || 1000;
+        const limit = app.documentCount || 25;
         const promise = this.client.then((client) => {
             return client.apis['MCP Server Documents'].getMCPServerDocuments(
                 { mcpServerId, limit },

--- a/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/MCPServer.jsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { app } from 'Settings';
 import APIClientFactory from './APIClientFactory';
 import Resource from './Resource';
 import Utils from './Utils';
@@ -266,9 +267,10 @@ export default class MCPServer extends Resource {
      * @returns {Promise} - Promise resolving to the API response.
      */
     getDocuments(mcpServerId, callback = null) {
+        const limit = app.documentCount || 1000;
         const promise = this.client.then((client) => {
             return client.apis['MCP Server Documents'].getMCPServerDocuments(
-                { mcpServerId },
+                { mcpServerId, limit },
                 this._requestMetaData(),
             );
         });

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { app } from 'Settings';
 import APIClientFactory from './APIClientFactory';
 import Resource from './Resource';
 import Wsdl from './Wsdl';
@@ -90,8 +91,9 @@ export default class API extends Resource {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getDocumentsByAPIId(id, callback = null) {
+        const limit = app.documentCount || 1000;
         const promiseGet = this.client.then((client) => {
-            return client.apis['API Documents'].get_apis__apiId__documents({ apiId: id }, this._requestMetaData());
+            return client.apis['API Documents'].get_apis__apiId__documents({ apiId: id, limit }, this._requestMetaData());
         });
         if (callback) {
             return promiseGet.then(callback);

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -91,7 +91,7 @@ export default class API extends Resource {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getDocumentsByAPIId(id, callback = null) {
-        const limit = app.documentCount || 1000;
+        const limit = app.documentCount || 25;
         const promiseGet = this.client.then((client) => {
             return client.apis['API Documents'].get_apis__apiId__documents({ apiId: id, limit }, this._requestMetaData());
         });

--- a/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/api.jsx
@@ -91,7 +91,7 @@ export default class API extends Resource {
      * @returns {promise} With given callback attached to the success chain else API invoke promise.
      */
     getDocumentsByAPIId(id, callback = null) {
-        const limit = app.documentCount || 25;
+        const limit = app.documentCount || 100;
         const promiseGet = this.client.then((client) => {
             return client.apis['API Documents'].get_apis__apiId__documents({ apiId: id, limit }, this._requestMetaData());
         });

--- a/tests/cypress/e2e/devportal/000-general/01-anonymous-user-view-public-apis.cy.js
+++ b/tests/cypress/e2e/devportal/000-general/01-anonymous-user-view-public-apis.cy.js
@@ -74,7 +74,7 @@ describe("Anonymous view apis", () => {
 
         // intercepting overview page network calls
         cy.intercept('GET', '**/apis/**/comments**').as('getComments');
-        cy.intercept('GET', '**/apis/**/documents').as('getDocuments');
+        cy.intercept('GET', '**/apis/**/documents**').as('getDocuments');
         cy.intercept('GET', '**/throttling-policies/subscription').as('getSubscriptionPolicies');
         cy.intercept('GET', '**/apis/**/thumbnail').as('getThumbnail');
 

--- a/tests/cypress/e2e/devportal/000-general/06-wsdl-url-generation.cy.js
+++ b/tests/cypress/e2e/devportal/000-general/06-wsdl-url-generation.cy.js
@@ -39,7 +39,7 @@ describe("WSDL Download URL - Copy URL button", () => {
 
     const visitOverview = (apiId) => {
         cy.intercept("GET", "**/apis/**/comments**").as("getComments");
-        cy.intercept("GET", "**/apis/**/documents").as("getDocuments");
+        cy.intercept("GET", "**/apis/**/documents**").as("getDocuments");
         cy.intercept("GET", "**/throttling-policies/subscription").as("getSubscriptionPolicies");
         cy.intercept("GET", "**/apis/**/thumbnail").as("getThumbnail");
 


### PR DESCRIPTION
### Summary
This PR addresses the issue where the DevPortal API, MCP & API Product documentation sections were limited to displaying only 25 documents by default (the backend's default limit). It introduces a configurable document limit, aligning the DevPortal's behavior with the Publisher portal.

### Changes
- **Configuration**: Added `documentCount` to the DevPortal's `settings.json` file under the `app` section, setting a default limit of `25`.
- **Data Layer (API)**: Updated the `getDocumentsByAPIId` method in the DevPortal's `API` data class to retrieve and apply the `documentCount` limit from the application configuration.
- **Data Layer (MCPServer)**: Updated the `getDocuments` method in the `MCPServer` data class to similarly support the configurable document limit.
- **Fallback Logic**: Implemented a fallback value of `25` in the code to ensure robustness even if the configuration is missing from `settings.json`.
- **Cypress Tests**: Updated `cy.intercept` patterns in DevPortal tests to match requests with query parameters.

### Impact
Users can now view a significantly larger number of documents in the API documentation section. Administrators can further tune this limit by modifying the `documentCount` property in the portal's theme settings.

Resolves: https://github.com/wso2/api-manager/issues/4998