### PR TITLE
Add support for User Managed Identity (UMI) auth in AI endpoint security

### DIFF
--- a/portals/admin/src/main/webapp/site/public/locales/en.json
+++ b/portals/admin/src/main/webapp/site/public/locales/en.json
@@ -31,7 +31,7 @@
   "APIKeys.ListApiKeys.value.never": "Never",
   "Admin.Addons.Help.Base.title": "Help",
   "Admin.AiVendor.form.llm.auth.aws.service.label": "AWS Service Name",
-  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway pod must have the AKS Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
+  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway must have the Azure Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
   "Admin.AiVendor.label.apiVersion": "API Version",
   "Admin.GatewayEnvironment.form.type": "Gateway Environment Type",
   "Admin.KeyManager.form.type": "Key Manager Type",

--- a/portals/admin/src/main/webapp/site/public/locales/en.json
+++ b/portals/admin/src/main/webapp/site/public/locales/en.json
@@ -31,6 +31,7 @@
   "APIKeys.ListApiKeys.value.never": "Never",
   "Admin.Addons.Help.Base.title": "Help",
   "Admin.AiVendor.form.llm.auth.aws.service.label": "AWS Service Name",
+  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway pod must have the AKS Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
   "Admin.AiVendor.label.apiVersion": "API Version",
   "Admin.GatewayEnvironment.form.type": "Gateway Environment Type",
   "Admin.KeyManager.form.type": "Key Manager Type",

--- a/portals/admin/src/main/webapp/site/public/locales/fr.json
+++ b/portals/admin/src/main/webapp/site/public/locales/fr.json
@@ -31,7 +31,7 @@
   "APIKeys.ListApiKeys.value.never": "Never",
   "Admin.Addons.Help.Base.title": "Help",
   "Admin.AiVendor.form.llm.auth.aws.service.label": "AWS Service Name",
-  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway pod must have the AKS Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
+  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway must have the Azure Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
   "Admin.AiVendor.label.apiVersion": "API Version",
   "Admin.GatewayEnvironment.form.type": "Gateway Environment Type",
   "Admin.KeyManager.form.type": "Key Manager Type",

--- a/portals/admin/src/main/webapp/site/public/locales/fr.json
+++ b/portals/admin/src/main/webapp/site/public/locales/fr.json
@@ -31,6 +31,7 @@
   "APIKeys.ListApiKeys.value.never": "Never",
   "Admin.Addons.Help.Base.title": "Help",
   "Admin.AiVendor.form.llm.auth.aws.service.label": "AWS Service Name",
+  "Admin.AiVendor.form.llm.auth.umi.info": "Azure User Managed Identity (UMI) authentication will be used. The gateway pod must have the AKS Workload Identity webhook configured with the appropriate AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_FEDERATED_TOKEN_FILE environment variables. No credentials need to be stored.",
   "Admin.AiVendor.label.apiVersion": "API Version",
   "Admin.GatewayEnvironment.form.type": "Gateway Environment Type",
   "Admin.KeyManager.form.type": "Key Manager Type",

--- a/portals/admin/src/main/webapp/source/src/app/components/AiServiceProviders/AddEditAiServiceProvider.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/AiServiceProviders/AddEditAiServiceProvider.jsx
@@ -1113,7 +1113,7 @@ export default function AddEditAiServiceProvider(props) {
                                                         id='Admin.AiVendor.form.llm.auth.umi.info'
                                                         defaultMessage={
                                                             'Azure User Managed Identity (UMI) authentication will '
-                                                            + 'be used. The gateway pod must have the AKS Workload '
+                                                            + 'be used. The gateway must have the Azure Workload '
                                                             + 'Identity webhook configured with the appropriate '
                                                             + 'AZURE_TENANT_ID, AZURE_CLIENT_ID, and '
                                                             + 'AZURE_FEDERATED_TOKEN_FILE environment variables. '

--- a/portals/admin/src/main/webapp/source/src/app/components/AiServiceProviders/AddEditAiServiceProvider.jsx
+++ b/portals/admin/src/main/webapp/source/src/app/components/AiServiceProviders/AddEditAiServiceProvider.jsx
@@ -126,7 +126,7 @@ export default function AddEditAiServiceProvider(props) {
         type: 'none',
         parameters: {},
     });
-    const authSources = ['none', 'apikey', 'aws'];
+    const authSources = ['none', 'apikey', 'aws', 'umi'];
     const [validating, setValidating] = useState(false);
     const [file, setFile] = useState(null);
     const [loading, setLoading] = useState(!!vendorId); // Set to true if editing (vendorId exists)
@@ -1105,6 +1105,23 @@ export default function AddEditAiServiceProvider(props) {
                                                 }))}
                                                 required
                                             />
+                                        )}
+                                        {(authConfig.type === 'umi') && (
+                                            <Box mt={2}>
+                                                <Typography variant='body2' color='textSecondary'>
+                                                    <FormattedMessage
+                                                        id='Admin.AiVendor.form.llm.auth.umi.info'
+                                                        defaultMessage={
+                                                            'Azure User Managed Identity (UMI) authentication will '
+                                                            + 'be used. The gateway pod must have the AKS Workload '
+                                                            + 'Identity webhook configured with the appropriate '
+                                                            + 'AZURE_TENANT_ID, AZURE_CLIENT_ID, and '
+                                                            + 'AZURE_FEDERATED_TOKEN_FILE environment variables. '
+                                                            + 'No credentials need to be stored.'
+                                                        }
+                                                    />
+                                                </Typography>
+                                            </Box>
                                         )}
                                     </FormControl>
                                 </Box>

--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -829,6 +829,7 @@
   "Apis.Details.Endpoints.AIEndpoints.Edit.aws.region.placeholder": "Enter AWS Region",
   "Apis.Details.Endpoints.AIEndpoints.Edit.secretKey": "AWS Secret Key",
   "Apis.Details.Endpoints.AIEndpoints.Edit.secretKey.placeholder": "Enter AWS Secret Key",
+  "Apis.Details.Endpoints.AIEndpoints.Edit.umi.info": "Azure User Managed Identity (UMI) authentication is configured. The gateway will automatically acquire and inject a Bearer token using the pod's AKS Workload Identity.",
   "Apis.Details.Endpoints.AIEndpoints.EndpointCard.backend.api.definition": "Backend API Definition",
   "Apis.Details.Endpoints.API.Definition.fetch.error": "Error occurred while fetching API definition",
   "Apis.Details.Endpoints.AdvancedConfig.AdvanceEndpointConfig.action": "Action",

--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -829,7 +829,7 @@
   "Apis.Details.Endpoints.AIEndpoints.Edit.aws.region.placeholder": "Enter AWS Region",
   "Apis.Details.Endpoints.AIEndpoints.Edit.secretKey": "AWS Secret Key",
   "Apis.Details.Endpoints.AIEndpoints.Edit.secretKey.placeholder": "Enter AWS Secret Key",
-  "Apis.Details.Endpoints.AIEndpoints.Edit.umi.info": "Azure User Managed Identity (UMI) authentication is configured. The gateway will automatically acquire and inject a Bearer token using the pod's AKS Workload Identity.",
+  "Apis.Details.Endpoints.AIEndpoints.Edit.umi.info": "Azure User Managed Identity (UMI) authentication is configured. The gateway will automatically acquire and inject a Bearer token using the configured Azure Workload Identity.",
   "Apis.Details.Endpoints.AIEndpoints.EndpointCard.backend.api.definition": "Backend API Definition",
   "Apis.Details.Endpoints.API.Definition.fetch.error": "Error occurred while fetching API definition",
   "Apis.Details.Endpoints.AdvancedConfig.AdvanceEndpointConfig.action": "Action",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AIEndpoints/AddEditAIEndpoint.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AIEndpoints/AddEditAIEndpoint.jsx
@@ -477,6 +477,25 @@ const AddEditAIEndpoint = ({
         }
     }, [state]);
 
+    // Auto-configure endpoint security for UMI — no credentials needed from the user.
+    // set it immediately when the component mounts (or when the deployment stage changes).
+    useEffect(() => {
+        if (llmProviderEndpointConfiguration?.authenticationConfiguration?.type === 'umi' &&
+            llmProviderEndpointConfiguration?.authenticationConfiguration?.enabled === true) {
+            const envType = state.deploymentStage === CONSTS.DEPLOYMENT_STAGE.production
+                ? 'production' : 'sandbox';
+            const existing = state.endpointConfig.endpoint_security?.[envType];
+            // Only set if not already persisted to avoid unnecessary re-renders
+            if (!existing || existing.type !== 'umi') {
+                saveEndpointSecurityConfig({
+                    ...CONSTS.DEFAULT_ENDPOINT_SECURITY,
+                    type: 'umi',
+                    enabled: true,
+                }, envType);
+            }
+        }
+    }, [llmProviderEndpointConfiguration, state.deploymentStage]);
+
     /**
      * Method to test the endpoint.
      * @param {String} endpointURL Endpoint URL 
@@ -881,6 +900,9 @@ const AddEditAIEndpoint = ({
     const IS_AWS_SIGV4_AUTH_ENABLED = (config) =>
         config?.authenticationConfiguration?.enabled === true &&
         config?.authenticationConfiguration?.type === 'aws';
+    const IS_UMI_AUTH_ENABLED = (config) =>
+        config?.authenticationConfiguration?.enabled === true &&
+        config?.authenticationConfiguration?.type === 'umi';
     return (
         <StyledGrid container justifyContent='center'>
             <Grid item sm={12} md={12} lg={8}>
@@ -1217,6 +1239,22 @@ const AddEditAIEndpoint = ({
                                 </>
                             )}
 
+                            {/* User Managed Identity (UMI) Auth Info */}
+                            {IS_UMI_AUTH_ENABLED(llmProviderEndpointConfiguration) && (
+                                <Grid item xs={12}>
+                                    <Typography variant='body2' color='textSecondary'>
+                                        <FormattedMessage
+                                            id='Apis.Details.Endpoints.AIEndpoints.Edit.umi.info'
+                                            defaultMessage={
+                                                'Azure User Managed Identity (UMI) authentication is configured. '
+                                                + 'The gateway will automatically acquire and inject a Bearer token '
+                                                + 'using the pod\'s AKS Workload Identity.'
+                                            }
+                                        />
+                                    </Typography>
+                                </Grid>
+                            )}
+                            
                         </Grid>
 
                         {/* Action Buttons */}

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AIEndpoints/AddEditAIEndpoint.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AIEndpoints/AddEditAIEndpoint.jsx
@@ -463,6 +463,16 @@ const AddEditAIEndpoint = ({
 
     const url = getBasePath(apiObject.apiType) + apiObject.id + '/endpoints';
 
+    const IS_APIKEY_AUTH_ENABLED = (config) =>
+        config?.authenticationConfiguration?.enabled === true &&
+        config?.authenticationConfiguration?.type === 'apikey';
+    const IS_AWS_SIGV4_AUTH_ENABLED = (config) =>
+        config?.authenticationConfiguration?.enabled === true &&
+        config?.authenticationConfiguration?.type === 'aws';
+    const IS_UMI_AUTH_ENABLED = (config) =>
+        config?.authenticationConfiguration?.enabled === true &&
+        config?.authenticationConfiguration?.type === 'umi';
+
     useEffect(() => {
         try {
             if (state.deploymentStage === CONSTS.DEPLOYMENT_STAGE.production) {
@@ -478,23 +488,31 @@ const AddEditAIEndpoint = ({
     }, [state]);
 
     // Auto-configure endpoint security for UMI — no credentials needed from the user.
-    // set it immediately when the component mounts (or when the deployment stage changes).
+    // Runs on mount, when the deployment stage changes, or when the security config
+    // is externally reset, to ensure UMI is always applied for UMI-type providers.
+    const currentEnvType = state.deploymentStage.toLowerCase();
+    const currentSecurity = state.endpointConfig.endpoint_security?.[currentEnvType];
+    const currentSecurityType = currentSecurity?.type;
+    const isCurrentSecurityEnabled = currentSecurity?.enabled === true;
+
     useEffect(() => {
-        if (llmProviderEndpointConfiguration?.authenticationConfiguration?.type === 'umi' &&
-            llmProviderEndpointConfiguration?.authenticationConfiguration?.enabled === true) {
-            const envType = state.deploymentStage === CONSTS.DEPLOYMENT_STAGE.production
-                ? 'production' : 'sandbox';
-            const existing = state.endpointConfig.endpoint_security?.[envType];
-            // Only set if not already persisted to avoid unnecessary re-renders
-            if (!existing || existing.type !== 'umi') {
-                saveEndpointSecurityConfig({
-                    ...CONSTS.DEFAULT_ENDPOINT_SECURITY,
-                    type: 'umi',
-                    enabled: true,
-                }, envType);
-            }
+        if (
+            IS_UMI_AUTH_ENABLED(llmProviderEndpointConfiguration)
+            && (currentSecurityType !== 'umi' || !isCurrentSecurityEnabled)
+        ) {
+            saveEndpointSecurityConfig({
+                ...CONSTS.DEFAULT_ENDPOINT_SECURITY,
+                type: 'umi',
+                enabled: true,
+            }, currentEnvType);
         }
-    }, [llmProviderEndpointConfiguration, state.deploymentStage]);
+    }, [
+        llmProviderEndpointConfiguration?.authenticationConfiguration?.type,
+        llmProviderEndpointConfiguration?.authenticationConfiguration?.enabled,
+        currentEnvType,
+        currentSecurityType,
+        isCurrentSecurityEnabled,
+    ]);
 
     /**
      * Method to test the endpoint.
@@ -894,15 +912,6 @@ const AddEditAIEndpoint = ({
         }, envType);
     };
 
-    const IS_APIKEY_AUTH_ENABLED = (config) =>
-        config?.authenticationConfiguration?.enabled === true &&
-        config?.authenticationConfiguration?.type === 'apikey';
-    const IS_AWS_SIGV4_AUTH_ENABLED = (config) =>
-        config?.authenticationConfiguration?.enabled === true &&
-        config?.authenticationConfiguration?.type === 'aws';
-    const IS_UMI_AUTH_ENABLED = (config) =>
-        config?.authenticationConfiguration?.enabled === true &&
-        config?.authenticationConfiguration?.type === 'umi';
     return (
         <StyledGrid container justifyContent='center'>
             <Grid item sm={12} md={12} lg={8}>
@@ -1248,7 +1257,7 @@ const AddEditAIEndpoint = ({
                                             defaultMessage={
                                                 'Azure User Managed Identity (UMI) authentication is configured. '
                                                 + 'The gateway will automatically acquire and inject a Bearer token '
-                                                + 'using the pod\'s AKS Workload Identity.'
+                                                + 'using the configured Azure Workload Identity.'
                                             }
                                         />
                                     </Typography>


### PR DESCRIPTION
## Description

Adds UI support for Azure User Managed Identity (UMI) as an authentication type across the
Admin and Publisher portals, complementing the gateway-side UMI implementation.

## Related Issue

-  https://github.com/wso2/api-manager/issues/5043

## What's changed

### Admin portal — AI Service Provider form
- Added `umi` as a selectable authentication type alongside `none`, `apikey`, and `aws`
- When UMI is selected, displays an informational message explaining that no credentials need
  to be stored and that the gateway pod must have the AKS Workload Identity webhook configured

### Publisher portal — AI Endpoint configuration
- Added `IS_UMI_AUTH_ENABLED` helper to detect when the LLM provider is configured for UMI
- Auto-configures endpoint security to `type=umi, enabled=true` when the provider's auth type
  is UMI — no manual credential input required from the API publisher
- Displays an informational message confirming that the gateway will automatically acquire and
  inject a Bearer token using the pod's AKS Workload Identity

## Backward compatibility

No changes to existing `none`, `apikey`, or `aws` authentication flows.

### Admin Portal:
<img width="841" height="424" alt="image" src="https://github.com/user-attachments/assets/ef710529-8f85-4a6c-b4b4-5e85ca926c54" />

### Publisher Portal
<img width="1018" height="359" alt="image" src="https://github.com/user-attachments/assets/3da31d9e-871e-47a3-a55e-ec122e582123" />
