### PR TITLE
Fix flaky subscribe-via-wizard Cypress test on LAN-IP transport

### DIFF
--- a/tests/cypress/e2e/devportal/002-subscriptions/02-subscribe-via-wizard.cy.js
+++ b/tests/cypress/e2e/devportal/002-subscriptions/02-subscribe-via-wizard.cy.js
@@ -69,13 +69,19 @@ describe("Anonymous view apis", () => {
 
                 cy.wait('@generateKeys', { timeout: Cypress.env('largeTimeout') });
 
-                cy.get('body').then(($body) => {
-                    if ($body.find('[data-testid="secret-value-dialog"]').length > 0) {
-                        cy.get('[data-testid="secret-dialog-close"]', { timeout: Cypress.env('largeTimeout') })
-                            .should('be.visible')
-                            .click();
-                    }
-                });
+                // The secret-value dialog always appears at this step. The previous conditional
+                // `$body.find(...).length > 0` guard was a synchronous, non-retrying check that
+                // raced React's re-render: cy.wait('@generateKeys') resolves as soon as the HTTP
+                // response lands, but SecretValueDialog only mounts after the subsequent re-render.
+                // On slower (LAN-IP) transport the find() ran before the dialog mounted, returned
+                // 0, skipped the close click, and left the modal open — so the frontend never
+                // issued GET /oauth-keys and the later cy.wait('@oauthKeys') timed out. A retrying
+                // assertion waits for the dialog to actually mount before closing it.
+                cy.get('[data-testid="secret-value-dialog"]', { timeout: Cypress.env('largeTimeout') })
+                    .should('be.visible');
+                cy.get('[data-testid="secret-dialog-close"]', { timeout: Cypress.env('largeTimeout') })
+                    .should('be.visible')
+                    .click();
 
                 cy.wait('@oauthKeys', { timeout: Cypress.env('largeTimeout') }).then(() => {
                     cy.get('#wizard-next-3-btn', { timeout: Cypress.env('largeTimeout') }).click();


### PR DESCRIPTION
## Purpose

Fixes intermittent CI failures in `tests/cypress/e2e/devportal/002-subscriptions/02-subscribe-via-wizard.cy.js`. The test passes on local/loopback runs but flakes on the CI pipeline (LAN-IP transport) with a timeout on `cy.wait('@oauthKeys')`.

## Root cause

After `cy.wait('@generateKeys', ...)`, the code did a synchronous one-shot check for the secret-value dialog:

```js
cy.get('body').then(($body) => {
    if ($body.find('[data-testid="secret-value-dialog"]').length > 0) {
        ...
    }
});
```

`cy.wait('@generateKeys')` resolves the moment the HTTP response lands, but `SecretValueDialog` only mounts after React re-renders. `$body.find(...).length` is synchronous with no retry, so on slower (LAN-IP) transport it fires before the dialog mounts, returns 0, and the close click is skipped. The modal stays open, the frontend never issues `GET /oauth-keys`, and the later `cy.wait('@oauthKeys')` times out.

## Fix

The secret-value dialog always appears at this step, so the conditional guard was incorrect. Replaced the `cy.get('body').then(...)` block with a retrying assertion that waits for the dialog to actually mount before closing it, with a comment explaining why the conditional was removed. Only this one spec file is modified.
