### PR TITLE
Fix API resources and thumbnail refresh on update, and shared scope nav bar link conditions

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/NewOverview/Resources.jsx
@@ -109,6 +109,17 @@ class Resources extends React.Component {
     }
 
     componentDidMount() {
+        this.fetchSwagger();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.api.id !== this.props.api.id) {
+            this.setState({ paths: null, notFound: false });
+            this.fetchSwagger();
+        }
+    }
+
+    fetchSwagger() {
         const { id } = this.props.api;
         const promisedAPI = this.restApi.getSwagger(id);
         promisedAPI

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/BaseThumbnail.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Listing/components/ImageGenerator/BaseThumbnail.jsx
@@ -167,7 +167,7 @@ const BaseThumbnail = (props) => {
         } else {
             setImageLoaded(true);
         }
-    }, [imageUpdate]);
+    }, [id, imageUpdate]);
 
     useEffect(() => {
         setThumbnail(thumbnailPop);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Base/Header/navbar/GlobalNavLinks.jsx
@@ -161,21 +161,25 @@ function GlobalNavLinks(props) {
                                 defaultMessage='Services'
                             />
                         </GlobalNavLink>
-                        <GlobalNavLink
-                            id='scope'
-                            to='/scopes'
-                            type='scopes'
-                            title={intl.formatMessage({
-                                id: 'Base.Header.navbar.GlobalNavBar.title.scopes',
-                                defaultMessage: 'Scopes',
-                            })}
-                            active={selected === 'scopes'}
-                        >
-                            <FormattedMessage
-                                id='Base.Header.navbar.GlobalNavBar.scopes'
-                                defaultMessage='Scopes'
-                            />
-                        </GlobalNavLink>
+                    </div>
+                )}
+                <GlobalNavLink
+                    id='scope'
+                    to='/scopes'
+                    type='scopes'
+                    title={intl.formatMessage({
+                        id: 'Base.Header.navbar.GlobalNavBar.title.scopes',
+                        defaultMessage: 'Scopes',
+                    })}
+                    active={selected === 'scopes'}
+                >
+                    <FormattedMessage
+                        id='Base.Header.navbar.GlobalNavBar.scopes'
+                        defaultMessage='Scopes'
+                    />
+                </GlobalNavLink>
+                {gateway && (settings && !settings.portalConfigurationOnlyModeEnabled) && (
+                    <div>
                         <GlobalNavLink
                             id='policies'
                             to='/policies'


### PR DESCRIPTION
## Purpose

This pull request introduces several improvements to the API Publisher Portal's React components, focusing on better state management, navigation logic, and image handling. The changes enhance component reactivity to prop updates, refine navigation visibility based on app settings, and ensure images update correctly when relevant props change.

**Component lifecycle and state management improvements:**

* Refactored the `Resources` component to fetch the Swagger definition both on mount and whenever the `api.id` prop changes, ensuring the displayed API data stays current. State is reset appropriately on API change.

**Navigation logic updates:**

* Updated the `GlobalNavLinks` component to conditionally render the "Policies" navigation link only when both `gateway` is enabled and `portalConfigurationOnlyModeEnabled` is false in settings, improving navigation accuracy.
* Fixed the conditional rendering block to ensure proper closing and structure around the "Services" navigation link.

**Image handling enhancements:**

* Modified the `BaseThumbnail` component to include the `id` prop as a dependency for its image loading effect, ensuring that the image is reloaded when the `id` changes as well as when `imageUpdate` changes.

## Related Issue

Resolves https://github.com/wso2/api-manager/issues/5039