### PR TITLE
Fix Devportal button text casing inconsistency

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
+++ b/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
@@ -40,6 +40,13 @@ const DefaultConfigurations = {
             color: '#666',
         },
     },
+    overrides: {
+        MuiButton: {
+            root: {
+                textTransform: 'none',
+            },
+        },
+    },
     custom: {
         contentAreaWidth: 1240,
         backgroundImage: '', // Add a watermark background to the content area of the page. Example ( '/devportal/site/public/images/back-light.png')


### PR DESCRIPTION
Fixes wso2/api-manager#3858. This PR updates the Devportal's defaultTheme.js to disable the default uppercase textTransform on MuiButton, bringing it into consistency with Publisher's title casing.