### PR TITLE
Fix alphabetical sorting of documents within document type groups in Dev Portal

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
@@ -271,14 +271,21 @@ function DocList(props) {
 
     const getDocumentOrder = (type) => {
     const order = documentTypeOrder.indexOf(type);
-    return order === -1 ? -1 : order;
-    };
-    
+    return order === -1 ? documentTypeOrder.length : order;
+};
+
     const sortDocuments = (a, b) => {
-        const typeOrder = getDocumentOrder(a.type) - getDocumentOrder(b.type);
+        const aOrder = getDocumentOrder(a.type);
+        const bOrder = getDocumentOrder(b.type);
+    
+        const typeOrder = aOrder - bOrder;
     
         if (typeOrder !== 0) {
             return typeOrder;
+        }
+    
+        if (a.type !== b.type) {
+            return String(a.type).localeCompare(String(b.type));
         }
     
         return a.name.localeCompare(b.name);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
@@ -269,6 +269,23 @@ function DocList(props) {
         }),
     };
 
+    const getDocumentOrder = (type) => {
+    const order = documentTypeOrder.indexOf(type);
+    return order === -1 ? -1 : order;
+    };
+    
+    const sortDocuments = (a, b) => {
+        const typeOrder = getDocumentOrder(a.type) - getDocumentOrder(b.type);
+    
+        if (typeOrder !== 0) {
+            return typeOrder;
+        }
+    
+        return a.name.localeCompare(b.name);
+    };
+    
+    const sortedDocuments = [...documentList].sort(sortDocuments);
+    
     const [viewDocument, setViewDocument] = useState(selectedDoc);
     useEffect(() => {
         setbreadcrumbDocument(viewDocument.name);
@@ -293,13 +310,7 @@ function DocList(props) {
                     value={selectedDoc}
                     id='document-autocomplete'
                     className={classes.autocomplete}
-                    options={documentList.sort((a, b) => {
-                        const getOrder = (type) => {
-                            const order = documentTypeOrder.indexOf(type);
-                            return order === -1 ? -1 : order;
-                        };
-                        return getOrder(a.type) - getOrder(b.type);
-                    })}
+                    options={sortedDocuments}
                     groupBy={(document) => {
                         if (document.type in documentTypes) {
                             return documentTypes[document.type];


### PR DESCRIPTION
## Purpose

This PR fixes the document ordering in the Dev Portal document dropdown.

Previously, documents were only sorted by document type (`HOWTO`, `SAMPLES`, `PUBLIC_FORUM`, `SUPPORT_FORUM`, `OTHER`). As a result, documents within the same type were displayed in the order received from the backend API, which could appear inconsistent.

## Goals

* Preserve the existing document type ordering.
* Sort documents alphabetically by document name within each document type group.
* Avoid mutating the original document list while sorting.

## Solution

Updated the document sorting logic in the Dev Portal document dropdown to:

1. Sort documents based on the predefined document type order.
2. Apply a secondary alphabetical sort using the document name when documents belong to the same type.
3. Use a copied array for sorting instead of mutating the original `documentList` prop.

## Testing

Verified the document dropdown ordering using multiple documents with different names under the same document type.

Example:

Before:

```text
HOWTO
  Zebra Guide
  Apple Guide
  Mango Guide
```

After:

```text
HOWTO
  Apple Guide
  Mango Guide
  Zebra Guide
```

The existing document type grouping and ordering remain unchanged.

Fixes #5060