### PR TITLE
Sort documents alphabetically within type groups in devportal doc list

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/Documents/DocList.jsx
@@ -293,12 +293,16 @@ function DocList(props) {
                     value={selectedDoc}
                     id='document-autocomplete'
                     className={classes.autocomplete}
-                    options={documentList.sort((a, b) => {
+                    options={[...documentList].sort((a, b) => {
                         const getOrder = (type) => {
                             const order = documentTypeOrder.indexOf(type);
                             return order === -1 ? -1 : order;
                         };
-                        return getOrder(a.type) - getOrder(b.type);
+                        const typeDiff = getOrder(a.type) - getOrder(b.type);
+                        if (typeDiff !== 0) return typeDiff;
+                        const caseInsensitiveDiff = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+                        if (caseInsensitiveDiff !== 0) return caseInsensitiveDiff;
+                        return b.name.localeCompare(a.name);
                     })}
                     groupBy={(document) => {
                         if (document.type in documentTypes) {

--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -1069,6 +1069,7 @@
   "Apis.Details.Endpoints.UploadCustomBackend.config.save.button": "Save",
   "Apis.Details.Endpoints.UploadCustomBackend.invalid.file": "Invalid file type",
   "Apis.Details.Endpoints.add.new.endpoint": "Add Sandbox Endpoint",
+  "Apis.Details.Environments.Environments\n                                                                            .select.vhost": "Select Access URL",
   "Apis.Details.Environments.Environments\n                                                                    .select.vhost": "Select Access URL",
   "Apis.Details.Environments.Environments.APIGateways": "Gateways",
   "Apis.Details.Environments.Environments.Create.Revision.Deploy": "Create new revision and deploy",

--- a/tests/cypress/e2e/publisher/012-documents/01-view-generated-document-rest.cy.js
+++ b/tests/cypress/e2e/publisher/012-documents/01-view-generated-document-rest.cy.js
@@ -23,6 +23,10 @@ const genApiName = Utils.generateName();
 const documentName = Utils.generateName();
 const documentSummary = 'api document summery';
 
+// Documents added out of alphabetical order intentionally to verify sort fix
+const howToDocs = ['C HowTo', 'A HowTo', 'B HowTo'];
+const samplesDocs = ['C Sample', 'A Sample', 'B Sample'];
+
 describe("publisher-012-01 :View generated document for rest apis", () => {
     const { publisher, password, } = Utils.getUserInfo();
     Cypress.on('uncaught:exception', (err, runnable) => {
@@ -55,16 +59,67 @@ describe("publisher-012-01 :View generated document for rest apis", () => {
             // Checking it's existence
             cy.get('table a').contains(documentName).should('be.visible');
 
+            // Add HOWTO documents out of alphabetical order to verify sort fix
+            howToDocs.forEach((name) => {
+                cy.get('[data-testid="add-document-btn"]').click();
+                cy.get('#doc-name').type(name);
+                cy.get('#doc-summary').click();
+                cy.get('#doc-summary').type('summary');
+                cy.get('#add-document-btn').scrollIntoView();
+                cy.get('#add-document-btn').click();
+                cy.get('#add-content-back-to-listing-btn').click();
+                cy.get('table a').contains(name).should('be.visible');
+            });
+
+            // Add SAMPLES documents out of alphabetical order to verify sort fix
+            samplesDocs.forEach((name) => {
+                cy.get('[data-testid="add-document-btn"]').click();
+                cy.get('#doc-name').type(name);
+                cy.get('#doc-summary').click();
+                cy.get('#doc-summary').type('summary');
+                cy.get('input[value="SAMPLES"]').click();
+                cy.get('#add-document-btn').scrollIntoView();
+                cy.get('#add-document-btn').click();
+                cy.get('#add-content-back-to-listing-btn').click();
+                cy.get('table a').contains(name).should('be.visible');
+            });
+
             Utils.publishAPI(apiId);
         });
     });
-    it.only("Viewing generated document in devportal", () => {
+    it.only("Viewing generated document in devportal and verifying alphabetical sort", () => {
         cy.intercept('GET', '**/apis/**/swagger**').as('getSwagger');
         cy.visit(`/devportal/apis/${genApiId}/documents/default?tenant=carbon.super`);
         cy.wait('@getSwagger').its('response.statusCode').should('eq', 200);
         cy.get('#apim_elements').should('be.visible');
         cy.get('#document-autocomplete').should('have.value', 'Default');
         cy.get('h1[class*="sl-text-"]').contains(genApiName).should('be.visible');
+
+        // Open the Select Documents dropdown and verify docs are sorted alphabetically within each type group
+        cy.get('#document-autocomplete').click();
+        cy.get('[id^="document-autocomplete-option-"]').then(($options) => {
+            const names = [...$options].map((el) => el.textContent.trim());
+
+            const alphabeticalSort = (a, b) => {
+                const caseInsensitiveDiff = a.toLowerCase().localeCompare(b.toLowerCase());
+                if (caseInsensitiveDiff !== 0) return caseInsensitiveDiff;
+                return b.localeCompare(a);
+            };
+
+            // Verify HOWTO docs are in alphabetical order
+            const presentHowToDocs = names.filter((n) => howToDocs.includes(n));
+            expect(presentHowToDocs).to.deep.equal([...presentHowToDocs].sort(alphabeticalSort));
+
+            // Verify SAMPLES docs are in alphabetical order
+            const presentSamplesDocs = names.filter((n) => samplesDocs.includes(n));
+            expect(presentSamplesDocs).to.deep.equal([...presentSamplesDocs].sort(alphabeticalSort));
+
+            // Verify HOWTO group appears before SAMPLES group
+            const firstHowToIndex = names.findIndex((n) => howToDocs.includes(n));
+            const firstSamplesIndex = names.findIndex((n) => samplesDocs.includes(n));
+            expect(firstHowToIndex).to.be.lessThan(firstSamplesIndex);
+        });
+
         // Test is done. Now delete the api
         cy.loginToPublisher(publisher, password);
         Utils.deleteAPI(genApiId);


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/5060

This pull request improves the sorting logic for API documents in the document selection dropdown and adds comprehensive Cypress tests to verify the new sorting behavior. The main focus is to ensure that documents are grouped by type and sorted alphabetically (case-insensitive) within each group, with additional tie-breaking for names that differ only by case.

**Frontend sorting logic improvements:**

- Enhanced the sorting function in `DocList.jsx` to sort document options by type order, then alphabetically (case-insensitive), and finally by case-sensitive order if names are otherwise identical. This ensures consistent and user-friendly ordering of documents in the dropdown.

**Automated test enhancements:**

- Updated Cypress tests to add HOWTO and SAMPLES documents in non-alphabetical order, verifying that the UI sorts them correctly in the dropdown by type and then alphabetically within each group. [[1]](diffhunk://#diff-f6a8ad530c018e0bd462e90a4701821d1129fd2c25df582c05a9a039f47f3dc4R26-R29) [[2]](diffhunk://#diff-f6a8ad530c018e0bd462e90a4701821d1129fd2c25df582c05a9a039f47f3dc4R62-R122)
- Added assertions in the test to check that the HOWTO group appears before the SAMPLES group and that documents within each group are sorted as intended.

<img width="1705" height="954" alt="image" src="https://github.com/user-attachments/assets/51438909-ce00-4eb1-89dc-b7a12a3b13d4" />