### PR TITLE
Fix cert deletion warning to show total dependent API count

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/GeneralConfiguration/Certificates.jsx
@@ -266,7 +266,7 @@ function Certificates(props) {
 
     const getWarningMessage = () => {
         return certificateToDelete.alias + ' is used by ' +
-            certificateUsageDetails.count + ' other APIs. ';
+            certificateUsageDetails.count + ' APIs. ';
     }
 
 

--- a/tests/cypress/e2e/publisher/004-endpoints/08-usage-warning-certificates.cy.skip.js
+++ b/tests/cypress/e2e/publisher/004-endpoints/08-usage-warning-certificates.cy.skip.js
@@ -108,7 +108,7 @@ describe("Endpoint certificate usage testing", () => {
 
     it.only("Has correct warning message", () => {
         // Expected warning message
-        const expectedMessage = `${alias} is used by ${random_number} other APIs`;
+        const expectedMessage = `${alias} is used by ${random_number} APIs.`;
 
         // Test for correct warning message
         cy.get('#delete-cert-btn').click({ force: true });


### PR DESCRIPTION
## Summary

- The certificate deletion warning dialog said "N **other** APIs" which was ambiguous — when deleting from the global certificates list there is no "current" API context, so "other" has no clear referent.
- Changed to "N APIs" to make the count unambiguous.

## Changes

- **`Certificates.jsx`** — removed the word "other" from `getWarningMessage()`

## Related

Backend fix (wildcard cert usage detection): wso2/carbon-apimgt (pending — fork required)

Fixes: https://github.com/wso2/api-manager/issues/5053

🤖 Generated with [Claude Code](https://claude.com/claude-code)