### PR TITLE
Fix misleading hardcoded 30000 in Advanced Endpoint Configuration Duration field

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AdvancedConfig/AdvanceEndpointConfig.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/AdvancedConfig/AdvanceEndpointConfig.jsx
@@ -112,7 +112,7 @@ function AdvanceEndpointConfig(props) {
             config.optimize = 'leave-as-is';
         }
         if (api?.type !== 'WS') {
-            config.actionDuration = '30000';
+            config.actionDuration = '';
             config.actionSelect = 'fault';
             config.retryDelay = '';
             config.retryErroCode = [];
@@ -552,6 +552,7 @@ function AdvanceEndpointConfig(props) {
                                 className={classes.textField}
                                 id='duration-input'
                                 value={advanceConfigObj.actionDuration}
+                                placeholder='30000'
                                 onKeyDown={(event) => validateNumber(event)}
                                 onChange= {(event) => handleConfigFieldChange(event, 'actionDuration')}
                                 label={(


### PR DESCRIPTION
## Issue

https://github.com/wso2/api-manager/issues/5068

## Root Cause

In `AdvanceEndpointConfig.jsx`, the `useState` initializer unconditionally sets `config.actionDuration = '30000'`. Because the Duration `TextField` binds `value={advanceConfigObj.actionDuration}`, the field displays `30000` on every fresh/unconfigured API — indistinguishable from a value the operator actually set. When the operator clicks Save without touching this field, `30000` is persisted as the endpoint-specific timeout, silently overriding the global `synapse.globa
l_timeout_interval` (typically 75 s or 120 s).

## Changes

**File:** `portals/publisher/source/src/app/components/Apis/Details/Endpoints/AdvancedConfig/AdvanceEndpointConfig.jsx`

- `useState` initializer: `config.actionDuration = '30000'` → `config.actionDuration = ''`
  — ensures an unconfigured field is not pre-committed, so a no-op Save does not persist a phantom 30 s timeout.
- Duration `TextField`: added `placeholder='30000'`
  — the default is still visible to the operator as a grayed hint, not a committed value.

Diff: 1 file, +2/-1.

<img width="599" height="252" alt="Screenshot 2026-06-16 at 09 22 37" src="https://github.com/user-attachments/assets/cd152d3a-b13f-40c7-8ea8-ac0c6cacf371" />
<img width="602" height="249" alt="Screenshot 2026-06-16 at 09 22 49" src="https://github.com/user-attachments/assets/ed6f3b2d-9142-48fb-8c54-a8fe6c6710a6" />
<img width="600" height="248" alt="Screenshot 2026-06-16 at 09 23 01" src="https://github.com/user-attachments/assets/afe0e921-ede4-4120-bba9-5eb2a07c1164" />

## Verification

Fix was independently verified at runtime (FIXED verdict):

1. **Fresh API:** `input#duration-input` renders `value=""`, `placeholder="30000"` — the 30000 appears only as a grayed placeholder.
2. **No-op Save:** open dialog → Save without editing →
 reopen → Duration still `value=""`. REST `GET /apis/{id}` confirms `actionDuration=""` (not `"30000"`) — global `synapse.global_timeout_interval` continues to apply.
3. **Regression:** type `10000` → Save → reopen → `value="10000"` — operator-entered values still persist correctly.

## Test Plan

- [x] Open the Publisher on a fresh REST API with no endpoint-specific timeout configured.
- [x] Open Endpoints → Advanced Endpoint Configuration dialog.
- [x] Verify the Connection Timeout → Duration (ms) field is empty (not pre-filled with 30000); 30000 should appear only as grayed placeholder text.
- [x] Click Save without editing. Reopen the dialog — confirm Duration is still empty (no phantom 30000 persisted).
- [x] Type `10000`, Save, reopen — confirm `10000` is committed and shown.

Logs when invoking a mock backend which waits for 500s when a req comes:

```
1. Without giving any timeout values: Global timeout value is used
[2026-06-15 19:36:31,579]  INFO - TimeoutHandler This engine will expire all callbacks after GLOBAL_TIMEOUT: 120 seconds, irrespective of the timeout action, after the specified or optional timeout

[2026-06-15 19:38:46,609]  WARN - TimeoutHandler Expiring message ID : urn:uuid:0caf2210-b262-4ea9-8b3b-54f700b88e0e; dropping message after GLOBAL_TIMEOUT of : 120 seconds for Endpoint [ReadingListAPI--v1.0_APIproductionEndpoint], URI : http://localhost:8089/books, Received through API : prod--ReadingListAPI:v1.0Correlation ID : f3472dce-39eb-400d-bbb6-6a14b6b284c7

2. With a value: When 10000 is given as the value
[2026-06-15 19:40:01,618]  WARN - TimeoutHandler Expiring message ID : urn:uuid:a2dfde32-a585-44a3-9804-055606efde70; dropping message after ENDPOINT_TIMEOUT of : 10 seconds for Endpoint [ReadingListAPI--v1.0_APIproductionEndpoint], URI : http://localhost:8089/books, Received through API : prod--ReadingListAPI:v1.0Correlation ID : fa33599d-1c5b-466e-8a97-295e91225052
```
