### PR TITLE
Prevent AsyncAPI definition request for API Products

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -775,9 +775,10 @@ export default function Environments() {
     };
 
     const externalEnvWithEndpoints = [];
-    useEffect(() => {
-        if (!isMCPServer) {
-            const promise = restApi.getAsyncAPIDefinition(api.id);
+useEffect(() => {
+    const isAPIProduct = api.apiType === API.CONSTS.APIProduct;
+    if (!isMCPServer && !isAPIProduct) {
+        const promise = restApi.getAsyncAPIDefinition(api.id);
             promise.then(async (response) => {
                 if (response.data && (typeof response.data === "string" || typeof response.data === "object")) {
                     let doc;
@@ -825,7 +826,7 @@ export default function Environments() {
                 }
             })
         }
-    }, [api.id]);
+    }, [api.id, api.apiType, isMCPServer]);
 
     const toggleOpenConfirmDelete = (revisionName, revisionId) => {
         setRevisionToDelete([revisionName, revisionId]);

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -826,7 +826,7 @@ useEffect(() => {
                 }
             })
         }
-    }, [api.id, api.apiType, isMCPServer]);
+    }, [api.id, api.apiType, isMCPServer, allExternalGateways]);
 
     const toggleOpenConfirmDelete = (revisionName, revisionId) => {
         setRevisionToDelete([revisionName, revisionId]);


### PR DESCRIPTION
Fixes wso2/api-manager#5092

This PR prevents the Publisher deployment page from calling the AsyncAPI definition endpoint for API Products.

API Products do not carry AsyncAPI definitions, so calling `restApi.getAsyncAPIDefinition(api.id)` for API Products creates an unnecessary failed network request.

The fix adds an API Product guard while keeping the existing MCP Server guard unchanged.

Changes:

* Added an API Product check using `api.apiType === API.CONSTS.APIProduct`
* Skipped `getAsyncAPIDefinition` when the current entity is an API Product
* Updated the React effect dependency list to include `api.apiType` and `isMCPServer`

Testing:

* Verified the code change with `git diff`
* Confirmed only `Environments.jsx` was changed
