### PR TITLE
Surface backend validation error messages inline in the Create-API wizard

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -180,6 +180,7 @@
   "Apis.Create.OpenAPI.create.api.form.file.label": "OpenAPI File/Archive",
   "Apis.Create.OpenAPI.create.api.form.url.label": "OpenAPI URL",
   "Apis.Create.OpenAPI.create.api.openapi.content.validation.failed": "OpenAPI content validation failed!",
+  "Apis.Create.OpenAPI.create.api.openapi.validation.error": "Error while validating OpenAPI definition",
   "Apis.Create.OpenAPI.create.api.url.helper.text": "Click away to validate the URL",
   "Apis.Create.OpenAPI.create.api.url.label": "OpenAPI URL",
   "Apis.Create.OpenAPI.create.api.url.placeholder": "Enter OpenAPI URL",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/ProvideOpenAPI.jsx
@@ -48,8 +48,9 @@ import API from 'AppData/api';
 import MCPServer from 'AppData/MCPServer';
 import DropZoneLocal, { humanFileSize } from 'AppComponents/Shared/DropZoneLocal';
 import Utils from 'AppData/Utils';
-import {  
+import {
     getLinterResultsFromContent } from "../../../Details/APIDefinition/Linting/Linting";
+import getValidationErrorsFromError from './validationErrorUtils';
 import ValidationResults from './ValidationResults';
 
 const PREFIX = 'ProvideOpenAPI';
@@ -133,6 +134,12 @@ export default function ProvideOpenAPI(props) {
                         defaultMessage: 'Failed to validate the OpenAPI URL. Please try again.',
                     });
                 setValidity({ url: { message: errorMessage } });
+                // Surface a rejected validation (e.g. an SSRF block, HTTP 400 "not trusted")
+                // in the Validation Errors card, matching the isValid:false path.
+                setValidationErrors(getValidationErrorsFromError(error, intl.formatMessage({
+                    id: 'Apis.Create.OpenAPI.create.api.openapi.validation.error',
+                    defaultMessage: 'Error while validating OpenAPI definition',
+                })));
                 onValidate(false);
                 setIsValidating(false);
                 console.error(error);
@@ -234,6 +241,7 @@ export default function ProvideOpenAPI(props) {
                         validFile = file;
                         inputsDispatcher({ action: 'preSetAPI', value: info });
                         setValidity({ ...isValid, file: null });
+                        setValidationErrors([]);
                     } else {
                         setValidity({
                             ...isValid, file: {
@@ -255,6 +263,12 @@ export default function ProvideOpenAPI(props) {
                             })
                         }
                     });
+                    // Surface a rejected validation (e.g. an SSRF block, HTTP 400 "not trusted")
+                    // in the Validation Errors card, matching the isValid:false path above.
+                    setValidationErrors(getValidationErrorsFromError(error, intl.formatMessage({
+                        id: 'Apis.Create.OpenAPI.create.api.openapi.validation.error',
+                        defaultMessage: 'Error while validating OpenAPI definition',
+                    })));
                     console.error(error);
                 })
                 .finally(() => {
@@ -273,6 +287,7 @@ export default function ProvideOpenAPI(props) {
                         validFile = file;
                         inputsDispatcher({ action: 'preSetAPI', value: info });
                         setValidity({ ...isValid, file: null });
+                        setValidationErrors([]);
                     } else {
                         setValidity({
                             ...isValid, file: {
@@ -294,6 +309,12 @@ export default function ProvideOpenAPI(props) {
                             })
                         }
                     });
+                    // Surface a rejected validation (e.g. an SSRF block, HTTP 400 "not trusted")
+                    // in the Validation Errors card, matching the isValid:false path above.
+                    setValidationErrors(getValidationErrorsFromError(error, intl.formatMessage({
+                        id: 'Apis.Create.OpenAPI.create.api.openapi.validation.error',
+                        defaultMessage: 'Error while validating OpenAPI definition',
+                    })));
                     console.error(error);
                 })
                 .finally(() => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/validationErrorUtils.test.ts
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/validationErrorUtils.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import getValidationErrorsFromError from './validationErrorUtils';
+
+const TITLE = 'Error while validating OpenAPI definition';
+
+describe('getValidationErrorsFromError', () => {
+    it('surfaces the backend description from a rejected validation (e.g. SSRF block, HTTP 400 "not trusted")', () => {
+        const notTrusted = 'The provided URL is not trusted. Please contact the system administrator.';
+        const error = {
+            response: { body: { code: 400, message: 'Bad Request', description: notTrusted } },
+        };
+
+        expect(getValidationErrorsFromError(error, TITLE)).toEqual([
+            { message: TITLE, description: notTrusted },
+        ]);
+    });
+
+    it('returns [] without a backend description (network/other errors keep the generic fallback)', () => {
+        const noDescriptionCases = [
+            new Error('Network Error'),
+            { response: { body: {} } },
+            { response: {} },
+            undefined,
+        ];
+        noDescriptionCases.forEach((error) => {
+            expect(getValidationErrorsFromError(error, TITLE)).toEqual([]);
+        });
+    });
+});

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/validationErrorUtils.ts
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Create/OpenAPI/Steps/validationErrorUtils.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Build "Validation Errors" card entries from a rejected OpenAPI validation request.
+ *
+ * When validate-openapi returns 200 with `isValid:false`, its `errors` array is shown in the
+ * card directly. But when it *rejects* with an HTTP error (e.g. an SSRF block — 400
+ * UNTRUSTED_URL, "The provided URL is not trusted."), the reason lives in
+ * `error.response.body.description` and was previously dropped to the console, leaving the
+ * card empty and the user with only a generic "validation failed" message.
+ *
+ * This surfaces that backend description as a card entry so a rejected validation is shown as
+ * prominently as the `isValid:false` path. Errors without a backend description (network
+ * failures, etc.) return `[]`, so callers keep their existing generic-message fallback.
+ *
+ * @param {any} error caught error from a validateOpenAPIByFile / validateOpenAPIByUrl call
+ * @param {string} title localized bold title shown above the backend description
+ * @returns {Array<{message: string, description: string}>} card entries (empty when there is
+ *  no backend-provided description)
+ */
+export default function getValidationErrorsFromError(
+    error: any,
+    title: string,
+): Array<{ message: string; description: string }> {
+    const description = error?.response?.body?.description;
+    if (!description) {
+        return [];
+    }
+    return [{ message: title, description }];
+}


### PR DESCRIPTION
Superseded by #1374 (branch renamed for clarity; no content change).