### PR TITLE
Fix API Console stuck in loading state when switching Gateway Env

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -683,6 +683,7 @@ class ApiConsole extends React.Component {
                 </Paper>
                 <Paper className={classes.swaggerUIPaper} dir='ltr'>
                     <SwaggerUI
+                        key={selectedEnvironment}
                         api={this.state.api}
                         accessTokenProvider={this.accessTokenProvider}
                         spec={swaggerSpec}


### PR DESCRIPTION
### Purpose

Fixes the API Console getting stuck in a loading state when switching the gateway environment after executing a request.

### Changes 

- The API Console showed an indefinite loading spinner after a request was executed and the gateway environment was switched. This happened because <SwaggerUI> in ApiConsole.jsx had no key prop — React kept the component mounted across environment switches, preserving its internal Redux state (e.g. isExecuting: true) from the previous request. 
- Adding key={selectedEnvironment} forces a full remount of the SwaggerUI component whenever the environment changes, resetting all internal state cleanly.

### Related Issues

Fixes wso2/api-manager#5098   