### PR TITLE
Add Cypress e2e tests for RTL language support in DevPortal

### DIFF
--- a/tests/cypress/e2e/devportal/005-localization/00-rtl-language-switching.cy.js
+++ b/tests/cypress/e2e/devportal/005-localization/00-rtl-language-switching.cy.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ Verifies that the DevPortal flips its layout from LTR to RTL when an RTL
+ language is selected. Only the direction switch is under test (the translated
+ text is user-editable and out of scope).
+ 
+ Activation: on a fresh pack the language switcher is off; it is normally turned
+ on by `custom.languageSwitch.active` in the server's userTheme.json. The suite
+ runs against a remote server (no filesystem access), so we inject that config
+ client-side: the page loads `/site/public/theme/userTheme.js` as a classic
+ script defining the global `const Configurations`, which webpack maps to
+ `import Configurations from 'Config'` and DevPortal.jsx merges over the default
+ theme. Stubbing that one request with cy.intercept makes the app behave exactly
+ as if the pack carried the config, with no server-side footprint.
+ */
+
+import Utils from '@support/utils';
+
+const languageSwitchTheme = {
+    direction: 'ltr',
+    custom: {
+        landingPage: { active: false },
+        languageSwitch: {
+            active: true,
+            showFlag: true,
+            showText: true,
+            minWidth: 60,
+            languages: [
+                { key: 'en', image: '/site/public/images/flags/en.png', imageWidth: 24, text: 'English', direction: 'ltr' },
+                { key: 'ar', image: '/site/public/images/flags/ar.png', imageWidth: 24, text: 'Arabic', direction: 'rtl' },
+            ],
+        },
+    },
+};
+
+// Replace the theme script body so `Configurations` carries the language switch.
+// Registered before cy.visit; survives the in-test window.location.reload() the
+// selector triggers. no-store makes the reload re-hit the stub, not the cache.
+const stubThemeWithLanguageSwitch = () => {
+    cy.intercept('GET', '**/site/public/theme/userTheme.js', {
+        statusCode: 200,
+        headers: {
+            'content-type': 'application/javascript; charset=UTF-8',
+            'cache-control': 'no-store',
+        },
+        body: `const Configurations = ${JSON.stringify(languageSwitchTheme)};`,
+    }).as('userTheme');
+};
+
+describe('DevPortal RTL - direction switching', () => {
+    beforeEach(() => {
+        stubThemeWithLanguageSwitch();
+        // Uses the merged systemTheme directly, so our injected config takes effect.
+        cy.visit('/devportal/apis?tenant=carbon.super');
+        cy.wait('@userTheme');
+    });
+
+    it('renders the language switcher and defaults to LTR', () => {
+        cy.get('#demo-language-select', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible');
+        cy.get('body').should('have.attr', 'dir', 'ltr');
+        cy.get('body').should('have.css', 'direction', 'ltr');
+    });
+
+    it('flips the document direction to RTL on Arabic and back to LTR on English', () => {
+        cy.get('#demo-language-select', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible');
+        cy.get('body').should('have.attr', 'dir', 'ltr');
+
+        // Select Arabic -> selector persists the choice and reloads the page.
+        cy.get('#demo-language-select').click();
+        cy.get('li[data-value="ar"]', { timeout: Cypress.env('largeTimeout') }).click();
+
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'rtl');
+        cy.get('body').should('have.css', 'direction', 'rtl');
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('language')).to.eq('ar');
+        });
+
+        // Switch back to English -> direction returns to LTR (bidirectional switching).
+        cy.get('#demo-language-select', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible')
+            .click();
+        cy.get('li[data-value="en"]', { timeout: Cypress.env('largeTimeout') }).click();
+
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'ltr');
+        cy.get('body').should('have.css', 'direction', 'ltr');
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem('language')).to.eq('en');
+        });
+    });
+
+    it('mirrors the floating chat bubble from the right in LTR to the left in RTL', () => {
+        // The floating chat button is positioned with insetInlineEnd, so it aligns to the
+        // right edge in LTR and mirrors to the left edge in RTL.
+        const VIEWPORT_WIDTH = 1280;
+        cy.viewport(VIEWPORT_WIDTH, 800);
+
+        cy.visit('/devportal/apis?tenant=carbon.super', {
+            onBeforeLoad(win) { win.localStorage.setItem('language', 'en'); },
+        });
+        cy.wait('@userTheme');
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'ltr');
+
+        let ltrLeft;
+        cy.get('[aria-label="chat"]', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible')
+            .then(($c) => {
+                ltrLeft = $c[0].getBoundingClientRect().left;
+                expect(ltrLeft, 'chat bubble on the right in LTR (insetInlineEnd)')
+                    .to.be.greaterThan(VIEWPORT_WIDTH / 2);
+            });
+
+        cy.visit('/devportal/apis?tenant=carbon.super', {
+            onBeforeLoad(win) { win.localStorage.setItem('language', 'ar'); },
+        });
+        cy.wait('@userTheme');
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'rtl');
+        cy.get('[aria-label="chat"]', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible')
+            .then(($c) => {
+                const rtlLeft = $c[0].getBoundingClientRect().left;
+                expect(rtlLeft, 'chat bubble on the left in RTL')
+                    .to.be.lessThan(VIEWPORT_WIDTH / 2);
+                expect(rtlLeft, 'chat bubble moved leftward when flipping to RTL')
+                    .to.be.lessThan(ltrLeft);
+            });
+    });
+});
+
+describe('DevPortal RTL - layout mirroring on the API details page', () => {
+    const { publisher, password } = Utils.getUserInfo();
+    const apiName = Utils.generateName();
+    const apiVersion = '1.0.0';
+    const VIEWPORT_WIDTH = 1280;
+    let apiId;
+
+    const overviewUrl = () => `/devportal/apis/${apiId}/overview?tenant=carbon.super`;
+
+    // Visit the API overview, and return the left edge (viewport px) of the left menu.
+    const leftMenuEdge = (lang) => {
+        const expectedDir = lang === 'ar' ? 'rtl' : 'ltr';
+        cy.visit(overviewUrl(), {
+            onBeforeLoad(win) {
+                win.localStorage.setItem('language', lang);
+            },
+        });
+        cy.wait('@userTheme');
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', expectedDir);
+        return cy.get('.left-menu', { timeout: Cypress.env('largeTimeout') })
+            .should('be.visible')
+            .then(($el) => $el[0].getBoundingClientRect().left);
+    };
+
+    before(() => {
+        // Create, deploy and publish a throwaway API so the details page (and its
+        // left menu) is available to view in the devportal.
+        cy.loginToPublisher(publisher, password);
+        Utils.addAPIWithEndpoints({ name: apiName, version: apiVersion }).then((id) => {
+            apiId = id;
+            Utils.addRevision(id).then((revId) => {
+                Utils.deployRevision(id, revId).then(() => {
+                    Utils.publishAPI(id);
+                });
+            });
+        });
+    });
+
+    beforeEach(() => {
+        stubThemeWithLanguageSwitch();
+        cy.viewport(VIEWPORT_WIDTH, 800);
+    });
+
+    it('pins the API-details left menu to the left in LTR and to the right in RTL', () => {
+        let ltrLeft;
+
+        // LTR: insetInlineStart:0 resolves to the left edge.
+        leftMenuEdge('en').then((left) => {
+            ltrLeft = left;
+            expect(ltrLeft, 'left menu hugs the left edge in LTR')
+                .to.be.lessThan(VIEWPORT_WIDTH / 2);
+        });
+
+        // RTL: the same insetInlineStart:0 now resolves to the right edge. Before
+        // the logical CSS this was a physical 'left', so it would NOT have moved.
+        leftMenuEdge('ar').then((rtlLeft) => {
+            expect(rtlLeft, 'left menu hugs the right edge in RTL')
+                .to.be.greaterThan(VIEWPORT_WIDTH / 2);
+            expect(rtlLeft, 'left menu moved rightward when flipping to RTL')
+                .to.be.greaterThan(ltrLeft);
+        });
+    });
+
+    it('flips the breadcrumb separator arrow direction (NavigateNext <-> NavigateBefore)', () => {
+        // The breadcrumb uses a direction-aware separator icon:
+        //   LTR -> NavigateNextIcon, RTL -> NavigateBeforeIcon
+        
+        // LTR
+        cy.visit(overviewUrl(), {
+            onBeforeLoad(win) { win.localStorage.setItem('language', 'en'); },
+        });
+        cy.wait('@userTheme');
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'ltr');
+        cy.get('[aria-label="breadcrumb"]', { timeout: Cypress.env('largeTimeout') }).should('be.visible');
+        cy.get('[aria-label="breadcrumb"] [data-testid="NavigateNextIcon"]').should('exist');
+        cy.get('[aria-label="breadcrumb"] [data-testid="NavigateBeforeIcon"]').should('not.exist');
+
+        // RTL: the separator arrow mirrors.
+        cy.visit(overviewUrl(), {
+            onBeforeLoad(win) { win.localStorage.setItem('language', 'ar'); },
+        });
+        cy.wait('@userTheme');
+        cy.get('body', { timeout: Cypress.env('largeTimeout') }).should('have.attr', 'dir', 'rtl');
+        cy.get('[aria-label="breadcrumb"]', { timeout: Cypress.env('largeTimeout') }).should('be.visible');
+        cy.get('[aria-label="breadcrumb"] [data-testid="NavigateBeforeIcon"]').should('exist');
+        cy.get('[aria-label="breadcrumb"] [data-testid="NavigateNextIcon"]').should('not.exist');
+    });
+
+    after(() => {
+        Utils.deleteAPI(apiId);
+    });
+});


### PR DESCRIPTION
## Purpose

This PR adds Cypress end-to-end test coverage for the RTL (Right-to-Left) language support added to the DevPortal in the feature PR mentioned below. The tests verify that selecting an RTL language flips the portal layout from LTR to RTL. Translated text itself is out of scope (it is user-editable via userTheme.json); only the direction switch and layout mirroring are under test.

### Related

- Feature PR: https://github.com/wso2/apim-apps/pull/1362
- Git Issue: https://github.com/wso2/api-manager/issues/5030

## Approach

- Added a self-contained spec at `cypress/e2e/devportal/005-localization/00-rtl-language-switching.cy.js`. No new fixtures or shared/custom commands, all helpers are local to the spec.

- Activated the language switcher without touching the pack. On a fresh pack the language switcher is off. It is normally enabled by `custom.languageSwitch.active` in the server's `userTheme.json`, which lives on the server filesystem. To avoid attempting to alter files within the pack, the config is injected client-side by stubbing the theme script request with `cy.intercept`:

```javascript
cy.intercept('GET', '**/site/public/theme/userTheme.js', {
    statusCode: 200,
    headers: { 'content-type': 'application/javascript; charset=UTF-8', 'cache-control': 'no-store' },
    body: `const Configurations = ${JSON.stringify(languageSwitchTheme)};`,
}).as('userTheme');
```
The page loads `userTheme.js` as a classic script defining the global const Configurations, which webpack maps to import. Configurations from 'Config' and `DevPortal.jsx` merges over the default theme. Stubbing that one request makes the app behave exactly as if the pack carried the config, with zero server-side footprint and no impact on other specs regardless of run order.

- Asserted the master direction switch. The suite drives the real `LanguageSelector → updateLocale() → RTL Emotion-cache` pipeline: selecting Arabic sets localStorage and reloads, then `body[dir="rtl"]`, computed CSS direction: `rtl`, and the persisted language are verified; switching back to English confirms bidirectional switching.

- Target PR-specific layout flips, not "free" native ones. The AppBar mirrors automatically because flexbox reverses under `dir="rtl"`; that does not exercise the specific RTL fixes. Instead the tests assert on elements that migrated from **physical CSS** (left/right) to **logical properties** (insetInlineStart/insetInlineEnd) in the feature PR:

  - **Floating chat bubble** (insetInlineEnd) - aligns to the right in LTR and mirrors to the left in RTL.
  - **API-details left menu** (insetInlineStart) - pins to the left edge in LTR and to the right edge in RTL. Verified via `getBoundingClientRect()` against a deterministic viewport, using a throwaway published API.
  - **Breadcrumb separator arrows** - direction-aware icons that flip from `NavigateNextIcon` (LTR) to `NavigateBeforeIcon` (RTL).

- Used a fixed `cy.viewport` for the positional assertions so layout-flip comparisons are deterministic, and `largeTimeout` waits to retry through the selector's page reload and React re-mount.

### Test Coverage

- **DevPortal RTL - direction switching**
  - renders the language switcher and defaults to LTR
  - flips the document direction to RTL on Arabic and back to LTR on English
  - mirrors the floating chat bubble from the right in LTR to the left in RTL

- **DevPortal RTL - layout mirroring on the API details page**
  - pins the API-details left menu to the left in LTR and to the right in RTL
  - flips the breadcrumb separator arrow direction (NavigateNext / NavigateBefore)