### PR TITLE
Fix duplicate basePath in Try Out URL for Swagger 2.0 third-party APIs

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx
@@ -368,16 +368,18 @@ class ApiConsole extends React.Component {
      */
     setServersSpec(spec, serverUrl) {
         let schemes;
-        const [protocol, host] = serverUrl.split('://');
-        if (protocol === 'http') {
+        const parsed = new URL(serverUrl);
+        if (parsed.protocol === 'http:') {
             schemes = ['http'];
-        } else if (protocol === 'https') {
+        } else if (parsed.protocol === 'https:') {
             schemes = ['https'];
         }
+        const basePath = parsed.pathname !== '/' ? parsed.pathname : (spec.basePath || '/');
         return {
             ...spec,
             schemes,
-            host,
+            host: parsed.host,
+            basePath,
         };
     }
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
@@ -219,16 +219,18 @@ const TryOutConsole = () => {
     const isAdvertised = api.advertiseInfo && api.advertiseInfo.advertised;
     const setServersSpec = (spec, serverUrl) => {
         let schemes;
-        const [protocol, host] = serverUrl.split('://');
-        if (protocol === 'http') {
+        const parsed = new URL(serverUrl);
+        if (parsed.protocol === 'http:') {
             schemes = ['http'];
-        } else if (protocol === 'https') {
+        } else if (parsed.protocol === 'https:') {
             schemes = ['https'];
         }
+        const basePath = parsed.pathname !== '/' ? parsed.pathname : (spec.basePath || '/');
         return {
             ...spec,
             schemes,
-            host,
+            host: parsed.host,
+            basePath,
         };
     };
     const updatedOasDefinition = useMemo(() => {

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
@@ -221,7 +221,7 @@ const TryOutConsole = () => {
         let parsed;
         try {
             parsed = new URL(serverUrl);
-        } catch (error) {
+        } catch {
             return spec;
         }
         let schemes;

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx
@@ -218,8 +218,13 @@ const TryOutConsole = () => {
 
     const isAdvertised = api.advertiseInfo && api.advertiseInfo.advertised;
     const setServersSpec = (spec, serverUrl) => {
+        let parsed;
+        try {
+            parsed = new URL(serverUrl);
+        } catch (error) {
+            return spec;
+        }
         let schemes;
-        const parsed = new URL(serverUrl);
         if (parsed.protocol === 'http:') {
             schemes = ['http'];
         } else if (parsed.protocol === 'https:') {


### PR DESCRIPTION
## Purpose
Fix incorrect Try Out URL construction for Swagger 2.0 third-party APIs when the external endpoint URL contains a path component.

Fixes: https://github.com/wso2/api-manager/issues/5118

## Problem
For third-party APIs, `setServersSpec()` used `split('://')` to extract the host from the endpoint URL. This incorrectly included the path in the host field (e.g. `petstore.swagger.io/v2` instead of `petstore.swagger.io`).

SwaggerUI then appended `basePath` on top, producing a double path:
`https://petstore.swagger.io/v2/v2/pet/1`

## Fix
Replaced `split('://')` with `new URL()`, which correctly separates host from pathname. The pathname is then used as `basePath` when present, falling back to the spec's original `basePath` when the URL has no path component.

## Files Changed
- `portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/ApiConsole/ApiConsole.jsx`
- `portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/TryOut/TryOutConsole.jsx`

## Testing
Tested with a Swagger 2.0 petstore API configured as a third-party API.

**Before fix — Production (double `/v2`)**
`https://petstore.swagger.io/v2/v2/pet/1` → 404
<img width="1177" height="682" alt="image" src="https://github.com/user-attachments/assets/0420615b-753c-40b1-a382-f68b26695686" />

**After fix — Production (correct)**
`https://petstore.swagger.io/v2/pet/1` → 200
<img width="938" height="704" alt="image" src="https://github.com/user-attachments/assets/bf62c5b7-bd70-4b5d-925c-aeb3212523db" />

**After fix — Sandbox (correct)**
`https://petstore.swagger.io/v2/pet/1`
<img width="886" height="688" alt="image" src="https://github.com/user-attachments/assets/83da6ebf-5ce7-4ca9-bfed-0a3da3fb4580" />
