### PR TITLE
Stabilize user-self-signup username unavailable config tests

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -51,6 +51,17 @@ Cypress.Commands.add('carbonLogin', (username, password) => {
     cy.visit(`/carbon/admin/login.jsp`);
     cy.get('#txtUserName').type(username);
     cy.get('#txtPassword').type(password);
+
+    // After login the carbon console dashboard loads template.js, where a YUI preload-attach timer can
+    // fire hideSection before the target DOM node exists, intermittently throwing
+    // "Cannot read properties of null (reading 'style')". This is a benign race in the carbon console
+    // itself, so suppress only that specific error rather than failing the test on it.
+    Cypress.on('uncaught:exception', (err) => {
+        if (err.message.includes("Cannot read properties of null (reading 'style')")) {
+            return false;
+        }
+        return true;
+    });
     cy.get('form').submit();
 })
 


### PR DESCRIPTION
This pull request stabilizes user-self-signup username unavailable config tests.

This addresses an intermittent test failure in the Cypress end-to-end tests caused by a benign JavaScript error in the Carbon console dashboard. The main change is the addition of logic to suppress a specific uncaught exception that does not impact the functionality being tested.

Test stability enhancement:

* Updated the `carbonLogin` Cypress command in `commands.js` to suppress a specific, harmless "Cannot read properties of null (reading 'style')" exception that sometimes occurs due to a race condition in the Carbon console's JavaScript, ensuring tests do not fail unnecessarily.