### PR TITLE
Fix #4874 - Disable edit action for deprecated API subscriptions

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -399,7 +399,8 @@ class SubscriptionTableData extends React.Component {
                             onClick={this.handleRequestOpenEditMenu}
                             startIcon={<Icon>edit</Icon>}
                             disabled={tiers.length === 0 || status === SUBSCRIPTION_STATUS.BLOCKED
-                                || status === SUBSCRIPTION_STATUS.PROD_ONLY_BLOCKED}
+                                || status === SUBSCRIPTION_STATUS.PROD_ONLY_BLOCKED
+                                || apiInfo.lifeCycleStatus === 'DEPRECATED'}
                         >
                             <FormattedMessage
                                 id='Applications.Details.SubscriptionTableData.edit.text'


### PR DESCRIPTION
## Purpose

Fixes #4874
https://github.com/wso2/api-manager/issues/4874

### Description

- Disable the Edit action for subscriptions associated with deprecated APIs in the Developer Portal.
- Align the UI behavior with the backend restriction and the existing behavior for blocked APIs.

### Related Issue

- Fixes #4874