### PR TITLE
fix(publisher): Fix endpoint security API key re-saving issue

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Endpoints/EndpointOverview.jsx
@@ -696,6 +696,8 @@ function EndpointOverview(props) {
             === secretPlaceholder ? '' : newEndpointSecurityObj.clientSecret;
         newEndpointSecurityObj.password = newEndpointSecurityObj.password 
             === secretPlaceholder ? '' : newEndpointSecurityObj.password;
+        newEndpointSecurityObj.apiKeyValue = newEndpointSecurityObj.apiKeyValue
+            === secretPlaceholder ? '' : newEndpointSecurityObj.apiKeyValue;
         if (type === 'NONE') {
             newEndpointSecurityObj = { ...CONSTS.DEFAULT_ENDPOINT_SECURITY, type };
         } else {


### PR DESCRIPTION
### Purpose                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
In the APIM publisher portal, when an API key is configured for endpoint security and then re-saved without making any changes, the system inadvertently updates the API key secret to match the UI text field's placeholder value (asterisks ******). This causes the literal asterisk string to be transmitted during API invocation.

This PR resolves the issue by ensuring the API key value remains unchanged and consistent upon re-saving.
                                                                                                                                                                                                                                                    
Fixes **#4983**   

[Issue Link](https://github.com/wso2/api-manager/issues/4983)                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                    
### Approach                

File Modified: `EndpointOverview.jsx`

Change: Updated the conditional logic within the `saveEndpointSecurityConfig` function to appropriately check against the `secretPlaceholder` before assigning the API key value, preventing the masked string from overwriting the actual secret.
