### PR TITLE
Fix #4942: Remove Additional FlowArrow in Publisher Portal UI

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
@@ -138,6 +138,7 @@ const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
                 }
                 isApiRevision={isApiRevision}
             />
+            <FlowArrow arrowDirection={arrowDirection === 'left' ? 'right' : 'left'} />
         </Box>
     );
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
@@ -138,7 +138,6 @@ const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
                 }
                 isApiRevision={isApiRevision}
             />
-            <FlowArrow arrowDirection={arrowDirection === 'left' ? 'right' : 'left'} />
         </Box>
     );
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/PoliciesUI/PoliciesExpansion.tsx
@@ -81,6 +81,7 @@ interface PolicySectionConfig {
     >;
     droppablePolicyList: string[];
     currentFlow: string;
+    showEndArrow?: boolean;
 }
 
 const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
@@ -114,6 +115,7 @@ const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
         setCurrentPolicyList,
         droppablePolicyList,
         currentFlow,
+        showEndArrow,
     }: PolicySectionConfig) => (
         <Box
             className={classes.flowSpecificPolicyAttachGrid}
@@ -138,7 +140,9 @@ const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
                 }
                 isApiRevision={isApiRevision}
             />
-            <FlowArrow arrowDirection={arrowDirection === 'left' ? 'right' : 'left'} />
+            {showEndArrow && (
+                <FlowArrow arrowDirection={arrowDirection === 'left' ? 'right' : 'left'} />
+            )}
         </Box>
     );
 
@@ -158,6 +162,7 @@ const PoliciesExpansionShared: FC<PoliciesExpansionSharedProps> = ({
                 setCurrentPolicyList: setRequestFlowPolicyList,
                 droppablePolicyList: requestFlowDroppablePolicyList,
                 currentFlow: 'hub',
+                showEndArrow: true,
             });
         }
 


### PR DESCRIPTION
## Problem
The API Policies page for the default gateway incorrectly renders an extra trailing arrow after the policy dropzone in the Request/Response/Fault flow sections. This should only appear for the platform gateway (Policy Hub) flow, where the unified policy section legitimately needs a closing arrow.

## Solution                                                                                                                                                                           
Added an optional showEndArrow flag to PolicySectionConfig in PoliciesExpansionShared (PoliciesExpansion.tsx). The trailing FlowArrow is now only rendered when showEndArrow is explicitly set to true.

After Fix:
<img width="1512" height="833" alt="default_gateway_api_policy_page" src="https://github.com/user-attachments/assets/653ce6d4-b33f-425a-8c1c-c6bf781670cb" />

<img width="1512" height="837" alt="policyhub_gateway_page" src="https://github.com/user-attachments/assets/cd3715ee-559f-46ef-9f97-25170665ab8c" />

## Related Issue
Link: https://github.com/wso2/api-manager/issues/4942 
