### PR TITLE
Add pagination for devportal application subscriptions list

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Details/index.jsx
@@ -375,7 +375,6 @@ class DetailsLegacy extends React.Component {
             if (user != null) {
                 this.setState({ open: user.isSideBarOpen });
                 const restApi = new Api();
-                existingSubscriptions = restApi.getSubscriptions(this.api_uuid, null);
                 const subscriptionLimit = app.subscribeApplicationLimit || 5000;
                 existingSubscriptions = restApi.getSubscriptions(this.api_uuid, null, subscriptionLimit);
                 promisedApplications = restApi.getAllApplications(null, subscriptionLimit);

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
@@ -167,6 +167,9 @@ const SubscriptionSection = ({
     onAddClick,
     handleSubscriptionDelete,
     handleSubscriptionUpdate,
+    getAPIById,
+    getMCPServerById,
+    getSubscriptionPolicyByName,
     noSubscriptionsMessage,
     noSubscriptionsContent,
     entityNameColumn,
@@ -261,6 +264,9 @@ const SubscriptionSection = ({
                                                                 subscription={subscription}
                                                                 handleSubscriptionDelete={handleSubscriptionDelete}
                                                                 handleSubscriptionUpdate={handleSubscriptionUpdate}
+                                                                getAPIById={getAPIById}
+                                                                getMCPServerById={getMCPServerById}
+                                                                getSubscriptionPolicyByName={getSubscriptionPolicyByName}
                                                             />
                                                         );
                                                     })}
@@ -285,6 +291,9 @@ SubscriptionSection.propTypes = {
     onAddClick: PropTypes.func.isRequired,
     handleSubscriptionDelete: PropTypes.func.isRequired,
     handleSubscriptionUpdate: PropTypes.func.isRequired,
+    getAPIById: PropTypes.func.isRequired,
+    getMCPServerById: PropTypes.func.isRequired,
+    getSubscriptionPolicyByName: PropTypes.func.isRequired,
     noSubscriptionsMessage: PropTypes.node.isRequired,
     noSubscriptionsContent: PropTypes.node.isRequired,
     entityNameColumn: PropTypes.node.isRequired,

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
@@ -24,6 +24,7 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TablePagination from '@mui/material/TablePagination';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import Icon from '@mui/material/Icon';
@@ -44,6 +45,7 @@ const classes = {
     genericMessageWrapper: `${PREFIX}-genericMessageWrapper`,
     subsTable: `${PREFIX}-subsTable`,
     sectionContainer: `${PREFIX}-sectionContainer`,
+    pagination: `${PREFIX}-pagination`,
 };
 
 const Root = styled('div')((
@@ -151,6 +153,19 @@ const Root = styled('div')((
         tableLayout: 'fixed',
         width: '100%',
     },
+
+    [`& .${classes.pagination}`]: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        borderTop: `1px solid ${theme.palette.divider}`,
+        '& .MuiTablePagination-toolbar': {
+            minHeight: 48,
+            paddingRight: 0,
+        },
+        '& .MuiTablePagination-displayedRows': {
+            margin: 0,
+        },
+    },
 }));
 
 /**
@@ -170,6 +185,10 @@ const SubscriptionSection = ({
     getAPIById,
     getMCPServerById,
     getSubscriptionPolicyByName,
+    paginationCount,
+    paginationPage,
+    rowsPerPage,
+    onPaginationPageChange,
     noSubscriptionsMessage,
     noSubscriptionsContent,
     entityNameColumn,
@@ -223,55 +242,66 @@ const SubscriptionSection = ({
                                     {subscriptionsNotFound ? (
                                         <ResourceNotFound />
                                     ) : (
-                                        <Table className={classes.subsTable}>
-                                            <TableHead>
-                                                <TableRow>
-                                                    <TableCell className={classes.firstCell}>
-                                                        {entityNameColumn}
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <FormattedMessage
-                                                            id='Applications.Details.Subscriptions.subscription.state'
-                                                            defaultMessage='Lifecycle State'
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <FormattedMessage
-                                                            id='Applications.Details.Subscriptions.business.plan'
-                                                            defaultMessage='Business Plan'
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <FormattedMessage
-                                                            id='Applications.Details.Subscriptions.Status'
-                                                            defaultMessage='Subscription Status'
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <FormattedMessage
-                                                            id='Applications.Details.Subscriptions.action'
-                                                            defaultMessage='Action'
-                                                        />
-                                                    </TableCell>
-                                                </TableRow>
-                                            </TableHead>
-                                            <TableBody>
-                                                {subscriptions
-                                                    && subscriptions.map((subscription) => {
-                                                        return (
-                                                            <SubscriptionTableData
-                                                                key={subscription.subscriptionId}
-                                                                subscription={subscription}
-                                                                handleSubscriptionDelete={handleSubscriptionDelete}
-                                                                handleSubscriptionUpdate={handleSubscriptionUpdate}
-                                                                getAPIById={getAPIById}
-                                                                getMCPServerById={getMCPServerById}
-                                                                getSubscriptionPolicyByName={getSubscriptionPolicyByName}
+                                        <>
+                                            <Table className={classes.subsTable}>
+                                                <TableHead>
+                                                    <TableRow>
+                                                        <TableCell className={classes.firstCell}>
+                                                            {entityNameColumn}
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <FormattedMessage
+                                                                id='Applications.Details.Subscriptions.subscription.state'
+                                                                defaultMessage='Lifecycle State'
                                                             />
-                                                        );
-                                                    })}
-                                            </TableBody>
-                                        </Table>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <FormattedMessage
+                                                                id='Applications.Details.Subscriptions.business.plan'
+                                                                defaultMessage='Business Plan'
+                                                            />
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <FormattedMessage
+                                                                id='Applications.Details.Subscriptions.Status'
+                                                                defaultMessage='Subscription Status'
+                                                            />
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <FormattedMessage
+                                                                id='Applications.Details.Subscriptions.action'
+                                                                defaultMessage='Action'
+                                                            />
+                                                        </TableCell>
+                                                    </TableRow>
+                                                </TableHead>
+                                                <TableBody>
+                                                    {subscriptions
+                                                        && subscriptions.map((subscription) => {
+                                                            return (
+                                                                <SubscriptionTableData
+                                                                    key={subscription.subscriptionId}
+                                                                    subscription={subscription}
+                                                                    handleSubscriptionDelete={handleSubscriptionDelete}
+                                                                    handleSubscriptionUpdate={handleSubscriptionUpdate}
+                                                                    getAPIById={getAPIById}
+                                                                    getMCPServerById={getMCPServerById}
+                                                                    getSubscriptionPolicyByName={getSubscriptionPolicyByName}
+                                                                />
+                                                            );
+                                                        })}
+                                                </TableBody>
+                                            </Table>
+                                            <TablePagination
+                                                className={classes.pagination}
+                                                component='div'
+                                                count={paginationCount}
+                                                page={paginationPage}
+                                                rowsPerPage={rowsPerPage}
+                                                rowsPerPageOptions={[]}
+                                                onPageChange={onPaginationPageChange}
+                                            />
+                                        </>
                                     )}
                                 </Box>
                             )}
@@ -294,6 +324,10 @@ SubscriptionSection.propTypes = {
     getAPIById: PropTypes.func.isRequired,
     getMCPServerById: PropTypes.func.isRequired,
     getSubscriptionPolicyByName: PropTypes.func.isRequired,
+    paginationCount: PropTypes.number.isRequired,
+    paginationPage: PropTypes.number.isRequired,
+    rowsPerPage: PropTypes.number.isRequired,
+    onPaginationPageChange: PropTypes.func.isRequired,
     noSubscriptionsMessage: PropTypes.node.isRequired,
     noSubscriptionsContent: PropTypes.node.isRequired,
     entityNameColumn: PropTypes.node.isRequired,

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -37,7 +37,6 @@ import { FormattedMessage } from 'react-intl';
 import { ScopeValidation, resourceMethods, resourcePaths } from 'AppComponents/Shared/ScopeValidation';
 import PropTypes from 'prop-types';
 import CONSTANTS from 'AppData/Constants';
-import Subscription from 'AppData/Subscription';
 import { getBasePath } from 'AppUtils/utils';
 import { mdiOpenInNew } from '@mdi/js';
 import { Icon as MDIcon } from '@mdi/react';
@@ -103,7 +102,7 @@ class SubscriptionTableData extends React.Component {
         this.mounted = true;
         this.checkIfWebhookAPI();
         this.populateAPIData(subscription.apiId);
-        this.checkIfDynamicUsagePolicy(subscription.subscriptionId);
+        this.checkIfDynamicUsagePolicy(subscription.throttlingPolicy);
     }
 
     componentWillUnmount() {
@@ -208,26 +207,19 @@ class SubscriptionTableData extends React.Component {
 
     /**
      * Check if the policy is dynamic usage type
-     * @param {string} subscriptionUUID subscription UUID
+     * @param {string} throttlingPolicy throttling policy name, already available on the subscription
      */
-    checkIfDynamicUsagePolicy(subscriptionUUID) {
-        const client = new Subscription();
-        const promisedSubscription = client.getSubscription(subscriptionUUID);
-        promisedSubscription.then((response) => {
-            if (this.mounted && response && response.body) {
-                const subscriptionData = JSON.parse(response.data);
-                if (subscriptionData.throttlingPolicy) {
-                    const { getSubscriptionPolicyByName } = this.props;
-                    const promisedPolicy = getSubscriptionPolicyByName(subscriptionData.throttlingPolicy);
-                    promisedPolicy.then((policyData) => {
-                        if (this.mounted
-                            && policyData
-                            && policyData.monetizationAttributes
-                            && policyData.monetizationAttributes.billingType === 'DYNAMICRATE') {
-                            this.setState({ isDynamicUsagePolicy: true });
-                        }
-                    });
-                }
+    checkIfDynamicUsagePolicy(throttlingPolicy) {
+        if (!throttlingPolicy) {
+            return;
+        }
+        const { getSubscriptionPolicyByName } = this.props;
+        getSubscriptionPolicyByName(throttlingPolicy).then((policyData) => {
+            if (this.mounted
+                && policyData
+                && policyData.monetizationAttributes
+                && policyData.monetizationAttributes.billingType === 'DYNAMICRATE') {
+                this.setState({ isDynamicUsagePolicy: true });
             }
         });
     }

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -36,8 +36,6 @@ import HelpOutline from '@mui/icons-material/HelpOutline';
 import { FormattedMessage } from 'react-intl';
 import { ScopeValidation, resourceMethods, resourcePaths } from 'AppComponents/Shared/ScopeValidation';
 import PropTypes from 'prop-types';
-import Api from 'AppData/api';
-import MCPServer from 'AppData/MCPServer';
 import CONSTANTS from 'AppData/Constants';
 import Subscription from 'AppData/Subscription';
 import { getBasePath } from 'AppUtils/utils';
@@ -85,8 +83,7 @@ class SubscriptionTableData extends React.Component {
         this.handleRequestOpen = this.handleRequestOpen.bind(this);
         this.handleRequestDelete = this.handleRequestDelete.bind(this);
         this.checkIfDynamicUsagePolicy = this.checkIfDynamicUsagePolicy.bind(this);
-        this.checkIfMonetizedAPI = this.checkIfMonetizedAPI.bind(this);
-        this.populateSubscriptionTiers = this.populateSubscriptionTiers.bind(this);
+        this.populateAPIData = this.populateAPIData.bind(this);
         this.handleSubscriptionTierUpdate = this.handleSubscriptionTierUpdate.bind(this);
         this.handleRequestCloseEditMenu = this.handleRequestCloseEditMenu.bind(this);
         this.handleRequestOpenEditMenu = this.handleRequestOpenEditMenu.bind(this);
@@ -103,10 +100,14 @@ class SubscriptionTableData extends React.Component {
      */
     componentDidMount() {
         const { subscription } = this.props;
+        this.mounted = true;
         this.checkIfWebhookAPI();
-        this.checkIfMonetizedAPI(subscription.apiId);
+        this.populateAPIData(subscription.apiId);
         this.checkIfDynamicUsagePolicy(subscription.subscriptionId);
-        this.populateSubscriptionTiers(subscription.apiId);
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
     }
 
     /**
@@ -182,49 +183,25 @@ class SubscriptionTableData extends React.Component {
     }
 
     /**
-     * Getting the policies from api details
-     * @param {string} apiUUID API UUID
+     * Fetch the tiers and monetization status of the subscribed API/MCP Server in a single call.
+     * @param {string} apiUUID API/MCP Server UUID
      */
-    populateSubscriptionTiers(apiUUID) {
-        let promisedApi;
-        const { subscription } = this.props;
+    populateAPIData(apiUUID) {
+        const { subscription, getAPIById, getMCPServerById } = this.props;
         const isMCPServer = subscription.apiInfo.type === 'MCP';
-        if (isMCPServer) {
-            promisedApi = new MCPServer().getMCPServerById(apiUUID);
-        } else {
-            promisedApi = new Api().getAPIById(apiUUID);
-        }
-        promisedApi.then((response) => {
-            if (response && response.data) {
-                const api = JSON.parse(response.data);
-                const apiTiers = api.tiers;
+        const promisedApi = isMCPServer ? getMCPServerById(apiUUID) : getAPIById(apiUUID);
+        promisedApi.then((api) => {
+            if (this.mounted && api) {
+                const apiTiers = api.tiers || [];
                 const tiers = [];
                 for (let i = 0; i < apiTiers.length; i++) {
                     const { tierName } = apiTiers[i];
                     tiers.push({ value: tierName, label: tierName });
                 }
-                this.setState({ tiers });
-            }
-        });
-    }
-
-    /**
-     * Check if the API is monetized
-     * @param {string} apiUUID API UUID
-     */
-    checkIfMonetizedAPI(apiUUID) {
-        let promisedApi;
-        const { subscription } = this.props;
-        const isMCPServer = subscription.apiInfo.type === 'MCP';
-        if (isMCPServer) {
-            promisedApi = new MCPServer().getMCPServerById(apiUUID);
-        } else {
-            promisedApi = new Api().getAPIById(apiUUID);
-        }
-        promisedApi.then((response) => {
-            if (response && response.data) {
-                const apiData = JSON.parse(response.data);
-                this.setState({ isMonetizedAPI: apiData.monetization.enabled });
+                this.setState({
+                    tiers,
+                    isMonetizedAPI: api.monetization && api.monetization.enabled,
+                });
             }
         });
     }
@@ -237,16 +214,16 @@ class SubscriptionTableData extends React.Component {
         const client = new Subscription();
         const promisedSubscription = client.getSubscription(subscriptionUUID);
         promisedSubscription.then((response) => {
-            if (response && response.body) {
+            if (this.mounted && response && response.body) {
                 const subscriptionData = JSON.parse(response.data);
                 if (subscriptionData.throttlingPolicy) {
-                    const apiClient = new Api();
-                    const promisedPolicy = apiClient.getTierByName(subscriptionData.throttlingPolicy, 'subscription');
-                    promisedPolicy.then((policyResponse) => {
-                        const policyData = JSON.parse(policyResponse.data);
-                        if (policyData.monetizationAttributes.billingType
-                            && (policyData.monetizationAttributes.billingType
-                                === 'DYNAMICRATE')) {
+                    const { getSubscriptionPolicyByName } = this.props;
+                    const promisedPolicy = getSubscriptionPolicyByName(subscriptionData.throttlingPolicy);
+                    promisedPolicy.then((policyData) => {
+                        if (this.mounted
+                            && policyData
+                            && policyData.monetizationAttributes
+                            && policyData.monetizationAttributes.billingType === 'DYNAMICRATE') {
                             this.setState({ isDynamicUsagePolicy: true });
                         }
                     });
@@ -619,5 +596,8 @@ SubscriptionTableData.propTypes = {
     }).isRequired,
     handleSubscriptionDelete: PropTypes.func.isRequired,
     handleSubscriptionUpdate: PropTypes.func.isRequired,
+    getAPIById: PropTypes.func.isRequired,
+    getMCPServerById: PropTypes.func.isRequired,
+    getSubscriptionPolicyByName: PropTypes.func.isRequired,
 };
 export default SubscriptionTableData;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -29,6 +29,7 @@ import Paper from '@mui/material/Paper';
 import InputBase from '@mui/material/InputBase';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import SearchIcon from '@mui/icons-material/Search';
+import TablePagination from '@mui/material/TablePagination';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Progress from 'AppComponents/Shared/Progress';
 import Alert from 'AppComponents/Shared/Alert';
@@ -36,11 +37,40 @@ import APIList from 'AppComponents/Apis/Listing/APICardView';
 import CONSTANTS from 'AppData/Constants';
 import Subscription from 'AppData/Subscription';
 import Api from 'AppData/api';
+import MCPServer from 'AppData/MCPServer';
 import { app } from 'Settings';
 import { useAreApisAccessible, useAreMcpServersAccessible } from 'AppUtils/PortalModeUtils';
 import SubscriptionSection from './SubscriptionSection';
 
 const PREFIX = 'Subscriptions';
+const SUBSCRIPTIONS_PER_PAGE = 10;
+
+/**
+ * Parse a swagger-client response body, handling both string and pre-parsed payloads.
+ * @param {*} response swagger-client response
+ * @returns {*} parsed response data
+ */
+function parseResponseData(response) {
+    if (response && response.data) {
+        return typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
+    }
+    if (response && response.body) {
+        return typeof response.body === 'string' ? JSON.parse(response.body) : response.body;
+    }
+    return null;
+}
+
+/**
+ * A subscription is "pseudo" when it was auto-created under the default subscriptionless plan.
+ * @param {*} subscription subscription object
+ * @returns {boolean} true if the subscription is a pseudo subscription
+ */
+function isPseudoSubscription(subscription) {
+    const throttlingPolicies = subscription.apiInfo && subscription.apiInfo.throttlingPolicies;
+    return Boolean(throttlingPolicies
+        && throttlingPolicies.length === 1
+        && throttlingPolicies[0].includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN));
+}
 
 const classes = {
     searchRoot: `${PREFIX}-searchRoot`,
@@ -60,6 +90,7 @@ const classes = {
     searchResults: `${PREFIX}-searchResults`,
     clearSearchIcon: `${PREFIX}-clearSearchIcon`,
     subsTable: `${PREFIX}-subsTable`,
+    pagination: `${PREFIX}-pagination`,
     closeButton: `${PREFIX}-closeButton`,
 };
 
@@ -128,6 +159,19 @@ const Root = styled('div')((
             '&:last-child': {
                 borderRight: 'none',
             },
+        },
+    },
+
+    [`& .${classes.pagination}`]: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        borderTop: `1px solid ${theme.palette.divider}`,
+        '& .MuiTablePagination-toolbar': {
+            minHeight: 48,
+            paddingRight: 0,
+        },
+        '& .MuiTablePagination-displayedRows': {
+            margin: 0,
         },
     },
 
@@ -224,8 +268,13 @@ class SubscriptionsBase extends React.Component {
             searchText: '',
             pseudoSubscriptions: false,
             pseudoMcpSubscriptions: false,
+            subscriptionCount: 0,
+            subscriptionOffset: 0,
+            dialogSubscriptions: null,
+            dialogMcpSubscriptions: null,
         };
         this.checkSubValidationDisabled = this.checkSubValidationDisabled.bind(this);
+        this.checkMcpSubValidationDisabled = this.checkMcpSubValidationDisabled.bind(this);
         this.handleSubscriptionDelete = this.handleSubscriptionDelete.bind(this);
         this.handleSubscriptionUpdate = this.handleSubscriptionUpdate.bind(this);
         this.updateSubscriptions = this.updateSubscriptions.bind(this);
@@ -236,7 +285,23 @@ class SubscriptionsBase extends React.Component {
         this.handleSearchTextTmpChange = this.handleSearchTextTmpChange.bind(this);
         this.handleClearSearch = this.handleClearSearch.bind(this);
         this.handleEnterPress = this.handleEnterPress.bind(this);
+        this.handleSubscriptionPageChange = this.handleSubscriptionPageChange.bind(this);
+        this.updateDialogSubscriptions = this.updateDialogSubscriptions.bind(this);
+        this.getAPIById = this.getAPIById.bind(this);
+        this.getMCPServerById = this.getMCPServerById.bind(this);
+        this.getSubscriptionPolicyByName = this.getSubscriptionPolicyByName.bind(this);
+        this.getFullSubscriptions = this.getFullSubscriptions.bind(this);
+        this.resetAPIDetailsCache = this.resetAPIDetailsCache.bind(this);
+        this.loadAllSubscriptions = this.loadAllSubscriptions.bind(this);
+        this.apiDetailsById = {};
+        this.mcpDetailsById = {};
+        this.subscriptionPoliciesByName = {};
+        this.fullSubscriptionsPromise = null;
         this.searchTextTmp = '';
+        this.mounted = false;
+        this.subscriptionsRequestId = 0;
+        this.dialogLoadRequestId = 0;
+        this.mcpDialogLoadRequestId = 0;
     }
 
     /**
@@ -245,75 +310,209 @@ class SubscriptionsBase extends React.Component {
      * @memberof Subscriptions
      */
     componentDidMount() {
+        this.mounted = true;
         const { applicationId } = this.props.application;
         this.updateSubscriptions(applicationId);
     }
 
+    componentWillUnmount() {
+        this.mounted = false;
+        this.subscriptionsRequestId += 1;
+        this.dialogLoadRequestId += 1;
+        this.mcpDialogLoadRequestId += 1;
+    }
+
     handleOpenDialog() {
-        this.setState((prevState) => ({ openDialog: !prevState.openDialog, searchText: '' }));
+        const { applicationId } = this.props.application;
+        this.searchTextTmp = '';
+        this.dialogLoadRequestId += 1;
+        this.setState((prevState) => ({
+            openDialog: !prevState.openDialog,
+            searchText: '',
+            dialogSubscriptions: null,
+        }), () => {
+            if (this.state.openDialog) {
+                this.updateDialogSubscriptions(applicationId, false);
+            }
+        });
     }
 
     handleOpenMcpDialog() {
-        this.setState((prevState) => ({ openMcpDialog: !prevState.openMcpDialog, searchText: '' }));
+        const { applicationId } = this.props.application;
+        this.searchTextTmp = '';
+        this.mcpDialogLoadRequestId += 1;
+        this.setState((prevState) => ({
+            openMcpDialog: !prevState.openMcpDialog,
+            searchText: '',
+            dialogMcpSubscriptions: null,
+        }), () => {
+            if (this.state.openMcpDialog) {
+                this.updateDialogSubscriptions(applicationId, true);
+            }
+        });
+    }
+
+    /**
+     * Cache API/MCP Server and subscription-policy detail fetches so re-rendering a page
+     * of subscriptions doesn't refetch data for entities already looked up this session.
+     */
+    resetAPIDetailsCache() {
+        this.apiDetailsById = {};
+        this.mcpDetailsById = {};
+        this.subscriptionPoliciesByName = {};
+    }
+
+    getAPIById(apiUUID) {
+        if (!this.apiDetailsById[apiUUID]) {
+            const apiClient = new Api();
+            this.apiDetailsById[apiUUID] = apiClient.getAPIById(apiUUID).then(parseResponseData);
+        }
+        return this.apiDetailsById[apiUUID];
+    }
+
+    getMCPServerById(apiUUID) {
+        if (!this.mcpDetailsById[apiUUID]) {
+            const mcpClient = new MCPServer();
+            this.mcpDetailsById[apiUUID] = mcpClient.getMCPServerById(apiUUID).then(parseResponseData);
+        }
+        return this.mcpDetailsById[apiUUID];
+    }
+
+    getSubscriptionPolicyByName(policyName) {
+        if (!this.subscriptionPoliciesByName[policyName]) {
+            const apiClient = new Api();
+            this.subscriptionPoliciesByName[policyName] = apiClient
+                .getTierByName(policyName, 'subscription')
+                .then(parseResponseData);
+        }
+        return this.subscriptionPoliciesByName[policyName];
+    }
+
+    /**
+     * Load every subscription for the application, used when the current page alone
+     * isn't enough to answer a question (pseudo-subscription check, subscribe dialogs).
+     * @param {*} applicationId application id
+     * @param {number} offset subscription list offset
+     * @param {Array} accumulatedSubscriptions subscriptions collected from previous chunks
+     * @returns {Promise<Array>} the full subscription list
+     */
+    loadAllSubscriptions(applicationId, offset = 0, accumulatedSubscriptions = []) {
+        const client = new Subscription();
+        const subscriptionLimit = app.subscriptionLimit || 1000;
+        return client.getSubscriptions(null, applicationId, subscriptionLimit, offset)
+            .then((response) => {
+                const { body } = response;
+                const pagination = body.pagination || {};
+                const subscriptionList = body.list || [];
+                const subscriptions = accumulatedSubscriptions.concat(subscriptionList);
+                const total = pagination.total || subscriptions.length;
+                const limit = pagination.limit || subscriptionLimit;
+                const currentOffset = pagination.offset || offset;
+                const nextOffset = currentOffset + limit;
+
+                if (subscriptions.length < total && subscriptionList.length > 0) {
+                    return this.loadAllSubscriptions(applicationId, nextOffset, subscriptions);
+                }
+                return subscriptions;
+            });
+    }
+
+    /**
+     * Fetch (and cache for this subscription state) the complete, unpaginated subscription list.
+     * @param {*} applicationId application id
+     * @returns {Promise<Array>} the full subscription list
+     */
+    getFullSubscriptions(applicationId) {
+        if (!this.fullSubscriptionsPromise) {
+            this.fullSubscriptionsPromise = this.loadAllSubscriptions(applicationId);
+        }
+        return this.fullSubscriptionsPromise;
+    }
+
+    /**
+     * Shared implementation backing checkSubValidationDisabled / checkMcpSubValidationDisabled.
+     * The current page's subset of a given type may not represent every subscription of that
+     * type, so when the page subset looks fully pseudo, the full list is loaded to confirm.
+     * @param {*} subList current page's subscriptions of one type (API or MCP)
+     * @param {*} applicationId application id
+     * @param {*} requestId current subscriptions request id
+     * @param {*} options.stateKey state field to update
+     * @param {*} options.filterFn predicate selecting subscriptions of this type from a full list
+     */
+    checkTypeValidationDisabled(subList, applicationId, requestId, { stateKey, filterFn }) {
+        if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+            return;
+        }
+        if (!subList || subList.length === 0 || !subList.every(isPseudoSubscription)) {
+            this.setState({ [stateKey]: false });
+            return;
+        }
+        this.getFullSubscriptions(applicationId)
+            .then((allSubscriptions) => {
+                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                    return;
+                }
+                const fullTypeList = allSubscriptions.filter(filterFn);
+                this.setState({
+                    [stateKey]: fullTypeList.length > 0 && fullTypeList.every(isPseudoSubscription),
+                });
+            })
+            .catch(() => {
+                if (this.mounted && requestId === this.subscriptionsRequestId) {
+                    this.setState({ [stateKey]: false });
+                }
+            });
     }
 
     /**
      *
      * Check if the subscription validation is disabled
      * @param {*} subList Subscriptions list reponse object
-     * @returns
+     * @param {*} applicationId application id
+     * @param {*} requestId current subscriptions request id
      */
-    checkSubValidationDisabled(subList) {
-        if (subList !== null && subList.length > 0) {
-            const pseudoList = subList.filter((sub) => (sub.apiInfo.throttlingPolicies
-                && sub.apiInfo.throttlingPolicies.length === 1
-                && sub.apiInfo.throttlingPolicies[0].includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN)));
-            if (pseudoList.length === subList.length) {
-                this.setState({ pseudoSubscriptions: true });
-            } else {
-                this.setState({ pseudoSubscriptions: false });
-            }
-            return;
-        }
-        this.setState({ pseudoSubscriptions: false });
+    checkSubValidationDisabled(subList, applicationId, requestId) {
+        this.checkTypeValidationDisabled(subList, applicationId, requestId, {
+            stateKey: 'pseudoSubscriptions',
+            filterFn: (sub) => sub.apiInfo && sub.apiInfo.type !== 'MCP',
+        });
     }
 
     /**
      *
      * Check if the MCP subscription validation is disabled
      * @param {*} subList MCP Subscriptions list response object
-     * @returns
+     * @param {*} applicationId application id
+     * @param {*} requestId current subscriptions request id
      */
-    checkMcpSubValidationDisabled(subList) {
-        if (subList !== null && subList.length > 0) {
-            const pseudoList = subList.filter((sub) => (sub.apiInfo.throttlingPolicies
-                && sub.apiInfo.throttlingPolicies.length === 1
-                && sub.apiInfo.throttlingPolicies[0].includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN)));
-            if (pseudoList.length === subList.length) {
-                this.setState({ pseudoMcpSubscriptions: true });
-            } else {
-                this.setState({ pseudoMcpSubscriptions: false });
-            }
-            return;
-        }
-        this.setState({ pseudoMcpSubscriptions: false });
+    checkMcpSubValidationDisabled(subList, applicationId, requestId) {
+        this.checkTypeValidationDisabled(subList, applicationId, requestId, {
+            stateKey: 'pseudoMcpSubscriptions',
+            filterFn: (sub) => sub.apiInfo && sub.apiInfo.type === 'MCP',
+        });
     }
 
     /**
      *
      * Update subscriptions list of Application
      * @param {*} applicationId application id
+     * @param {number} offset subscription list offset
      * @memberof Subscriptions
      */
-    updateSubscriptions(applicationId) {
+    updateSubscriptions(applicationId, offset = 0) {
+        const requestId = ++this.subscriptionsRequestId;
+        this.resetAPIDetailsCache();
+        this.fullSubscriptionsPromise = null;
         const client = new Subscription();
-        const subscriptionLimit = app.subscriptionLimit || 1000;
-        const promisedSubscriptions = client.getSubscriptions(null, applicationId, subscriptionLimit);
+        const promisedSubscriptions = client.getSubscriptions(null, applicationId, SUBSCRIPTIONS_PER_PAGE, offset);
         promisedSubscriptions
             .then((response) => {
-                const allSubscriptions = response.body.list;
-                // Separate API and MCP subscriptions based on some criteria
-                // For now, assuming all are API subscriptions - you may need to modify this logic
+                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                    return;
+                }
+                const { body } = response;
+                const allSubscriptions = body.list || [];
+                const pagination = body.pagination || {};
                 const apiSubscriptions = allSubscriptions.filter((sub) => sub.apiInfo && sub.apiInfo.type !== 'MCP');
                 const mcpSubscriptions = allSubscriptions.filter((sub) => sub.apiInfo && sub.apiInfo.type === 'MCP');
 
@@ -321,11 +520,16 @@ class SubscriptionsBase extends React.Component {
                     subscriptions: allSubscriptions,
                     apiSubscriptions,
                     mcpSubscriptions,
+                    subscriptionCount: pagination.total ?? allSubscriptions.length,
+                    subscriptionOffset: pagination.offset ?? offset,
                 });
-                this.checkSubValidationDisabled(apiSubscriptions);
-                this.checkMcpSubValidationDisabled(mcpSubscriptions);
+                this.checkSubValidationDisabled(apiSubscriptions, applicationId, requestId);
+                this.checkMcpSubValidationDisabled(mcpSubscriptions, applicationId, requestId);
             })
             .catch((error) => {
+                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                    return;
+                }
                 const { status } = error;
                 if (status === 404) {
                     this.setState({ subscriptionsNotFound: true });
@@ -333,6 +537,52 @@ class SubscriptionsBase extends React.Component {
                     this.setState({ isAuthorize: false });
                 }
             });
+    }
+
+    /**
+     * Update the full, unpaginated list backing a subscribe dialog (API or MCP).
+     * @param {*} applicationId application id
+     * @param {boolean} isMcp whether this is refreshing the MCP Server dialog
+     * @returns {Promise<void>}
+     * @memberof Subscriptions
+     */
+    updateDialogSubscriptions(applicationId, isMcp) {
+        const requestId = isMcp ? ++this.mcpDialogLoadRequestId : ++this.dialogLoadRequestId;
+        return this.getFullSubscriptions(applicationId)
+            .then((allSubscriptions) => {
+                const currentRequestId = isMcp ? this.mcpDialogLoadRequestId : this.dialogLoadRequestId;
+                const dialogOpen = isMcp ? this.state.openMcpDialog : this.state.openDialog;
+                if (!this.mounted || requestId !== currentRequestId
+                    || !dialogOpen || this.props.application.applicationId !== applicationId) {
+                    return;
+                }
+                const filtered = allSubscriptions.filter((sub) => (
+                    isMcp ? sub.apiInfo && sub.apiInfo.type === 'MCP' : sub.apiInfo && sub.apiInfo.type !== 'MCP'
+                ));
+                this.setState(isMcp ? { dialogMcpSubscriptions: filtered } : { dialogSubscriptions: filtered });
+            })
+            .catch((error) => {
+                const currentRequestId = isMcp ? this.mcpDialogLoadRequestId : this.dialogLoadRequestId;
+                if (!this.mounted || requestId !== currentRequestId) {
+                    return;
+                }
+                const { status } = error;
+                if (status === 401) {
+                    this.setState({ isAuthorize: false });
+                } else {
+                    this.setState(isMcp ? { dialogMcpSubscriptions: [] } : { dialogSubscriptions: [] });
+                }
+            });
+    }
+
+    /**
+     * Handle a page change on the shared subscriptions table pagination control.
+     * @param {*} event unused MUI event
+     * @param {number} page requested page
+     */
+    handleSubscriptionPageChange(event, page) {
+        const { applicationId } = this.props.application;
+        this.updateSubscriptions(applicationId, page * SUBSCRIPTIONS_PER_PAGE);
     }
 
     /**
@@ -372,27 +622,12 @@ class SubscriptionsBase extends React.Component {
                     }));
                     return;
                 }
-                const { subscriptions, apiSubscriptions, mcpSubscriptions } = this.state;
-
-                // Remove from main subscriptions array
-                const updatedSubscriptions = subscriptions.filter((sub) => sub.subscriptionId !== subscriptionId);
-
-                // Remove from API subscriptions array
-                const updatedApiSubscriptions = apiSubscriptions
-                    ? apiSubscriptions.filter((sub) => sub.subscriptionId !== subscriptionId) : [];
-
-                // Remove from MCP subscriptions array
-                const updatedMcpSubscriptions = mcpSubscriptions
-                    ? mcpSubscriptions.filter((sub) => sub.subscriptionId !== subscriptionId) : [];
-
-                this.setState({
-                    subscriptions: updatedSubscriptions,
-                    apiSubscriptions: updatedApiSubscriptions,
-                    mcpSubscriptions: updatedMcpSubscriptions,
-                });
-
-                this.checkSubValidationDisabled(updatedApiSubscriptions);
-                this.checkMcpSubValidationDisabled(updatedMcpSubscriptions);
+                const { subscriptions, subscriptionOffset } = this.state;
+                const nextOffset = subscriptions.length === 1 && subscriptionOffset > 0
+                    ? subscriptionOffset - SUBSCRIPTIONS_PER_PAGE
+                    : subscriptionOffset;
+                const { applicationId } = this.props.application;
+                this.updateSubscriptions(applicationId, nextOffset);
                 this.props.getApplication();
             })
             .catch((error) => {
@@ -452,7 +687,8 @@ class SubscriptionsBase extends React.Component {
                         id: 'Applications.Details.Subscriptions.business.plan.updated',
                     }));
                 }
-                this.updateSubscriptions(applicationId);
+                const { subscriptionOffset } = this.state;
+                this.updateSubscriptions(applicationId, subscriptionOffset);
                 this.props.getApplication();
             })
             .catch((error) => {
@@ -512,7 +748,14 @@ class SubscriptionsBase extends React.Component {
                             defaultMessage: 'Subscription successful',
                         }));
                     }
-                    this.updateSubscriptions(applicationId);
+                    const { subscriptionOffset, openDialog, openMcpDialog } = this.state;
+                    this.updateSubscriptions(applicationId, subscriptionOffset);
+                    if (openDialog) {
+                        this.updateDialogSubscriptions(applicationId, false);
+                    }
+                    if (openMcpDialog) {
+                        this.updateDialogSubscriptions(applicationId, true);
+                    }
                     this.props.getApplication();
                 }
             })
@@ -569,6 +812,10 @@ class SubscriptionsBase extends React.Component {
             subscriptionsNotFound,
             pseudoSubscriptions,
             pseudoMcpSubscriptions,
+            subscriptionCount,
+            subscriptionOffset,
+            dialogSubscriptions,
+            dialogMcpSubscriptions,
         } = this.state;
 
         if (!isAuthorize) {
@@ -617,6 +864,9 @@ class SubscriptionsBase extends React.Component {
                                 onAddClick={this.handleOpenDialog}
                                 handleSubscriptionDelete={this.handleSubscriptionDelete}
                                 handleSubscriptionUpdate={this.handleSubscriptionUpdate}
+                                getAPIById={this.getAPIById}
+                                getMCPServerById={this.getMCPServerById}
+                                getSubscriptionPolicyByName={this.getSubscriptionPolicyByName}
                                 noSubscriptionsMessage={(
                                     <FormattedMessage
                                         id='Applications.Details.Subscriptions.no.api.subscriptions'
@@ -659,6 +909,9 @@ class SubscriptionsBase extends React.Component {
                                 onAddClick={this.handleOpenMcpDialog}
                                 handleSubscriptionDelete={this.handleSubscriptionDelete}
                                 handleSubscriptionUpdate={this.handleSubscriptionUpdate}
+                                getAPIById={this.getAPIById}
+                                getMCPServerById={this.getMCPServerById}
+                                getSubscriptionPolicyByName={this.getSubscriptionPolicyByName}
                                 noSubscriptionsMessage={(
                                     <FormattedMessage
                                         id='Applications.Details.Subscriptions.no.mcp.subscriptions'
@@ -678,6 +931,18 @@ class SubscriptionsBase extends React.Component {
                                     />
                                 )}
                                 data-testid='mcp-subscriptions-section'
+                            />
+                        )}
+
+                        {(apisAccessible || mcpServersAccessible) && subscriptionCount > 0 && (
+                            <TablePagination
+                                className={classes.pagination}
+                                component='div'
+                                count={subscriptionCount}
+                                page={Math.floor(subscriptionOffset / SUBSCRIPTIONS_PER_PAGE)}
+                                rowsPerPage={SUBSCRIPTIONS_PER_PAGE}
+                                rowsPerPageOptions={[]}
+                                onPageChange={this.handleSubscriptionPageChange}
                             />
                         )}
 
@@ -765,14 +1030,18 @@ class SubscriptionsBase extends React.Component {
                                     </IconButton>
                                 </Box>
                                 <Box padding={2}>
-                                    <APIList
-                                        apisNotFound={apisNotFound}
-                                        subscriptions={apiSubscriptions || []}
-                                        applicationId={applicationId}
-                                        handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
-                                        searchText={searchText}
-                                        entityType='API'
-                                    />
+                                    {dialogSubscriptions ? (
+                                        <APIList
+                                            apisNotFound={apisNotFound}
+                                            subscriptions={dialogSubscriptions}
+                                            applicationId={applicationId}
+                                            handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
+                                            searchText={searchText}
+                                            entityType='API'
+                                        />
+                                    ) : (
+                                        <Progress />
+                                    )}
                                 </Box>
                             </StyledDialog>
                         )}
@@ -861,14 +1130,18 @@ class SubscriptionsBase extends React.Component {
                                     </IconButton>
                                 </Box>
                                 <Box padding={2}>
-                                    <APIList
-                                        apisNotFound={apisNotFound}
-                                        subscriptions={mcpSubscriptions || []}
-                                        applicationId={applicationId}
-                                        handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
-                                        searchText={searchText}
-                                        entityType='MCP'
-                                    />
+                                    {dialogMcpSubscriptions ? (
+                                        <APIList
+                                            apisNotFound={apisNotFound}
+                                            subscriptions={dialogMcpSubscriptions}
+                                            applicationId={applicationId}
+                                            handleSubscribe={(appInner, api, policy) => this.handleSubscribe(appInner, api, policy)}
+                                            searchText={searchText}
+                                            entityType='MCP'
+                                        />
+                                    ) : (
+                                        <Progress />
+                                    )}
                                 </Box>
                             </StyledDialog>
                         )}

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -42,6 +42,7 @@ import { useAreApisAccessible, useAreMcpServersAccessible } from 'AppUtils/Porta
 import SubscriptionSection from './SubscriptionSection';
 
 const PREFIX = 'Subscriptions';
+
 const SUBSCRIPTIONS_PER_PAGE = 10;
 // Backend page size used while walking the subscriptions list in the background. Bigger than
 // SUBSCRIPTIONS_PER_PAGE to reduce round-trips, far smaller than a bulk "fetch everything" call.
@@ -314,8 +315,11 @@ class SubscriptionsBase extends React.Component {
      */
     componentDidMount() {
         this.mounted = true;
-        this.ensureLoaded(SUBSCRIPTIONS_PER_PAGE, SUBSCRIPTIONS_PER_PAGE)
-            .then(() => this.refreshDerivedState());
+        const { apisAccessible, mcpServersAccessible } = this.props;
+        this.ensureLoaded(
+            apisAccessible ? SUBSCRIPTIONS_PER_PAGE : 0,
+            mcpServersAccessible ? SUBSCRIPTIONS_PER_PAGE : 0,
+        ).then(() => this.refreshDerivedState());
     }
 
     componentWillUnmount() {
@@ -364,7 +368,11 @@ class SubscriptionsBase extends React.Component {
     getAPIById(apiUUID) {
         if (!this.apiDetailsById[apiUUID]) {
             const apiClient = new Api();
-            this.apiDetailsById[apiUUID] = apiClient.getAPIById(apiUUID).then(parseResponseData);
+            this.apiDetailsById[apiUUID] = apiClient.getAPIById(apiUUID).then(parseResponseData)
+                .catch((error) => {
+                    delete this.apiDetailsById[apiUUID];
+                    throw error;
+                });
         }
         return this.apiDetailsById[apiUUID];
     }
@@ -372,7 +380,11 @@ class SubscriptionsBase extends React.Component {
     getMCPServerById(apiUUID) {
         if (!this.mcpDetailsById[apiUUID]) {
             const mcpClient = new MCPServer();
-            this.mcpDetailsById[apiUUID] = mcpClient.getMCPServerById(apiUUID).then(parseResponseData);
+            this.mcpDetailsById[apiUUID] = mcpClient.getMCPServerById(apiUUID).then(parseResponseData)
+                .catch((error) => {
+                    delete this.mcpDetailsById[apiUUID];
+                    throw error;
+                });
         }
         return this.mcpDetailsById[apiUUID];
     }
@@ -382,7 +394,11 @@ class SubscriptionsBase extends React.Component {
             const apiClient = new Api();
             this.subscriptionPoliciesByName[policyName] = apiClient
                 .getTierByName(policyName, 'subscription')
-                .then(parseResponseData);
+                .then(parseResponseData)
+                .catch((error) => {
+                    delete this.subscriptionPoliciesByName[policyName];
+                    throw error;
+                });
         }
         return this.subscriptionPoliciesByName[policyName];
     }
@@ -445,13 +461,27 @@ class SubscriptionsBase extends React.Component {
                     if (!this.mounted || requestId !== this.subscriptionsRequestId) {
                         return;
                     }
-                    this.fullyLoaded = true;
                     const { status } = error;
                     if (status === 404) {
+                        // The application itself wasn't found — a genuinely terminal state.
+                        this.fullyLoaded = true;
                         this.setState({ subscriptionsNotFound: true, subscriptionsLoaded: true });
-                    } else if (status === 401) {
-                        this.setState({ isAuthorize: false });
+                        return;
                     }
+                    if (status === 401) {
+                        this.fullyLoaded = true;
+                        this.setState({ isAuthorize: false });
+                        return;
+                    }
+                    // Transient failure (5xx/network) — do not mark the walk complete, so a later
+                    // ensureLoaded call (e.g. the user retrying pagination) resumes from this same
+                    // backendOffset instead of being permanently short-circuited.
+                    this.loadChain = null;
+                    this.setState({ subscriptionsLoaded: true });
+                    Alert.error(this.props.intl.formatMessage({
+                        id: 'Applications.Details.Subscriptions.error.loading.subscriptions',
+                        defaultMessage: 'Error occurred while loading subscriptions',
+                    }));
                 });
         };
 
@@ -557,8 +587,9 @@ class SubscriptionsBase extends React.Component {
         this.subscriptionsRequestId += 1;
         this.resetAccumulation();
         const { apiPage, mcpPage } = this.state;
-        const requiredApi = (apiPage + 1) * SUBSCRIPTIONS_PER_PAGE;
-        const requiredMcp = (mcpPage + 1) * SUBSCRIPTIONS_PER_PAGE;
+        const { apisAccessible, mcpServersAccessible } = this.props;
+        const requiredApi = apisAccessible ? (apiPage + 1) * SUBSCRIPTIONS_PER_PAGE : 0;
+        const requiredMcp = mcpServersAccessible ? (mcpPage + 1) * SUBSCRIPTIONS_PER_PAGE : 0;
         this.ensureLoaded(requiredApi, requiredMcp).then(() => this.refreshDerivedState());
     }
 

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -29,7 +29,6 @@ import Paper from '@mui/material/Paper';
 import InputBase from '@mui/material/InputBase';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import SearchIcon from '@mui/icons-material/Search';
-import TablePagination from '@mui/material/TablePagination';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Progress from 'AppComponents/Shared/Progress';
 import Alert from 'AppComponents/Shared/Alert';
@@ -44,6 +43,9 @@ import SubscriptionSection from './SubscriptionSection';
 
 const PREFIX = 'Subscriptions';
 const SUBSCRIPTIONS_PER_PAGE = 10;
+// Backend page size used while walking the subscriptions list in the background. Bigger than
+// SUBSCRIPTIONS_PER_PAGE to reduce round-trips, far smaller than a bulk "fetch everything" call.
+const FETCH_CHUNK_SIZE = 25;
 
 /**
  * Parse a swagger-client response body, handling both string and pre-parsed payloads.
@@ -72,6 +74,14 @@ function isPseudoSubscription(subscription) {
         && throttlingPolicies[0].includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN));
 }
 
+function isApiSubscription(subscription) {
+    return Boolean(subscription.apiInfo) && subscription.apiInfo.type !== 'MCP';
+}
+
+function isMcpSubscription(subscription) {
+    return Boolean(subscription.apiInfo) && subscription.apiInfo.type === 'MCP';
+}
+
 const classes = {
     searchRoot: `${PREFIX}-searchRoot`,
     searchBar: `${PREFIX}-searchBar`,
@@ -90,7 +100,6 @@ const classes = {
     searchResults: `${PREFIX}-searchResults`,
     clearSearchIcon: `${PREFIX}-clearSearchIcon`,
     subsTable: `${PREFIX}-subsTable`,
-    pagination: `${PREFIX}-pagination`,
     closeButton: `${PREFIX}-closeButton`,
 };
 
@@ -159,19 +168,6 @@ const Root = styled('div')((
             '&:last-child': {
                 borderRight: 'none',
             },
-        },
-    },
-
-    [`& .${classes.pagination}`]: {
-        display: 'flex',
-        justifyContent: 'flex-end',
-        borderTop: `1px solid ${theme.palette.divider}`,
-        '& .MuiTablePagination-toolbar': {
-            minHeight: 48,
-            paddingRight: 0,
-        },
-        '& .MuiTablePagination-displayedRows': {
-            margin: 0,
         },
     },
 
@@ -257,9 +253,13 @@ class SubscriptionsBase extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            subscriptions: null,
-            apiSubscriptions: null,
-            mcpSubscriptions: null,
+            subscriptionsLoaded: false,
+            apiSubscriptions: [],
+            mcpSubscriptions: [],
+            apiCount: -1,
+            mcpCount: -1,
+            apiPage: 0,
+            mcpPage: 0,
             apisNotFound: false,
             subscriptionsNotFound: false,
             isAuthorize: true,
@@ -268,16 +268,14 @@ class SubscriptionsBase extends React.Component {
             searchText: '',
             pseudoSubscriptions: false,
             pseudoMcpSubscriptions: false,
-            subscriptionCount: 0,
-            subscriptionOffset: 0,
             dialogSubscriptions: null,
             dialogMcpSubscriptions: null,
         };
         this.checkSubValidationDisabled = this.checkSubValidationDisabled.bind(this);
         this.checkMcpSubValidationDisabled = this.checkMcpSubValidationDisabled.bind(this);
+        this.checkTypeValidationDisabled = this.checkTypeValidationDisabled.bind(this);
         this.handleSubscriptionDelete = this.handleSubscriptionDelete.bind(this);
         this.handleSubscriptionUpdate = this.handleSubscriptionUpdate.bind(this);
-        this.updateSubscriptions = this.updateSubscriptions.bind(this);
         this.handleSubscribe = this.handleSubscribe.bind(this);
         this.handleOpenDialog = this.handleOpenDialog.bind(this);
         this.handleOpenMcpDialog = this.handleOpenMcpDialog.bind(this);
@@ -285,23 +283,28 @@ class SubscriptionsBase extends React.Component {
         this.handleSearchTextTmpChange = this.handleSearchTextTmpChange.bind(this);
         this.handleClearSearch = this.handleClearSearch.bind(this);
         this.handleEnterPress = this.handleEnterPress.bind(this);
-        this.handleSubscriptionPageChange = this.handleSubscriptionPageChange.bind(this);
+        this.handleApiPageChange = this.handleApiPageChange.bind(this);
+        this.handleMcpPageChange = this.handleMcpPageChange.bind(this);
         this.updateDialogSubscriptions = this.updateDialogSubscriptions.bind(this);
         this.getAPIById = this.getAPIById.bind(this);
         this.getMCPServerById = this.getMCPServerById.bind(this);
         this.getSubscriptionPolicyByName = this.getSubscriptionPolicyByName.bind(this);
-        this.getFullSubscriptions = this.getFullSubscriptions.bind(this);
         this.resetAPIDetailsCache = this.resetAPIDetailsCache.bind(this);
-        this.loadAllSubscriptions = this.loadAllSubscriptions.bind(this);
+        this.resetAccumulation = this.resetAccumulation.bind(this);
+        this.ensureLoaded = this.ensureLoaded.bind(this);
+        this.refreshDerivedState = this.refreshDerivedState.bind(this);
+        this.refetchAfterMutation = this.refetchAfterMutation.bind(this);
+
         this.apiDetailsById = {};
         this.mcpDetailsById = {};
         this.subscriptionPoliciesByName = {};
-        this.fullSubscriptionsPromise = null;
         this.searchTextTmp = '';
         this.mounted = false;
         this.subscriptionsRequestId = 0;
         this.dialogLoadRequestId = 0;
         this.mcpDialogLoadRequestId = 0;
+
+        this.resetAccumulation();
     }
 
     /**
@@ -311,8 +314,8 @@ class SubscriptionsBase extends React.Component {
      */
     componentDidMount() {
         this.mounted = true;
-        const { applicationId } = this.props.application;
-        this.updateSubscriptions(applicationId);
+        this.ensureLoaded(SUBSCRIPTIONS_PER_PAGE, SUBSCRIPTIONS_PER_PAGE)
+            .then(() => this.refreshDerivedState());
     }
 
     componentWillUnmount() {
@@ -323,31 +326,27 @@ class SubscriptionsBase extends React.Component {
     }
 
     handleOpenDialog() {
-        const { applicationId } = this.props.application;
         this.searchTextTmp = '';
-        this.dialogLoadRequestId += 1;
         this.setState((prevState) => ({
             openDialog: !prevState.openDialog,
             searchText: '',
             dialogSubscriptions: null,
         }), () => {
             if (this.state.openDialog) {
-                this.updateDialogSubscriptions(applicationId, false);
+                this.updateDialogSubscriptions(false);
             }
         });
     }
 
     handleOpenMcpDialog() {
-        const { applicationId } = this.props.application;
         this.searchTextTmp = '';
-        this.mcpDialogLoadRequestId += 1;
         this.setState((prevState) => ({
             openMcpDialog: !prevState.openMcpDialog,
             searchText: '',
             dialogMcpSubscriptions: null,
         }), () => {
             if (this.state.openMcpDialog) {
-                this.updateDialogSubscriptions(applicationId, true);
+                this.updateDialogSubscriptions(true);
             }
         });
     }
@@ -389,200 +388,200 @@ class SubscriptionsBase extends React.Component {
     }
 
     /**
-     * Load every subscription for the application, used when the current page alone
-     * isn't enough to answer a question (pseudo-subscription check, subscribe dialogs).
-     * @param {*} applicationId application id
-     * @param {number} offset subscription list offset
-     * @param {Array} accumulatedSubscriptions subscriptions collected from previous chunks
-     * @returns {Promise<Array>} the full subscription list
+     * Reset the background subscription accumulator. Called on mount and after any mutation
+     * (delete/update/subscribe), since those can shift backend offsets in ways that are not
+     * safe to patch incrementally.
      */
-    loadAllSubscriptions(applicationId, offset = 0, accumulatedSubscriptions = []) {
-        const client = new Subscription();
-        const subscriptionLimit = app.subscriptionLimit || 1000;
-        return client.getSubscriptions(null, applicationId, subscriptionLimit, offset)
-            .then((response) => {
-                const { body } = response;
-                const pagination = body.pagination || {};
-                const subscriptionList = body.list || [];
-                const subscriptions = accumulatedSubscriptions.concat(subscriptionList);
-                const total = pagination.total || subscriptions.length;
-                const limit = pagination.limit || subscriptionLimit;
-                const currentOffset = pagination.offset || offset;
-                const nextOffset = currentOffset + limit;
-
-                if (subscriptions.length < total && subscriptionList.length > 0) {
-                    return this.loadAllSubscriptions(applicationId, nextOffset, subscriptions);
-                }
-                return subscriptions;
-            });
+    resetAccumulation() {
+        this.combinedSubscriptions = [];
+        this.backendOffset = 0;
+        this.combinedTotal = null;
+        this.fullyLoaded = false;
+        this.loadChain = null;
+        this.resetAPIDetailsCache();
     }
 
     /**
-     * Fetch (and cache for this subscription state) the complete, unpaginated subscription list.
-     * @param {*} applicationId application id
-     * @returns {Promise<Array>} the full subscription list
+     * Walk the subscriptions list in the background (small chunks, not a bulk fetch) until
+     * at least `requiredApiCount` API-type and `requiredMcpCount` MCP-type subscriptions have
+     * been accumulated, or the full list has been exhausted. Pass Infinity for either count to
+     * force a complete walk (needed for the "all pseudo" check and the subscribe dialogs, which
+     * both need the definitive full per-type list).
+     * @param {number} requiredApiCount minimum accumulated API-type subscriptions needed
+     * @param {number} requiredMcpCount minimum accumulated MCP-type subscriptions needed
+     * @returns {Promise<void>}
      */
-    getFullSubscriptions(applicationId) {
-        if (!this.fullSubscriptionsPromise) {
-            this.fullSubscriptionsPromise = this.loadAllSubscriptions(applicationId);
+    ensureLoaded(requiredApiCount, requiredMcpCount) {
+        const { applicationId } = this.props.application;
+        const requestId = this.subscriptionsRequestId;
+
+        const step = () => {
+            if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                return Promise.resolve();
+            }
+            const apiSoFar = this.combinedSubscriptions.filter(isApiSubscription).length;
+            const mcpSoFar = this.combinedSubscriptions.filter(isMcpSubscription).length;
+            if (this.fullyLoaded || (apiSoFar >= requiredApiCount && mcpSoFar >= requiredMcpCount)) {
+                return Promise.resolve();
+            }
+            const client = new Subscription();
+            return client.getSubscriptions(null, applicationId, FETCH_CHUNK_SIZE, this.backendOffset)
+                .then((response) => {
+                    if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                        return undefined;
+                    }
+                    const { body } = response;
+                    const pagination = body.pagination || {};
+                    const list = body.list || [];
+                    this.combinedSubscriptions = this.combinedSubscriptions.concat(list);
+                    this.combinedTotal = pagination.total ?? this.combinedTotal ?? this.combinedSubscriptions.length;
+                    this.backendOffset = (pagination.offset ?? this.backendOffset) + (pagination.limit ?? list.length);
+                    if (list.length === 0 || this.combinedSubscriptions.length >= this.combinedTotal) {
+                        this.fullyLoaded = true;
+                    }
+                    return step();
+                })
+                .catch((error) => {
+                    if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                        return;
+                    }
+                    this.fullyLoaded = true;
+                    const { status } = error;
+                    if (status === 404) {
+                        this.setState({ subscriptionsNotFound: true, subscriptionsLoaded: true });
+                    } else if (status === 401) {
+                        this.setState({ isAuthorize: false });
+                    }
+                });
+        };
+
+        this.loadChain = (this.loadChain || Promise.resolve()).then(step);
+        return this.loadChain;
+    }
+
+    /**
+     * Recompute the visible page slices, per-type counts and pseudo-subscription flags from the
+     * background accumulator, then re-render. Called after every ensureLoaded resolution.
+     */
+    refreshDerivedState() {
+        if (!this.mounted) {
+            return;
         }
-        return this.fullSubscriptionsPromise;
+        const apiAccum = this.combinedSubscriptions.filter(isApiSubscription);
+        const mcpAccum = this.combinedSubscriptions.filter(isMcpSubscription);
+
+        this.setState((prevState) => {
+            let { apiPage, mcpPage } = prevState;
+            if (this.fullyLoaded) {
+                const maxApiPage = Math.max(0, Math.ceil(apiAccum.length / SUBSCRIPTIONS_PER_PAGE) - 1);
+                const maxMcpPage = Math.max(0, Math.ceil(mcpAccum.length / SUBSCRIPTIONS_PER_PAGE) - 1);
+                apiPage = Math.min(apiPage, maxApiPage);
+                mcpPage = Math.min(mcpPage, maxMcpPage);
+            }
+            const apiStart = apiPage * SUBSCRIPTIONS_PER_PAGE;
+            const mcpStart = mcpPage * SUBSCRIPTIONS_PER_PAGE;
+            return {
+                apiPage,
+                mcpPage,
+                apiSubscriptions: apiAccum.slice(apiStart, apiStart + SUBSCRIPTIONS_PER_PAGE),
+                mcpSubscriptions: mcpAccum.slice(mcpStart, mcpStart + SUBSCRIPTIONS_PER_PAGE),
+                apiCount: this.fullyLoaded ? apiAccum.length : -1,
+                mcpCount: this.fullyLoaded ? mcpAccum.length : -1,
+                subscriptionsLoaded: true,
+            };
+        }, () => {
+            this.checkSubValidationDisabled();
+            this.checkMcpSubValidationDisabled();
+        });
     }
 
     /**
      * Shared implementation backing checkSubValidationDisabled / checkMcpSubValidationDisabled.
-     * The current page's subset of a given type may not represent every subscription of that
-     * type, so when the page subset looks fully pseudo, the full list is loaded to confirm.
-     * @param {*} subList current page's subscriptions of one type (API or MCP)
-     * @param {*} applicationId application id
-     * @param {*} requestId current subscriptions request id
-     * @param {*} options.stateKey state field to update
-     * @param {*} options.filterFn predicate selecting subscriptions of this type from a full list
+     * Accumulated-so-far data may not represent every subscription of a type, so when what has
+     * been seen looks fully pseudo but the walk isn't complete, force a full walk to confirm.
+     * @param {Function} filterFn predicate selecting subscriptions of one type
+     * @param {string} stateKey state field to update
      */
-    checkTypeValidationDisabled(subList, applicationId, requestId, { stateKey, filterFn }) {
-        if (!this.mounted || requestId !== this.subscriptionsRequestId) {
-            return;
-        }
-        if (!subList || subList.length === 0 || !subList.every(isPseudoSubscription)) {
+    checkTypeValidationDisabled(filterFn, stateKey) {
+        const typeAccum = this.combinedSubscriptions.filter(filterFn);
+        if (typeAccum.length === 0 || !typeAccum.every(isPseudoSubscription)) {
             this.setState({ [stateKey]: false });
             return;
         }
-        this.getFullSubscriptions(applicationId)
-            .then((allSubscriptions) => {
-                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
-                    return;
-                }
-                const fullTypeList = allSubscriptions.filter(filterFn);
-                this.setState({
-                    [stateKey]: fullTypeList.length > 0 && fullTypeList.every(isPseudoSubscription),
-                });
-            })
-            .catch(() => {
-                if (this.mounted && requestId === this.subscriptionsRequestId) {
-                    this.setState({ [stateKey]: false });
-                }
-            });
-    }
-
-    /**
-     *
-     * Check if the subscription validation is disabled
-     * @param {*} subList Subscriptions list reponse object
-     * @param {*} applicationId application id
-     * @param {*} requestId current subscriptions request id
-     */
-    checkSubValidationDisabled(subList, applicationId, requestId) {
-        this.checkTypeValidationDisabled(subList, applicationId, requestId, {
-            stateKey: 'pseudoSubscriptions',
-            filterFn: (sub) => sub.apiInfo && sub.apiInfo.type !== 'MCP',
+        if (this.fullyLoaded) {
+            this.setState({ [stateKey]: true });
+            return;
+        }
+        const requestId = this.subscriptionsRequestId;
+        this.ensureLoaded(Infinity, Infinity).then(() => {
+            if (!this.mounted || requestId !== this.subscriptionsRequestId) {
+                return;
+            }
+            this.refreshDerivedState();
         });
     }
 
-    /**
-     *
-     * Check if the MCP subscription validation is disabled
-     * @param {*} subList MCP Subscriptions list response object
-     * @param {*} applicationId application id
-     * @param {*} requestId current subscriptions request id
-     */
-    checkMcpSubValidationDisabled(subList, applicationId, requestId) {
-        this.checkTypeValidationDisabled(subList, applicationId, requestId, {
-            stateKey: 'pseudoMcpSubscriptions',
-            filterFn: (sub) => sub.apiInfo && sub.apiInfo.type === 'MCP',
-        });
+    checkSubValidationDisabled() {
+        this.checkTypeValidationDisabled(isApiSubscription, 'pseudoSubscriptions');
     }
 
-    /**
-     *
-     * Update subscriptions list of Application
-     * @param {*} applicationId application id
-     * @param {number} offset subscription list offset
-     * @memberof Subscriptions
-     */
-    updateSubscriptions(applicationId, offset = 0) {
-        const requestId = ++this.subscriptionsRequestId;
-        this.resetAPIDetailsCache();
-        this.fullSubscriptionsPromise = null;
-        const client = new Subscription();
-        const promisedSubscriptions = client.getSubscriptions(null, applicationId, SUBSCRIPTIONS_PER_PAGE, offset);
-        promisedSubscriptions
-            .then((response) => {
-                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
-                    return;
-                }
-                const { body } = response;
-                const allSubscriptions = body.list || [];
-                const pagination = body.pagination || {};
-                const apiSubscriptions = allSubscriptions.filter((sub) => sub.apiInfo && sub.apiInfo.type !== 'MCP');
-                const mcpSubscriptions = allSubscriptions.filter((sub) => sub.apiInfo && sub.apiInfo.type === 'MCP');
-
-                this.setState({
-                    subscriptions: allSubscriptions,
-                    apiSubscriptions,
-                    mcpSubscriptions,
-                    subscriptionCount: pagination.total ?? allSubscriptions.length,
-                    subscriptionOffset: pagination.offset ?? offset,
-                });
-                this.checkSubValidationDisabled(apiSubscriptions, applicationId, requestId);
-                this.checkMcpSubValidationDisabled(mcpSubscriptions, applicationId, requestId);
-            })
-            .catch((error) => {
-                if (!this.mounted || requestId !== this.subscriptionsRequestId) {
-                    return;
-                }
-                const { status } = error;
-                if (status === 404) {
-                    this.setState({ subscriptionsNotFound: true });
-                } else if (status === 401) {
-                    this.setState({ isAuthorize: false });
-                }
-            });
+    checkMcpSubValidationDisabled() {
+        this.checkTypeValidationDisabled(isMcpSubscription, 'pseudoMcpSubscriptions');
     }
 
     /**
      * Update the full, unpaginated list backing a subscribe dialog (API or MCP).
-     * @param {*} applicationId application id
      * @param {boolean} isMcp whether this is refreshing the MCP Server dialog
      * @returns {Promise<void>}
      * @memberof Subscriptions
      */
-    updateDialogSubscriptions(applicationId, isMcp) {
+    updateDialogSubscriptions(isMcp) {
         const requestId = isMcp ? ++this.mcpDialogLoadRequestId : ++this.dialogLoadRequestId;
-        return this.getFullSubscriptions(applicationId)
-            .then((allSubscriptions) => {
-                const currentRequestId = isMcp ? this.mcpDialogLoadRequestId : this.dialogLoadRequestId;
-                const dialogOpen = isMcp ? this.state.openMcpDialog : this.state.openDialog;
-                if (!this.mounted || requestId !== currentRequestId
-                    || !dialogOpen || this.props.application.applicationId !== applicationId) {
-                    return;
-                }
-                const filtered = allSubscriptions.filter((sub) => (
-                    isMcp ? sub.apiInfo && sub.apiInfo.type === 'MCP' : sub.apiInfo && sub.apiInfo.type !== 'MCP'
-                ));
-                this.setState(isMcp ? { dialogMcpSubscriptions: filtered } : { dialogSubscriptions: filtered });
-            })
-            .catch((error) => {
-                const currentRequestId = isMcp ? this.mcpDialogLoadRequestId : this.dialogLoadRequestId;
-                if (!this.mounted || requestId !== currentRequestId) {
-                    return;
-                }
-                const { status } = error;
-                if (status === 401) {
-                    this.setState({ isAuthorize: false });
-                } else {
-                    this.setState(isMcp ? { dialogMcpSubscriptions: [] } : { dialogSubscriptions: [] });
-                }
-            });
+        return this.ensureLoaded(Infinity, Infinity).then(() => {
+            const currentRequestId = isMcp ? this.mcpDialogLoadRequestId : this.dialogLoadRequestId;
+            const dialogOpen = isMcp ? this.state.openMcpDialog : this.state.openDialog;
+            if (!this.mounted || requestId !== currentRequestId || !dialogOpen) {
+                return;
+            }
+            const filtered = this.combinedSubscriptions.filter(isMcp ? isMcpSubscription : isApiSubscription);
+            this.setState(isMcp ? { dialogMcpSubscriptions: filtered } : { dialogSubscriptions: filtered });
+            this.refreshDerivedState();
+        });
     }
 
     /**
-     * Handle a page change on the shared subscriptions table pagination control.
+     * Re-walk the subscriptions list from scratch after a mutation (delete/update/subscribe),
+     * refilling only up to whichever pages are currently visible in each section.
+     */
+    refetchAfterMutation() {
+        this.subscriptionsRequestId += 1;
+        this.resetAccumulation();
+        const { apiPage, mcpPage } = this.state;
+        const requiredApi = (apiPage + 1) * SUBSCRIPTIONS_PER_PAGE;
+        const requiredMcp = (mcpPage + 1) * SUBSCRIPTIONS_PER_PAGE;
+        this.ensureLoaded(requiredApi, requiredMcp).then(() => this.refreshDerivedState());
+    }
+
+    /**
+     * Handle a page change on the API subscriptions pagination control.
      * @param {*} event unused MUI event
      * @param {number} page requested page
      */
-    handleSubscriptionPageChange(event, page) {
-        const { applicationId } = this.props.application;
-        this.updateSubscriptions(applicationId, page * SUBSCRIPTIONS_PER_PAGE);
+    handleApiPageChange(event, page) {
+        const required = (page + 1) * SUBSCRIPTIONS_PER_PAGE;
+        this.setState({ apiPage: page });
+        this.ensureLoaded(required, 0).then(() => this.refreshDerivedState());
+    }
+
+    /**
+     * Handle a page change on the MCP Server subscriptions pagination control.
+     * @param {*} event unused MUI event
+     * @param {number} page requested page
+     */
+    handleMcpPageChange(event, page) {
+        const required = (page + 1) * SUBSCRIPTIONS_PER_PAGE;
+        this.setState({ mcpPage: page });
+        this.ensureLoaded(0, required).then(() => this.refreshDerivedState());
     }
 
     /**
@@ -610,8 +609,7 @@ class SubscriptionsBase extends React.Component {
                         defaultMessage: 'Subscription Deletion Request Created!',
                         id: 'Applications.Details.Subscriptions.request.created',
                     }));
-                    const { applicationId } = this.props.application;
-                    this.updateSubscriptions(applicationId);
+                    this.refetchAfterMutation();
                     return;
                 }
                 if (response.status !== 200 && response.status !== 201) {
@@ -622,12 +620,7 @@ class SubscriptionsBase extends React.Component {
                     }));
                     return;
                 }
-                const { subscriptions, subscriptionOffset } = this.state;
-                const nextOffset = subscriptions.length === 1 && subscriptionOffset > 0
-                    ? subscriptionOffset - SUBSCRIPTIONS_PER_PAGE
-                    : subscriptionOffset;
-                const { applicationId } = this.props.application;
-                this.updateSubscriptions(applicationId, nextOffset);
+                this.refetchAfterMutation();
                 this.props.getApplication();
             })
             .catch((error) => {
@@ -687,8 +680,7 @@ class SubscriptionsBase extends React.Component {
                         id: 'Applications.Details.Subscriptions.business.plan.updated',
                     }));
                 }
-                const { subscriptionOffset } = this.state;
-                this.updateSubscriptions(applicationId, subscriptionOffset);
+                this.refetchAfterMutation();
                 this.props.getApplication();
             })
             .catch((error) => {
@@ -748,13 +740,13 @@ class SubscriptionsBase extends React.Component {
                             defaultMessage: 'Subscription successful',
                         }));
                     }
-                    const { subscriptionOffset, openDialog, openMcpDialog } = this.state;
-                    this.updateSubscriptions(applicationId, subscriptionOffset);
+                    const { openDialog, openMcpDialog } = this.state;
+                    this.refetchAfterMutation();
                     if (openDialog) {
-                        this.updateDialogSubscriptions(applicationId, false);
+                        this.updateDialogSubscriptions(false);
                     }
                     if (openMcpDialog) {
-                        this.updateDialogSubscriptions(applicationId, true);
+                        this.updateDialogSubscriptions(true);
                     }
                     this.props.getApplication();
                 }
@@ -805,15 +797,17 @@ class SubscriptionsBase extends React.Component {
             openDialog,
             openMcpDialog,
             searchText,
-            subscriptions,
+            subscriptionsLoaded,
             apiSubscriptions,
             mcpSubscriptions,
+            apiCount,
+            mcpCount,
+            apiPage,
+            mcpPage,
             apisNotFound,
             subscriptionsNotFound,
             pseudoSubscriptions,
             pseudoMcpSubscriptions,
-            subscriptionCount,
-            subscriptionOffset,
             dialogSubscriptions,
             dialogMcpSubscriptions,
         } = this.state;
@@ -827,7 +821,7 @@ class SubscriptionsBase extends React.Component {
         } = this.props;
         const { applicationId } = application;
 
-        if (subscriptions) {
+        if (subscriptionsLoaded) {
             return (
                 <Root>
                     <Box className={classes.root}>
@@ -867,6 +861,10 @@ class SubscriptionsBase extends React.Component {
                                 getAPIById={this.getAPIById}
                                 getMCPServerById={this.getMCPServerById}
                                 getSubscriptionPolicyByName={this.getSubscriptionPolicyByName}
+                                paginationCount={apiCount}
+                                paginationPage={apiPage}
+                                rowsPerPage={SUBSCRIPTIONS_PER_PAGE}
+                                onPaginationPageChange={this.handleApiPageChange}
                                 noSubscriptionsMessage={(
                                     <FormattedMessage
                                         id='Applications.Details.Subscriptions.no.api.subscriptions'
@@ -912,6 +910,10 @@ class SubscriptionsBase extends React.Component {
                                 getAPIById={this.getAPIById}
                                 getMCPServerById={this.getMCPServerById}
                                 getSubscriptionPolicyByName={this.getSubscriptionPolicyByName}
+                                paginationCount={mcpCount}
+                                paginationPage={mcpPage}
+                                rowsPerPage={SUBSCRIPTIONS_PER_PAGE}
+                                onPaginationPageChange={this.handleMcpPageChange}
                                 noSubscriptionsMessage={(
                                     <FormattedMessage
                                         id='Applications.Details.Subscriptions.no.mcp.subscriptions'
@@ -931,18 +933,6 @@ class SubscriptionsBase extends React.Component {
                                     />
                                 )}
                                 data-testid='mcp-subscriptions-section'
-                            />
-                        )}
-
-                        {(apisAccessible || mcpServersAccessible) && subscriptionCount > 0 && (
-                            <TablePagination
-                                className={classes.pagination}
-                                component='div'
-                                count={subscriptionCount}
-                                page={Math.floor(subscriptionOffset / SUBSCRIPTIONS_PER_PAGE)}
-                                rowsPerPage={SUBSCRIPTIONS_PER_PAGE}
-                                rowsPerPageOptions={[]}
-                                onPageChange={this.handleSubscriptionPageChange}
                             />
                         )}
 

--- a/portals/devportal/src/main/webapp/source/src/app/data/Subscription.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/data/Subscription.jsx
@@ -33,14 +33,15 @@ export default class Subscription extends Resource {
     /**
      * Get all Subscriptions
      * @param apiId id of the API
-     * @param applicationId id of the application 
+     * @param applicationId id of the application
      * @param limit subscription count to return
+     * @param offset subscription list offset
      * @returns {promise} With all subscription for given applicationId or apiId.
      */
-    getSubscriptions(apiId, applicationId, limit = 25) {
+    getSubscriptions(apiId, applicationId, limit = 25, offset = 0) {
         var promise_get = this.client.then((client) => {
             return client.apis["Subscriptions"].get_subscriptions(
-                { apiId: apiId, applicationId: applicationId, limit });
+                { apiId: apiId, applicationId: applicationId, limit, offset });
         }
         );
         return promise_get;


### PR DESCRIPTION
## Summary
- Devportal's "Subscriptions" tab for an application fetched every subscription for that application in a single request (up to `app.subscriptionLimit`, default 1000). The devportal REST endpoint enriches every returned subscription with several DB lookups, so applications with large subscription counts (e.g. 264) took over a minute to load.
- Switches the subscriptions list to real backend-paginated fetches (10 per page) via a shared `TablePagination` control, so only the visible page's subscriptions are enriched per request. Because the subscriptions endpoint has no per-type filter, a fetched page is split client-side into the existing "Subscribed APIs" / "Subscribed MCP Servers" sections.
- The "all subscriptions are pseudo/subscriptionless" check and the "Subscribe to API(s)/MCP Server(s)" dialogs need the complete subscription list (not just the current page); these now load the full list on demand only when required, instead of on every page load.
- Consolidates `SubscriptionTableData`'s two separate per-row API/MCP Server detail fetches (tier list + monetization status) into one cached fetch, cutting duplicate per-row API calls.
- Removes a redundant, immediately-overwritten `getSubscriptions` call in the API details page.

## Source fix
https://github.com/wso2-support/apim-apps/pull/720

## Tracking issue
https://github.com/wso2/api-manager/issues/5082