### PR TITLE
Fix(publisher): Inconsistent role based behaviour in comment reply functionality

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Comments/CommentAdd.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Comments/CommentAdd.jsx
@@ -26,7 +26,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import Alert from 'AppComponents/Shared/Alert';
 import CommentsAPI from 'AppData/Comments';
 import MCPServer from 'AppData/MCPServer';
-import { isRestricted } from 'AppData/AuthManager';
+import AuthManager from 'AppData/AuthManager';
 
 const PREFIX = 'CommentAdd';
 
@@ -192,12 +192,8 @@ class CommentAdd extends React.Component {
      * @returns {boolean} - True if access is restricted, false otherwise
      */
     isAccessRestricted() {
-        const { api } = this.props;
-        if (api.apiType.toUpperCase() === MCPServer.CONSTS.MCP) {
-            return isRestricted(['apim:comment_write', 'apim:comment_manage'], api);
-        } else {
-            return isRestricted(['apim:api_create', 'apim:api_publish'], api);
-        }
+        const user = AuthManager.getUser();
+        return !user.scopes.includes("apim:comment_write") && !user.scopes.includes("apim:comment_manage");
     }
 
     /**

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Comments/CommentOptions.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Comments/CommentOptions.jsx
@@ -171,7 +171,7 @@ class CommentOptions extends React.Component {
         const user = AuthManager.getUser();
         const username = Utils.getUserNameWithoutDomain(user.name);
         const canDelete = (comment.createdBy === username) || user.isAdmin();
-        const canReply = !user.isCreator() || user.isAdmin();
+        const canReply = user.scopes.includes("apim:comment_write") || user.scopes.includes("apim:comment_manage");
         // const canModify = comment.createdBy === username;
         return (
             <StyledGrid container spacing={1} className={classes.verticalSpace} key={comment.id}>


### PR DESCRIPTION
### Purpose

In the Publisher portal's comment reply functionality, currently only users with publisher and admin roles can reply to a comment. For other roles, the `Reply` button and `Add Comment` text field are disabled, even if those roles have the default scopes to create a comment. The current implementation only checks the user's role instead of checking their scopes for the necessary permissions.

This PR fixes this issue by replacing that logic with proper user scope checking for both the `Reply` button's visibility and the `Add Comment` text field's editability.

Fixes **#4881**

[Public Issue Link](https://github.com/wso2/api-manager/issues/4881)

### Approach

File Modified: `CommentOptions.jsx`, `CommentAdd.jsx`

`CommentOptions.jsx`: Updated the `canReply` boolean variable to determine its value using the user's scopes instead of user roles.

`CommentAdd.jsx`: Updated the `isAccessRestricted` function to check the user's scopes for adding comments. (Note: The existing implementation used the default `AuthManager.isRestricted` function, which is not suitable for this scenario).