### PR TITLE
Detect backend OpenAPI version when creating an MCP Server from an existing API

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/data/MCPServer.js
+++ b/portals/publisher/src/main/webapp/source/src/app/data/MCPServer.js
@@ -172,7 +172,7 @@ class MCPServer extends Resource {
      * @returns {Promise<MCPServer>} A promise that resolves to the created MCPServer instance.
      */
     createMCPServerUsingExistingAPI() {
-        const promisedCreate = this.client.then(client => {
+        const promisedCreate = this.client.then(async (client) => {
             const apiData = this.getDataFromSpecFields(client);
             const data = {};
 
@@ -181,9 +181,28 @@ class MCPServer extends Resource {
                     data[apiAttribute] = this[apiAttribute];
                 }
             });
+            let openAPIVersion = 'v3';
+            const backendApiId = data.operations?.[0]?.apiOperationMapping?.apiId;
+            if (backendApiId) {
+                try {
+                    const swaggerResponse = await client.apis.APIs.getAPISwagger(
+                        { apiId: backendApiId },
+                        this._requestMetaData(),
+                    );
+                    const definition = typeof swaggerResponse.body === 'string'
+                        ? JSON.parse(swaggerResponse.body)
+                        : swaggerResponse.body;
+                    if (definition && definition.swagger
+                        && String(definition.swagger).startsWith('2.')) {
+                        openAPIVersion = 'v2';
+                    }
+                } catch (error) {
+                    console.error('Error detecting the OpenAPI version of the referenced API:', error);
+                }
+            }
 
             return client.apis['MCP Servers'].createMCPServerFromAPI(
-                { 'Content-Type': 'application/json' },
+                { 'Content-Type': 'application/json', openAPIVersion },
                 { requestBody: data },
                 this._requestMetaData(),
             );


### PR DESCRIPTION
## Description
### Purpose
When creating an MCP Server from an existing API, the Publisher did not send an `openAPIVersion`, so the backend defaulted to `v3`. For an existing API whose definition is Swagger 2.0 (v2), that mismatch caused the create call to fail.

### Change
In `MCPServer.createMCPServerUsingExistingAPI`, detect the referenced backend API's OpenAPI version (via `getAPISwagger`) and send the matching `openAPIVersion` (`v2` for Swagger 2.0, otherwise `v3`) on `POST /mcp-servers/generate-from-api`. If detection fails, it falls back to `v3` (previous behavior).

Related Issue : https://github.com/wso2/api-manager/issues/5127