### PR TITLE
Fix Policies page layout breaking with long resource paths

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/OperationsGroup.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/OperationsGroup.tsx
@@ -34,12 +34,13 @@ const StyledBox = styled(Box)((
     }
 ) => ({
     [`& .${classes.tagClass}`]: {
-        maxWidth: 1000,
+        minWidth: 0,
+        maxWidth: 550,
         overflow: 'hidden',
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
         [theme.breakpoints.down('lg')]: {
-            maxWidth: 800,
+            maxWidth: 400,
         },
     }
 }));


### PR DESCRIPTION
Fixes #4725 https://github.com/wso2/api-manager/issues/4725

Problem: On the Policies page, switching to Operation Level Policies with long resource paths pushed the Policy List off-screen.
Root cause: The path group header is nowrap text with maxWidth: 1000px (800 below lg) — wider than the 65% column at common window sizes, so the page grew past the viewport.
Fix: Reduced the caps.