### PR TITLE
Add subscriptionPolicyLimit to settings.json

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/conf/settings.json
+++ b/portals/publisher/src/main/webapp/site/public/conf/settings.json
@@ -18,6 +18,7 @@
         },
         "logoutSessionStateAppender": "",
         "throttlingPolicyLimit": 80,
+        "subscriptionPolicyLimit": 80,
         "operationPolicyCount": 500,
         "documentCount": 1000,
         "propertyDisplaySuffix": "__display",

--- a/portals/publisher/src/main/webapp/source/Tests/Unit/Subscriptions/SubscriptionPoliciesManage.test.js
+++ b/portals/publisher/src/main/webapp/source/Tests/Unit/Subscriptions/SubscriptionPoliciesManage.test.js
@@ -44,6 +44,15 @@ jest.mock('AppData/AuthManager', () => ({
     isRestricted: jest.fn(() => false),
 }));
 
+jest.mock('Config', () => ({
+    __esModule: true,
+    default: {
+        app: {
+            subscriptionPolicyLimit: 25,
+        },
+    },
+}));
+
 const API = require('AppData/api').default;
 
 const baseProps = {


### PR DESCRIPTION
## Purpose 

$subject 

**Configuration updates:**

* Added `subscriptionPolicyLimit` with a value of 80 to control the number of subscription policies rendered in publisher portal  .

**Testing improvements:**

* Mocked the `Config` module in the `SubscriptionPoliciesManage.test.js` unit test to provide a `subscriptionPolicyLimit` value of 25, which was the previous value.

Resolves https://github.com/wso2/api-manager/issues/5146