### PR TITLE
fix(publisher): Allow API definition editing for gateway-initiated APIs

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -827,7 +827,7 @@ class APIDefinition extends React.Component {
                             size='small'
                             className={classes.button}
                             onClick={this.openEditor}
-                            disabled={isRestricted(['apim:api_create'], api) || api.initiatedFromGateway}
+                            disabled={isRestricted(['apim:api_create'], api)}
                         >
                             <EditRounded className={classes.buttonIcon} />
                             <FormattedMessage
@@ -842,8 +842,7 @@ class APIDefinition extends React.Component {
                                 className={classes.button}
                                 onClick={this.openEditor}
                                 disabled={isRestricted(['apim:api_create'], api) || api.isRevision
-                                || (settings && settings.portalConfigurationOnlyModeEnabled) 
-                                || api.initiatedFromGateway}
+                                || (settings && settings.portalConfigurationOnlyModeEnabled)}
                                 id='edit-definition-btn'
                             >
                                 <EditRounded className={classes.buttonIcon} />
@@ -1098,6 +1097,7 @@ class APIDefinition extends React.Component {
                                 handleSave={this.handleSave}
                                 handleSaveAndDeploy={this.handleSaveAndDeploy}
                                 isUpdating={isUpdating}
+                                showOnlySaveButton={api.initiatedFromGateway}
                             />
                         </Grid>
                     </Grid>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/APIDefinition/APIDefinition.jsx
@@ -1066,13 +1066,25 @@ class APIDefinition extends React.Component {
                 </DialogTitle>
                 <DialogContent>
                     <DialogContentText id='alert-dialog-description'>
-                        <FormattedMessage
-                            id='Apis.Details.APIDefinition.APIDefinition.api.definition.save.confirmation'
-                            defaultMessage={
-                                'Are you sure you want to save the API Definition? This might affect the'
-                                + ' existing resources.'
-                            }
-                        />
+                        {api.initiatedFromGateway ? (
+                            <FormattedMessage
+                                id={'Apis.Details.APIDefinition.APIDefinition.api.definition.save'
+                                    + '.confirmation.gateway'}
+                                defaultMessage={
+                                    'Are you sure you want to save the API Definition? This will only'
+                                    + ' affect the developer portal content and will not change the'
+                                    + ' existing deployment.'
+                                }
+                            />
+                        ) : (
+                            <FormattedMessage
+                                id='Apis.Details.APIDefinition.APIDefinition.api.definition.save.confirmation'
+                                defaultMessage={
+                                    'Are you sure you want to save the API Definition? This might affect the'
+                                    + ' existing resources.'
+                                }
+                            />
+                        )}
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/CustomSplitButton.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/CustomSplitButton.jsx
@@ -22,7 +22,7 @@ export default function CustomSplitButton(props) {
     const [open, setOpen] = useState(false);
     const {
         advertiseInfo, handleSave, handleSaveAndDeploy, isUpdating, api, id, isValidSequenceBackend,
-        isCustomBackendSelected
+        isCustomBackendSelected, showOnlySaveButton
     } = props;
     const intl = useIntl();
     const options = [
@@ -106,59 +106,63 @@ export default function CustomSplitButton(props) {
                         ref={anchorRef}
                         aria-label='split button'
                         disabled={isUpdating || (!isValidSequenceBackend && isCustomBackendSelected)
-                            || api.initiatedFromGateway}
+                            || (api.initiatedFromGateway && !showOnlySaveButton)}
                     >
                         <Button
                             onClick={handleClick}
                             disabled={isUpdating || (!isValidSequenceBackend && isCustomBackendSelected)
-                                || api.initiatedFromGateway}
+                                || (api.initiatedFromGateway && !showOnlySaveButton)}
                             data-testid = 'custom-select-save-button'
                             style={{ minWidth: '120px' }}
                             id={id}
                         >
-                            {options[selectedIndex].label}
+                            {showOnlySaveButton ? options[1].label : options[selectedIndex].label}
                             {isUpdating && <CircularProgress size={24} />}
                         </Button>
-                        <Button
-                            color='primary'
-                            size='small'
-                            aria-controls={open ? 'split-button-menu' : undefined}
-                            aria-expanded={open ? 'true' : undefined}
-                            aria-label='select merge strategy'
-                            aria-haspopup='menu'
-                            onClick={handleToggle}
-                        >
-                            <ArrowDropDownIcon />
-                        </Button>
-                    </ButtonGroup>
-                    <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
-                        {({ TransitionProps, placement }) => (
-                            <Grow
-                                {...TransitionProps}
-                                style={{
-                                    transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
-                                }}
+                        {!showOnlySaveButton && (
+                            <Button
+                                color='primary'
+                                size='small'
+                                aria-controls={open ? 'split-button-menu' : undefined}
+                                aria-expanded={open ? 'true' : undefined}
+                                aria-label='select merge strategy'
+                                aria-haspopup='menu'
+                                onClick={handleToggle}
                             >
-                                <Paper>
-                                    <ClickAwayListener onClickAway={handleClose}>
-                                        <MenuList id='split-button-menu'>
-                                            {options.map((option, index) => (
-                                                <MenuItem
-                                                    key={option.key}
-                                                    selected={index === selectedIndex}
-                                                    onClick={(event) => handleOptionSelect(event, index)}
-                                                    disabled={(option.key === 'Save and deploy'
-                                                        && isDeployButtonDisabled)}
-                                                >
-                                                    {option.label}
-                                                </MenuItem>
-                                            ))}
-                                        </MenuList>
-                                    </ClickAwayListener>
-                                </Paper>
-                            </Grow>
+                                <ArrowDropDownIcon />
+                            </Button>
                         )}
-                    </Popper>
+                    </ButtonGroup>
+                    {!showOnlySaveButton && (
+                        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
+                            {({ TransitionProps, placement }) => (
+                                <Grow
+                                    {...TransitionProps}
+                                    style={{
+                                        transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+                                    }}
+                                >
+                                    <Paper>
+                                        <ClickAwayListener onClickAway={handleClose}>
+                                            <MenuList id='split-button-menu'>
+                                                {options.map((option, index) => (
+                                                    <MenuItem
+                                                        key={option.key}
+                                                        selected={index === selectedIndex}
+                                                        onClick={(event) => handleOptionSelect(event, index)}
+                                                        disabled={(option.key === 'Save and deploy'
+                                                            && isDeployButtonDisabled)}
+                                                    >
+                                                        {option.label}
+                                                    </MenuItem>
+                                                ))}
+                                            </MenuList>
+                                        </ClickAwayListener>
+                                    </Paper>
+                                </Grow>
+                            )}
+                        </Popper>
+                    )}
                 </Grid>
             )}
         </Grid>
@@ -168,6 +172,7 @@ export default function CustomSplitButton(props) {
 CustomSplitButton.defaultProps = {
     isCustomBackendSelected: false,
     isValidSequenceBackend: true,
+    showOnlySaveButton: false,
 };
 CustomSplitButton.propTypes = {
     api: PropTypes.shape({}).isRequired,
@@ -176,4 +181,5 @@ CustomSplitButton.propTypes = {
     isUpdating: PropTypes.bool.isRequired,
     isValidSequenceBackend: PropTypes.bool,
     isCustomBackendSelected: PropTypes.bool,
+    showOnlySaveButton: PropTypes.bool,
 };

--- a/portals/publisher/src/main/webapp/source/src/app/components/Shared/CustomSplitButton.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Shared/CustomSplitButton.jsx
@@ -67,7 +67,7 @@ export default function CustomSplitButton(props) {
     };
 
     const handleClick = () => {
-        if (`${options[selectedIndex].key}` === 'Save') {
+        if (showOnlySaveButton || `${options[selectedIndex].key}` === 'Save') {
             handleSave();
         } else {
             handleSaveAndDeploy();


### PR DESCRIPTION
## Fixes

wso2/api-manager#4971

## Problem

For APIs where `initiatedFromGateway` is `true`, the Publisher Portal disabled all editing of the API Definition (OpenAPI/AsyncAPI schema) entirely. This was too restrictive:

- The gateway does not need a fully OpenAPI-compatible definition to deploy/route an API — it only needs routing info — so a gateway-generated definition is often minimal or incomplete.
- Because editing was fully blocked, portal users had no way to enrich that definition with developer-portal-relevant details (descriptions, examples, docs, etc.) for APIs that originated from the gateway.

## Before

- On the **API Definition** page, both the top "Edit" button and the in-dialog "Edit" button were disabled whenever `api.initiatedFromGateway` was `true`, in addition to the existing permission/revision/portal-config-only checks.
- The `CustomSplitButton` (the shared Save / Save-and-deploy split button used on this and 6 other pages — Endpoints, Operations, RuntimeConfiguration, RuntimeConfigurationWebSocket, ProductResourcesEdit, Properties, and Resources/SaveOperations) also disabled itself entirely whenever `api.initiatedFromGateway` was `true`.
- Net effect: gateway-initiated APIs were fully read-only on the definition page — no edits, no saves, no deploys.

## Approach

1. **`APIDefinition.jsx`** — removed `api.initiatedFromGateway` from the `disabled` conditions on both "Edit" buttons, so the swagger/AsyncAPI editor can now be opened and edited for gateway-initiated APIs.
2. **`CustomSplitButton.jsx`** — added a new, opt-in `showOnlySaveButton` prop (default `false`):
   - When `true`: the "Save and deploy" option and the dropdown arrow/menu are hidden, and the single visible button always renders as "Save" and only ever triggers `handleSave` (never `handleSaveAndDeploy`).
   - When `false` (default, unchanged for existing callers): behaves exactly as before, including still disabling the whole control when `api.initiatedFromGateway` is `true`.
   - `APIDefinition.jsx` passes `showOnlySaveButton={api.initiatedFromGateway}`, so only this page opts out of the gateway-initiated disable — deployment stays impossible, but plain saves are now allowed.

This keeps the fix scoped to the one page the issue is about, without changing behavior on the other 6 pages that reuse `CustomSplitButton` (Endpoints, Operations, RuntimeConfiguration(WebSocket), ProductResourcesEdit, Properties, Resources) — those continue to fully block saving for gateway-initiated APIs, since the gateway remains the owner of routing/endpoint/operations config for those APIs.

## Impact

- Gateway-initiated APIs: the API Definition editor is now editable and savable (portal-only metadata changes persist), but "Save and deploy" is not offered, so no gateway redeployment can be triggered from this flow.
- All other pages using `CustomSplitButton` (Endpoints, Operations, RuntimeConfiguration, RuntimeConfigurationWebSocket, ProductResourcesEdit, Properties, Resources): no behavior change — saving remains disabled for gateway-initiated APIs, exactly as before.
- No changes to permission checks, revision checks, or portal-configuration-only-mode checks — those continue to apply as before on top of this.

<img width="730" height="222" alt="image" src="https://github.com/user-attachments/assets/c9798ad3-10b7-42a4-bf66-629644ad730f" />
<img width="585" height="159" alt="image" src="https://github.com/user-attachments/assets/fa1a1e9b-9d4a-426e-815a-98828636acc3" />



## Testing

- Verified via code inspection that `showOnlySaveButton` defaults to `false` for all 6 other `CustomSplitButton` callers, preserving their original disabled-on-`initiatedFromGateway` behavior.
- Verified `handleClick`'s "Save" vs "Save and deploy" branching still matches the displayed label when `showOnlySaveButton` is `true` (the dropdown that changes `selectedIndex` is hidden in that mode, so it always resolves to "Save").
