### PR TITLE
fix(devportal): mask basic-auth password in try-out console

### DIFF
--- a/portals/devportal/src/main/webapp/source/Tests/Unit/TryOutController.test.js
+++ b/portals/devportal/src/main/webapp/source/Tests/Unit/TryOutController.test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getBasicAuthPasswordInputType } from 'AppComponents/Shared/ApiTryOut/TryOutController';
+
+describe('TryOutController basic auth password masking (product-apim#8988)', () => {
+    it('masks password input by default', () => {
+        expect(getBasicAuthPasswordInputType(false)).toBe('password');
+    });
+
+    it('allows revealing the password when the visibility toggle is enabled', () => {
+        expect(getBasicAuthPasswordInputType(true)).toBe('text');
+    });
+});

--- a/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Shared/ApiTryOut/TryOutController.jsx
@@ -54,6 +54,17 @@ import isPlatformGatewayApi from '../../Apis/Details/ApiConsole/platformGateway'
 
 const PREFIX = 'TryOutController';
 
+/**
+ * Resolves the HTML input type for the basic-auth password field.
+ * Passwords must be masked by default (product-apim#8988).
+ *
+ * @param {boolean} showPassword Whether the visibility toggle is enabled
+ * @returns {'password'|'text'} Input type for the password field
+ */
+export function getBasicAuthPasswordInputType(showPassword) {
+    return showPassword ? 'text' : 'password';
+}
+
 const classes = {
     centerItems: `${PREFIX}-centerItems`,
     tokenType: `${PREFIX}-tokenType`,
@@ -934,10 +945,10 @@ function TryOutController(props) {
                                             <TextField
                                                 margin='normal'
                                                 variant='outlined'
-                                                id='username'
+                                                id='basic-auth-username-input'
                                                 label={(
                                                     <FormattedMessage
-                                                        id='username'
+                                                        id='Apis.Details.ApiConsole.basic.auth.username'
                                                         defaultMessage='Username'
                                                     />
                                                 )}
@@ -945,24 +956,27 @@ function TryOutController(props) {
                                                 onChange={handleChanges}
                                                 value={username || ''}
                                                 fullWidth
+                                                inputProps={{
+                                                    'data-testid': 'basic-auth-username-input',
+                                                    autoComplete: 'username',
+                                                }}
                                             />
                                             <TextField
                                                 margin='normal'
                                                 variant='outlined'
-                                                id='input-password'
+                                                id='basic-auth-password-input'
                                                 label={(
                                                     <FormattedMessage
-                                                        id='password'
+                                                        id='Apis.Details.ApiConsole.basic.auth.password'
                                                         defaultMessage='Password'
                                                     />
                                                 )}
                                                 name='password'
                                                 onChange={handleChanges}
-                                                type={showPassword ? 'text' : 'password'}
+                                                type={getBasicAuthPasswordInputType(showPassword)}
                                                 value={password || ''}
                                                 fullWidth
                                                 InputProps={{
-                                                    autoComplete: 'new-password',
                                                     endAdornment: (
                                                         <InputAdornment position='end'>
                                                             <IconButton
@@ -975,6 +989,10 @@ function TryOutController(props) {
                                                             </IconButton>
                                                         </InputAdornment>
                                                     ),
+                                                }}
+                                                inputProps={{
+                                                    'data-testid': 'basic-auth-password-input',
+                                                    autoComplete: 'current-password',
                                                 }}
                                             />
                                         </Grid>


### PR DESCRIPTION
Ensures the Dev Portal try-out Basic Credentials password field is masked by default. Adds regression test for wso2/product-apim#8988
