### PR TITLE
Guard Resources page against unresolved $ref in parameters/requestBody

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/ListParameters.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/ListParameters.jsx
@@ -126,7 +126,7 @@ export default function ListParameters(props) {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {operation.parameters
+                    {operation.parameters && resolvedSpec.paths
                         && operation.parameters.map((parameter, index) => {
                             const isRefParam = isRef(parameter);
                             const paramCopy = isRefParam
@@ -202,8 +202,8 @@ export default function ListParameters(props) {
                                 </TableRow>
                             );
                         })}
-                    {operation.requestBody && (isRef(operation.requestBody)
-                        ? Object.entries(resolvedSpec.paths[target][verb].requestBody.content).map(
+                    {operation.requestBody && isRef(operation.requestBody) && resolvedSpec.paths
+                        && Object.entries(resolvedSpec.paths[target][verb].requestBody.content).map(
                             ([contentType, content]) => {
                                 return (
                                     <RequestBody
@@ -218,7 +218,9 @@ export default function ListParameters(props) {
                                     />
                                 );
                             },
-                        ) : Object.entries(operation.requestBody.content).map(([contentType, content]) => {
+                        )}
+                    {operation.requestBody && !isRef(operation.requestBody)
+                        && Object.entries(operation.requestBody.content).map(([contentType, content]) => {
                             return (
                                 <RequestBody
                                     contentType={contentType}
@@ -231,7 +233,7 @@ export default function ListParameters(props) {
                                     verb={verb}
                                 />
                             );
-                        }))}
+                        })}
                 </TableBody>
             </Table>
         </Root>


### PR DESCRIPTION
### Purpose

Harden `ListParameters.jsx` in the Publisher Resources page so it can't crash when `resolvedSpec` doesn't contain a fully `$ref`-resolved spec for the operation being rendered.

### Related issue

Fixes (proactively) the failure mode reported in wso2/api-manager#1354 — "Resources page break if the API definition has references."

### Background / root cause

#1354 was originally caused by the Publisher's `updated` swagger-validation mode: `Resources.jsx` built `resolvedSpec` from the `validate-openapi` REST endpoint's response, which returns a stripped-down spec (no full `paths`). `ListParameters.jsx` then indexed into `resolvedSpec.paths[target][verb]` to resolve `$ref` parameters/requestBody, which threw when `paths` was missing.

That specific code path (`swaggerValidationBehaviour: 'updated'`, and the branch that substituted the stripped REST response for `resolvedSpec`) no longer exists in this repo — `Resources.jsx` now always resolves the spec via `SwaggerClient.resolve()` before rendering, so the original trigger is gone.

However, `ListParameters.jsx` never picked up the defensive guards that were added alongside that original fix (in the old `carbon-apimgt` `publisher.feature` module, support hotfix branch `support-9.0.174.x-full`).

`SwaggerClient.resolve()` can still fail to fully resolve a spec (circular refs, an unreachable external `$ref`, a malformed pointer), in which case `resolvedSpec.paths[target][verb]` can be undefined or incomplete while `resolvedSpec.spec` itself is non-empty — which would reproduce the same crash shape through a different trigger. This PR ports those guards.

### What changed

`portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/operationComponents/ListParameters.jsx`

- Parameters list: only map `operation.parameters` when `resolvedSpec.paths` is actually present, instead of assuming it's always populated.
- Request body: split the single ternary (ref vs. non-ref) into two independent guarded blocks, each checking `resolvedSpec.paths` before indexing into it, so a missing/partial resolve can no longer throw.