### PR TITLE
Fix subscription policy pagination UI issue in async APIs

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -1852,6 +1852,7 @@
   "Apis.Details.Subscriptions.SubscriptionAvailability.sub.heading": "Make subscriptions available to tenants",
   "Apis.Details.Subscriptions.SubscriptionAvailability.subscription.availability": "Subscription Availability",
   "Apis.Details.Subscriptions.SubscriptionPoliciesManage.business.plans": "Business Plans",
+  "Apis.Details.Subscriptions.SubscriptionPoliciesManage.fetch.all.policies.error": "Error while fetching subscription policies.",
   "Apis.Details.Subscriptions.SubscriptionPoliciesManage.sub.heading": "Attach business plans to {type}",
   "Apis.Details.Subscriptions.SubscriptionPoliciesManage.sub.migrated": "Following policies are migrated from an old version of APIM. You can uncheck and select a different policy. Note that this is an irreversible operation.",
   "Apis.Details.Subscriptions.Subscriptions.cancel": "Cancel",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
@@ -29,6 +29,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
 import TablePagination from '@mui/material/TablePagination';
 import API from 'AppData/api';
+import Alert from 'AppComponents/Shared/Alert';
 import MCPServer from 'AppData/MCPServer';
 import { isRestricted } from 'AppData/AuthManager';
 import Configurations from 'Config';
@@ -91,7 +92,7 @@ export class SubscriptionPoliciesManage extends Component {
             page: 0,
             rowsPerPage,
             totalPolicies: 0,
-            allAsyncPolicyNames: null,
+            allAsyncPolicyNames: [],
         };
         this.handleChange = this.handleChange.bind(this);
         this.fetchPolicies = this.fetchPolicies.bind(this);
@@ -174,17 +175,22 @@ export class SubscriptionPoliciesManage extends Component {
     }
 
     fetchAllAsyncPoliciesForMigrationCheck() {
-        API.asyncAPIPolicies(undefined, undefined)
+        const limit = Configurations.app.subscriptionPolicyLimit || 80;
+        API.asyncAPIPolicies(limit)
             .then((res) => {
                 const policies = res.body.list || [];
                 this.setState({
-                    allAsyncPolicyNames: new Set(policies.map((p) => p.displayName)),
+                    allAsyncPolicyNames: policies.map((p) => p.displayName),
                 });
             })
             .catch((error) => {
                 if (process.env.NODE_ENV !== 'production') {
                     console.error(error);
                 }
+                Alert.error(this.props.intl.formatMessage({
+                    id: 'Apis.Details.Subscriptions.SubscriptionPoliciesManage.fetch.all.policies.error',
+                    defaultMessage: 'Error while fetching subscription policies.',
+                }));
             });
     }
 
@@ -262,8 +268,8 @@ export class SubscriptionPoliciesManage extends Component {
         */
         let migratedCase = false;
         let preMigrationPolicies;
-        if (isAsyncAPI && allAsyncPolicyNames !== null && api.policies && api.policies.length > 0) {
-            preMigrationPolicies = api.policies.filter((apiPolicy) => !allAsyncPolicyNames.has(apiPolicy));
+        if (isAsyncAPI && allAsyncPolicyNames.length > 0 && api.policies && api.policies.length > 0) {
+            preMigrationPolicies = api.policies.filter((apiPolicy) => !allAsyncPolicyNames.includes(apiPolicy));
             migratedCase = preMigrationPolicies.length > 0;
         }
 

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Subscriptions/SubscriptionPoliciesManage.jsx
@@ -91,11 +91,13 @@ export class SubscriptionPoliciesManage extends Component {
             page: 0,
             rowsPerPage,
             totalPolicies: 0,
+            allAsyncPolicyNames: null,
         };
         this.handleChange = this.handleChange.bind(this);
         this.fetchPolicies = this.fetchPolicies.bind(this);
         this.handleChangePage = this.handleChangePage.bind(this);
         this.handleChangeRowsPerPage = this.handleChangeRowsPerPage.bind(this);
+        this.fetchAllAsyncPoliciesForMigrationCheck = this.fetchAllAsyncPoliciesForMigrationCheck.bind(this);
     }
 
     componentDidMount() {
@@ -108,7 +110,12 @@ export class SubscriptionPoliciesManage extends Component {
         this.setState({
             isAsyncAPI,
             isMutualSslOnly,
-        }, () => this.fetchPolicies(0, this.state.rowsPerPage, isAsyncAPI));
+        }, () => {
+            this.fetchPolicies(0, this.state.rowsPerPage, isAsyncAPI);
+            if (isAsyncAPI && api.policies && api.policies.length > 0) {
+                this.fetchAllAsyncPoliciesForMigrationCheck();
+            }
+        });
     }
 
     fetchPolicies(page, rowsPerPage, isAsyncAPIOverride = this.state.isAsyncAPI) {
@@ -164,6 +171,21 @@ export class SubscriptionPoliciesManage extends Component {
     handleChangeRowsPerPage(event) {
         const rowsPerPage = parseInt(event.target.value, 10);
         this.fetchPolicies(0, rowsPerPage);
+    }
+
+    fetchAllAsyncPoliciesForMigrationCheck() {
+        API.asyncAPIPolicies(undefined, undefined)
+            .then((res) => {
+                const policies = res.body.list || [];
+                this.setState({
+                    allAsyncPolicyNames: new Set(policies.map((p) => p.displayName)),
+                });
+            })
+            .catch((error) => {
+                if (process.env.NODE_ENV !== 'production') {
+                    console.error(error);
+                }
+            });
     }
 
     /**
@@ -225,7 +247,7 @@ export class SubscriptionPoliciesManage extends Component {
     render() {
         const {  api, policies } = this.props;
         const {
-            subscriptionPolicies, isAsyncAPI, page, rowsPerPage, totalPolicies,
+            subscriptionPolicies, isAsyncAPI, page, rowsPerPage, totalPolicies, allAsyncPolicyNames,
         } = this.state;
 
         /*
@@ -235,14 +257,13 @@ export class SubscriptionPoliciesManage extends Component {
         But throttling-policies/streaming/subscription does not have this "Unlimited" policy after 4.0
         So logic in UI shows no policy is attached to the API.
         Following logic identifies that special case.
+        We compare against the full async policy set (allAsyncPolicyNames) rather than the current page
+        (subscriptionPolicies) to avoid false positives when a selected policy happens to be on a different page.
         */
         let migratedCase = false;
         let preMigrationPolicies;
-        if (isAsyncAPI && subscriptionPolicies.length !== 0 && api.policies && api.policies.length > 0) {
-            preMigrationPolicies = api.policies.filter((apiPolicy) => {
-                const samePolicies = subscriptionPolicies.filter((subPolicy) => apiPolicy === subPolicy.displayName);
-                return samePolicies.length === 0;
-            });
+        if (isAsyncAPI && allAsyncPolicyNames !== null && api.policies && api.policies.length > 0) {
+            preMigrationPolicies = api.policies.filter((apiPolicy) => !allAsyncPolicyNames.has(apiPolicy));
             migratedCase = preMigrationPolicies.length > 0;
         }
 

--- a/tests/cypress/e2e/publisher/006-subscriptions/02-subscription-policy-pagination.cy.js
+++ b/tests/cypress/e2e/publisher/006-subscriptions/02-subscription-policy-pagination.cy.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("API subscription policies - pagination", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    const apiName = Utils.generateName();
+    const apiVersion = '1.0.0';
+
+    let testApiId;
+
+    const buildPolicy = (name) => ({
+        name,
+        displayName: name,
+        description: `${name} policy`,
+        policyLevel: 'SUBSCRIPTION',
+        attributes: {},
+        requestCount: 1000,
+        dataUnit: null,
+        unitTime: 1,
+        timeUnit: 'min',
+        rateLimitCount: 0,
+        rateLimitTimeUnit: null,
+        quotaPolicyType: 'REQUESTCOUNT',
+        tierPlan: 'FREE',
+        stopOnQuotaReach: true,
+        monetizationAttributes: {},
+        throttlingPolicyPermissions: { type: 'ALLOW', roles: ['Internal/everyone'] },
+    });
+
+    // create policies
+    const page1List = Array.from({ length: 10 }, (_, i) =>
+        buildPolicy(`Policy${String(i + 1).padStart(2, '0')}`));
+    const page2List = [
+        buildPolicy('PlatinumPolicy01'),
+        buildPolicy('PlatinumPolicy02'),
+        buildPolicy('PlatinumPolicy03'),
+        buildPolicy('PlatinumPolicy04'),
+    ];
+
+    const allPoliciesList = [...page1List, ...page2List];
+    const totalPolicies = allPoliciesList.length;
+
+    before(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Selecting a policy from page 2, saving it, and returning to page 1 must not trigger the migration warning", () => {
+        // Step 1: Create a REST API
+        Utils.addAPI({ name: apiName, version: apiVersion }).then((apiId) => {
+            testApiId = apiId;
+
+            let savedPolicies = [];
+
+            cy.intercept('GET', '**/throttling-policies/subscription*', (req) => {
+                const params = new URLSearchParams(req.url.split('?')[1] || '');
+                const limit = parseInt(params.get('limit') || '100', 10);
+                const offset = parseInt(params.get('offset') || '0', 10);
+
+                if (offset > 0) {
+                    req.reply({
+                        body: {
+                            count: page2List.length,
+                            list: page2List,
+                            pagination: { offset, limit, total: totalPolicies, next: '', previous: '' },
+                        },
+                    });
+                } else {
+                    req.reply({
+                        body: {
+                            count: page1List.length,
+                            list: page1List,
+                            pagination: { offset: 0, limit, total: totalPolicies, next: '', previous: '' },
+                        },
+                    });
+                }
+            }).as('getPolicies');
+
+            cy.intercept('GET', `**/apis/${apiId}`, (req) => {
+                req.continue((res) => {
+                    res.body.policies = savedPolicies;
+                });
+            }).as('getApi');
+
+            cy.intercept('PUT', `**/apis/${apiId}`, (req) => {
+                savedPolicies = req.body.policies || [];
+                req.reply({ statusCode: 200, body: { ...req.body, policies: savedPolicies } });
+            }).as('saveApi');
+
+            // Step 2: Navigate to the Subscriptions page
+            cy.visit(`/publisher/apis/${apiId}/overview`);
+            cy.get('#itest-api-details-portal-config-acc').click();
+            cy.get('#left-menu-itemsubscriptions').click();
+            cy.wait('@getPolicies');
+            cy.wait('@getPolicies');
+
+            // Step 3: Change rows per page to 10 (settings.json may default to a larger value)
+            cy.get('div[class*="MuiTablePagination-select"]').first().click();
+            cy.get('[role="listbox"] li[data-value="10"]').click();
+            cy.wait('@getPolicies');
+
+            // Step 4: Verify page 1 is shown, pagination is active, no false migration warnings
+            cy.get('[data-testid="policy-checkbox-policy01"]').should('exist');
+            cy.get('[data-testid="policy-checkbox-platinumpolicy01"]').should('not.exist');
+            cy.get('button[aria-label="Go to next page"]').should('not.be.disabled');
+            cy.contains('Following policies are migrated').should('not.exist');
+
+            // Step 5: Navigate to page 2
+            cy.get('button[aria-label="Go to next page"]').click();
+            cy.wait('@getPolicies');
+
+            // Step 6: Select PlatinumPolicy01 on page 2 and Save
+            cy.get('[data-testid="policy-checkbox-platinumpolicy01"]').click();
+            cy.get('[data-testid="policy-checkbox-platinumpolicy01"] input').should('be.checked');
+            cy.get('#subscriptions-save-btn').click();
+            cy.wait('@saveApi');
+
+            // Step 7: Go back to page 1 via the previous page button
+            cy.get('button[aria-label="Go to previous page"]').click();
+            cy.wait('@getPolicies');
+
+            // Step 8: Page 1 must not show the migration warning
+            cy.contains('Following policies are migrated').should('not.exist');
+            cy.get('[data-testid="policy-checkbox-platinumpolicy01"]').should('not.exist');
+            cy.get('[data-testid="policy-checkbox-policy01"]').should('exist');
+
+            // Step 9: Navigate to page 2 and verify PlatinumPolicy01 is still selected
+            cy.get('button[aria-label="Go to next page"]').click();
+            cy.wait('@getPolicies');
+            cy.get('[data-testid="policy-checkbox-platinumpolicy01"] input').should('be.checked');
+        });
+    });
+
+    afterEach(() => {
+        if (testApiId) {
+            Utils.deleteAPI(testApiId);
+        }
+    });
+});


### PR DESCRIPTION
### Purpose

When viewing subscription policies for an async API with pagination enabled, selected policies from other pages were incorrectly shown with the pre-migration warning.

#### Root cause

The migration check compared api.policies (saved policies for API) against subscriptionPolicies which only holds the current page's results. Any selected policy not present on the currently visible page was incorrectly treated as migrated policy.

#### implementation details

On page load, fetch the complete async policy list and use that for the migration check.