### PR TITLE
Fix .ts/.tsx UI overrides being silently ignored in Publisher and Devportal

### DIFF
--- a/portals/devportal/src/main/webapp/webpack.config.js
+++ b/portals/devportal/src/main/webapp/webpack.config.js
@@ -150,6 +150,9 @@ module.exports = function (env, argv) {
                                 onlyCompileBundledFiles: true,
                             },
                         },
+                        {
+                            loader: path.resolve('loader.js'),
+                        },
                     ],
                 },
                 {

--- a/portals/publisher/src/main/webapp/webpack.config.js
+++ b/portals/publisher/src/main/webapp/webpack.config.js
@@ -179,6 +179,9 @@ module.exports = (env, argv) => {
                                 onlyCompileBundledFiles: true,
                             },
                         },
+                        {
+                            loader: path.resolve('loader.js'),
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
### Problem
`.ts`/`.tsx` files placed under `<webapp>/override/src` for Advanced UI Customization are silently ignored. The build completes with exit code 0 and emits no error or warning, so the missing override is very hard to detect. `.js`/`.jsx` overrides are applied correctly.

Related Issue : Fixes https://github.com/wso2/api-manager/issues/5161

### Root cause
`loader.js` performs the `source/src` → `override/src` substitution, but it is registered only on the `/\.(js|jsx)$/` webpack rule. It is absent from the `/\.tsx?$/` rule, so TypeScript modules bypass the substitution entirely and are compiled straight from `source/src`. 

### Fix
Register `loader.js` on the `/\.tsx?$/` rule in both portals. It is listed **after** `ts-loader` so it runs **first** - webpack executes a `use` array bottom-to-top, substituting the override before TypeScript compiles it. This mirrors the ordering already used by the adjacent `/\.(js|jsx)$/` rule.

- `portals/publisher/src/main/webapp/webpack.config.js`
- `portals/devportal/src/main/webapp/webpack.config.js`

The Admin portal is unaffected: no `.tsx?` rule, no `ts-loader`, no `tsconfig.json`, no `override/` directory, zero TypeScript sources.

### Behaviour change
Because override TypeScript is now genuinely compiled, it is also type-checked against the web app's `tsconfig.json` (`strict` mode). A `.ts`/`.tsx` file under `override/src` containing a type error previously built green because it was
never read, it will now fail the build with a TypeScript diagnostic. Nothing changes until the web application is next rebuilt.

### Testing
Verified per portal by overriding a matched `.tsx`/`.jsx` pair with distinct sentinel strings and grepping `site/public/dist/*.bundle.js`:

| | before | after |
|---|---|---|
| `.tsx` override sentinel | 0 | 1 |
| `.jsx` override sentinel (control) | 1 | 1 |
| original literal | present | absent |

The `.jsx` control passing in both builds isolates the failure to the TypeScript path. Confirmed for `build:prod` and `build:dev`, and at rendered-UI level in a running server. Also confirmed a type-broken override `.tsx` now fails the build
(`TS2322`), substantiating the behaviour-change note.