### PR TITLE
Make devportal listing left menu initial state configurable via userTheme.json

### DIFF
--- a/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Apis/Listing/CommonListing.jsx
@@ -232,6 +232,7 @@ class CommonListingLegacy extends React.Component {
     constructor(props) {
         super(props);
         let { defaultApiView } = props.theme.custom;
+        const { apiLeftMenu } = props.theme.custom;
         this.showToggle = true;
         if (typeof defaultApiView === 'object' && defaultApiView.length > 0) {
             if (defaultApiView.length === 1) { // We will disable the other
@@ -243,7 +244,7 @@ class CommonListingLegacy extends React.Component {
         }
         this.state = {
             listType: defaultApiView,
-            showLeftMenu: false,
+            showLeftMenu: apiLeftMenu?.showByDefault ?? false,
             isMonetizationEnabled: false,
             isRecommendationEnabled: false,
             allTags: [],

--- a/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
+++ b/portals/devportal/src/main/webapp/source/src/app/data/defaultTheme.js
@@ -96,6 +96,11 @@ const DefaultConfigurations = {
             tableBodyOddBackgrund: '#efefef',
             tableBodyEvenBackgrund: '#fff',
         },
+        apiLeftMenu: {
+            // Open the Tags / API Categories left pane by default on page load.
+            // Overridable via site/public/theme/userTheme.json.
+            showByDefault: false,
+        },
         overview: {
             titleIconColor: '#89b4ff',
             titleIconSize: 16,


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/5178

## Problem

`showLeftMenu` in the devportal's `CommonListing.jsx` was hardcoded to `false`, so the left navigation pane (Tags / API Categories) was always collapsed on initial page load. There was no way to change that default without a React component override and a custom build.

## Change

Exposes the pane's initial state as a theme property, `custom.apiLeftMenu.showByDefault`, overridable from `userTheme.json`:

```json
{
  "custom": {
    "apiLeftMenu": {
      "showByDefault": true
    }
  }
}
```

2 files, 7 insertions, 1 deletion:
- `defaultTheme.js` — new `apiLeftMenu: { showByDefault: false }` block
- `CommonListing.jsx` — `const { apiLeftMenu } = props.theme.custom;` and `showLeftMenu: apiLeftMenu?.showByDefault ?? false,`

**Backward compatible by construction.** The shipped default `false` is identical to the hardcoded literal it replaces, so any deployment that does not opt in renders exactly as before. `apiLeftMenu?.` plus `?? false` keeps an existing `userTheme.json` that has no `apiLeftMenu` key from throwing. No backend, JSP or `web.xml` change — the theme was already delivered to the browser and merged into `theme.custom`; the listing simply never read it. The runtime toggle is untouched: the theme sets only the *initial* state.

## Please note — `apiLeftMenu` also governs the MCP Servers listing

`CommonListing` is imported by both `Apis.jsx` and `MCPServers.jsx`, so this key controls the pane on `/devportal/mcp-servers` as well as `/devportal/apis`. Confirmed at runtime (case (d) below).

Flagging rather than renaming unilaterally: an `api`-prefixed key governing a non-API listing may not be what we want long term. **Renaming is free now and a compatibility commitment once this ships**, so if it should be something listing-neutral, this is the moment.

## Testing

Playwright against a `wso2am-4.7.0-SNAPSHOT` pack whose expanded devportal was replaced with a `npm run build:prod` build of this source. Build exit 0, 67 bundles, no errors. Every case asserted the served `const Configurations` first, so no case could pass against a stale theme. Assertions are the two mutually exclusive markers `.api-listing-left-menu` (open) / `.api-listing-left-menu-hidden` (collapsed).

| # | `custom.apiLeftMenu` | Route | Expected | Result |
|---|---|---|---|---|
| (a) | absent | `/devportal/apis` | COLLAPSED | PASS — open=0, hidden=1 |
| (b) | `showByDefault: true` | `/devportal/apis` | EXPANDED on load, zero clicks | PASS — open=1, hidden=0 |
| (c) | `showByDefault: false` | `/devportal/apis` | COLLAPSED | PASS |
| (d) | `showByDefault: true` | `/devportal/mcp-servers` | EXPANDED | PASS |
| (e) | within each of (a)–(d) | both routes | slider flips both directions | PASS |

Case (a) is the backward-compatibility gate. Additional checks: `null` value, non-boolean values, and `showByDefault: true` with no tags and no categories (neither pane renders, so the new default cannot produce an empty open pane).

The one console error observed on every load (`IsAnonymousModeEnabled`, `DevPortal.jsx:104-105`) was proven pre-existing by restoring the pristine shipped bundles and reproducing it identically. It is unrelated to this change and worth a separate issue.

**No automated tests ship with this change.** A rendering suite was written and passed, but it required adding `jest-environment-jsdom` plus a ~481-line `package-lock.json` change, which seemed disproportionate for a one-line behavioural change. Happy to add it back if you would prefer it in this PR.

## Note on `en.json`

`npm run build:prod` runs `i18n:en`, which regenerates `site/public/locales/en.json` with two message ids that exist in master's sources but were never re-extracted (`Applications.Details.Subscriptions.error.loading.subscriptions`, `Shared.AppsAndKeys.KeyConfCiguration.required.empty.error`). Unrelated to this change — no user-facing strings are added here — so the file was reverted to keep this PR to two files. Worth a separate re-extraction.
