### PR TITLE
Fix Policies tab container resize on tab switch

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Policies/Policies.tsx
@@ -66,6 +66,7 @@ const StyledApiOperationContextProvider = styled(ApiOperationContextProvider)(
 
         [`& .${classes.paper}`]: {
             padding: '2px',
+            minHeight: '400px',
         },
 
         [`& .${classes.ccTypography}`]: {


### PR DESCRIPTION
Fixes wso2/api-manager#4725

The Policies page container (`.paper` class in Policies.tsx) had no minHeight,
so its size was determined entirely by the currently visible tab's content.
For OpenAI API / AzureAIFoundryAPI (which have few operations), the
Operation-level Policies tab renders much less content than the API-level tab,
causing the container to visibly shrink/resize when switching tabs.

Fix: added a minHeight to the .paper class so the container stays a
consistent size regardless of tab content.