### PR TITLE
Remove warning for path parameters in WebSub topic operations

### DIFF
--- a/portals/publisher/src/main/webapp/site/public/locales/en.json
+++ b/portals/publisher/src/main/webapp/site/public/locales/en.json
@@ -1670,7 +1670,6 @@
   "Apis.Details.Resources.components.AddOperation.operation.target.topic.name.label": "Topic Name",
   "Apis.Details.Resources.components.AddOperation.operation.target.uri.pattern": "Enter URI pattern",
   "Apis.Details.Resources.components.AddOperation.operation.target.uri.pattern.label": "URI Pattern",
-  "Apis.Details.Resources.components.AddOperation.operation.topic.cannot.have.path.params.warning": "WebSub topic can't have path parameters",
   "Apis.Details.Resources.components.AddOperation.option": "OPTIONS",
   "Apis.Details.Resources.components.AddOperation.option.title": "Select the OPTIONS method to send OPTIONS calls to the backend. If the OPTIONS method is not selected, OPTIONS calls will be returned from the Gateway with allowed methods.",
   "Apis.Details.Resources.components.AddParameter.clear.inputs.tooltip": "Clear inputs",

--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AddOperation.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Resources/components/AddOperation.jsx
@@ -224,14 +224,6 @@ function AddOperation(props) {
             }));
             return;
         }
-        if (api && api.type && api.type.toLowerCase() === 'websub'
-            && APIValidation.websubOperationTarget.validate(newOperations.target).error !== null) {
-            Alert.warning(intl.formatMessage({
-                id: 'Apis.Details.Resources.components.AddOperation.operation.topic.cannot.have.path.params.warning',
-                defaultMessage: "WebSub topic can't have path parameters",
-            }));
-            return;
-        }
         if (newOperations.target.indexOf(' ') >= 0) {
             Alert.warning(intl.formatMessage({
                 id: 'Apis.Details.Resources.components.AddOperation.operation.target.cannot.contains.white.spaces',


### PR DESCRIPTION
## Purpose

WebSub APIs now support wildcard topics (e.g. `/orders/*`) through URI template
matching in the gateway. The publisher still rejects a WebSub operation target
containing path parameters, so those topics cannot be added from the UI.

This removes the client-side `websubOperationTarget` validation in
`AddOperation.jsx` and the now-unused locale entry.

## Related

- Gateway-side change: https://github.com/wso2/carbon-apimgt/pull/13857
- Runtime template: https://github.com/wso2/product-apim/pull/14293
- Ports https://github.com/wso2-support/apim-apps/pull/687 (merged to `support-9.3.111.x-full`) to master
- Public issue: https://github.com/wso2/api-manager/issues/4948

## Notes

Opened as a draft: this should be merged together with the carbon-apimgt and
product-apim changes, since the wildcard topics it unblocks are only matched
once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
