### PR TITLE
fix intermittent deployment page crash issue

### DIFF
--- a/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
+++ b/portals/publisher/src/main/webapp/source/src/app/components/Apis/Details/Environments/Environments.jsx
@@ -2402,7 +2402,7 @@ export default function Environments() {
         });
         const gatewayRevisions = deployingGateway?.revisions;
 
-        if (!gatewayRevisions.length) {
+        if (!gatewayRevisions || gatewayRevisions.length === 0) {
             // Content to display when there is no revision
             return (
                 <FormattedMessage
@@ -2573,7 +2573,7 @@ export default function Environments() {
         return undefined;
     }, [allEnvRevision, settings]);
 
-    if (!noEnv && (isLoading || selectedVhosts === null)) {
+    if (!noEnv && (isLoading || selectedVhosts === null || !allEnvRevision)) {
         return <Progress per={80} message='Loading app settings ...' />;
     }
 


### PR DESCRIPTION
### Purpose

- Resolves : https://github.com/wso2/api-manager/issues/5202

### Problem

The Publisher Deployments page renders from two revision calls that fire in parallel with no ordering guarantee:

| Call | Populates |
|---|---|
| `/revisions` | `allRevisions` |
| `/revisions?query=deployed:true` | `allEnvRevision` |

`Environments.jsx` starts rendering its gateway table as soon as the portal settings are in, without waiting for `allEnvRevision`. So when `/revisions` resolves first, the re-render it triggers runs while `allEnvRevision` is still `null` and both values derived from it (`allEnvRevisionMapping`, `allEnvDeployments`) are `null` too. `getDeployedRevisionComponent` then reads `.length` on an undefined revisions list and throws NPE.

Since nothing orders the two responses, the crash is a coin flip on every load, which is why refreshing eventually works.

### Fix

- **`Environments.jsx`** — include `allEnvRevision` in the component's existing loading gate, so the gateway tables are never rendered before the deployed-revision data exists. This is the root-cause fix: it also removes the null dereferences of `allEnvDeployments` further down the same render path, which a guard-only change would have exposed next.
- **`Environments.jsx`** — add the missing null guard in `getDeployedRevisionComponent`, matching its sibling `getDeployedRevisionStatusComponent`, which already had it.