### PR TITLE
Add UI integration tests

### DIFF
--- a/tests/cypress/e2e/devportal/005-mcp-servers/00-browse-mcp-servers-in-devportal.cy.js
+++ b/tests/cypress/e2e/devportal/005-mcp-servers/00-browse-mcp-servers-in-devportal.cy.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env('largeTimeout') || 30000 };
+
+/**
+ * Creates, deploys, and publishes an MCP server using Utils methods.
+ * Returns { mcpId, name }.
+ */
+function createPublishedMcpServer() {
+    const name = `TestMCP${Utils.getRandomString(4)}`;
+    return Utils.addMCPServerFromEndpointConfig({ name }).then((mcpId) => {
+        expect(mcpId, 'MCP server created').to.be.a('string');
+        return Utils.addMCPRevision(mcpId).then((revisionId) => {
+            return Utils.deployMCPRevision(mcpId, revisionId).then(() => {
+                return Utils.publishMCPServer(mcpId).then(() => ({ mcpId, name }));
+            });
+        });
+    });
+}
+
+describe("devportal-005-00 : Browse published MCP Servers in DevPortal", () => {
+    const { publisher, developer, password } = Utils.getUserInfo();
+    let mcpId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    // Login as publisher before each test to establish a session for MCP creation.
+    // The test itself switches to the developer role via logout+login.
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Published MCP Server appears in DevPortal listing and can be navigated to", () => {
+        createPublishedMcpServer().then(({ mcpId: id, name }) => {
+            mcpId = id;
+
+            // Switch to DevPortal as developer
+            cy.logoutFromPublisher();
+            cy.loginToDevportal(developer, password);
+
+            cy.visit('/devportal/mcp-servers?tenant=carbon.super', largeTimeout);
+            cy.get('#commonListing', largeTimeout).should('be.visible');
+
+            // The published MCP server should appear in the listing
+            cy.contains(name, largeTimeout).should('be.visible');
+
+            // Clicking the card should navigate to the MCP server overview in DevPortal
+            cy.contains(name, largeTimeout).click();
+            cy.url({ timeout: 15000 }).should('match', /\/devportal\/mcp-servers\/[^/]+\/overview/);
+        });
+    });
+
+    afterEach(() => {
+        if (mcpId) {
+            // The test switched to the developer/DevPortal session. logoutFromPublisher()
+            // only ends the publisher app's own session, not the underlying SSO session, so
+            // re-visiting /publisher auto-authenticates as whoever is still logged in
+            // (developer) instead of showing a fresh login form - cy.loginToPublisher would
+            // silently fail here. Delete via admin Basic Auth instead, sidestepping the
+            // cookie/session dance entirely.
+            const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+            cy.request({
+                method: 'DELETE',
+                url: `${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpId}`,
+                auth: { username: carbonUsername, password: carbonPassword },
+                failOnStatusCode: false,
+            });
+            mcpId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/devportal/005-mcp-servers/00-browse-mcp-servers-in-devportal.cy.js
+++ b/tests/cypress/e2e/devportal/005-mcp-servers/00-browse-mcp-servers-in-devportal.cy.js
@@ -40,8 +40,6 @@ describe("devportal-005-00 : Browse published MCP Servers in DevPortal", () => {
     const { publisher, developer, password } = Utils.getUserInfo();
     let mcpId;
 
-    Cypress.on('uncaught:exception', () => false);
-
     // Login as publisher before each test to establish a session for MCP creation.
     // The test itself switches to the developer role via logout+login.
     beforeEach(() => {

--- a/tests/cypress/e2e/devportal/005-mcp-servers/01-subscribe-to-mcp-server.cy.js
+++ b/tests/cypress/e2e/devportal/005-mcp-servers/01-subscribe-to-mcp-server.cy.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env('largeTimeout') || 30000 };
+
+/**
+ * Creates, deploys, and publishes an MCP server using Utils methods.
+ */
+function createPublishedMcpServer() {
+    const name = `TestMCP${Utils.getRandomString(4)}`;
+    return Utils.addMCPServerFromEndpointConfig({ name }).then((mcpId) => {
+        expect(mcpId, 'MCP server created').to.be.a('string');
+        return Utils.addMCPRevision(mcpId).then((revisionId) => {
+            return Utils.deployMCPRevision(mcpId, revisionId).then(() => {
+                return Utils.publishMCPServer(mcpId).then(() => ({ mcpId, name }));
+            });
+        });
+    });
+}
+
+describe("devportal-005-01 : Subscribe to an MCP Server from the DevPortal", () => {
+    const { publisher, developer, password } = Utils.getUserInfo();
+    const appName = Utils.generateName();
+    const appDescription = 'Test app for MCP Server subscription';
+    let mcpId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    // Login as publisher to establish a session for MCP creation.
+    // The test itself switches to developer to perform the subscription.
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Subscribe to a published MCP Server and verify subscription appears in the list", () => {
+        createPublishedMcpServer().then(({ mcpId: id }) => {
+            mcpId = id;
+
+            cy.logoutFromPublisher();
+            cy.loginToDevportal(developer, password);
+
+            // Create an application in the DevPortal
+            cy.createApp(appName, appDescription);
+
+            // Navigate to the MCP Server overview in the DevPortal
+            cy.visit(`/devportal/mcp-servers/${mcpId}/overview?tenant=carbon.super`, largeTimeout);
+            cy.get('#left-menu-credentials', largeTimeout).click();
+
+            // Subscribe using the newly created application
+            cy.get('#application-subscribe', largeTimeout).click();
+            cy.get('.MuiAutocomplete-popper li', largeTimeout).contains(appName).click();
+            cy.get('#subscribe-to-api-btn').click();
+
+            // Subscription should appear in the subscriptions table
+            cy.get('#subscription-table td', largeTimeout).contains(appName).should('exist');
+        });
+    });
+
+    afterEach(() => {
+        // Delete app first to remove subscriptions, then the published MCP can be deleted directly.
+        cy.deleteApp(appName);
+        if (mcpId) {
+            Utils.deleteMCPServer(mcpId);
+            mcpId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/devportal/005-mcp-servers/02-devportal-mcp-playground.cy.js
+++ b/tests/cypress/e2e/devportal/005-mcp-servers/02-devportal-mcp-playground.cy.js
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env('largeTimeout') || 30000 };
+
+/**
+ * Mocks the actual tool invocation (tools/call) with a canned success result, leaving
+ * initialize/notifications/tools-list to pass through untouched - the gateway answers
+ * those directly from the MCP server's own stored metadata, never touching the backend.
+ * tools/call is the only step that would otherwise reach the (placeholder, unreachable)
+ * backend URL, so intercepting just that call here means no real backend is ever needed.
+ */
+function mockToolCallSuccess() {
+    cy.intercept('POST', '**/mcp', (req) => {
+        if (req.body && req.body.method === 'tools/call') {
+            req.reply({
+                statusCode: 200,
+                body: {
+                    jsonrpc: '2.0',
+                    id: req.body.id,
+                    result: {
+                        content: [{ type: 'text', text: JSON.stringify({ mockToolResult: 'success-verified' }) }],
+                        isError: false,
+                    },
+                },
+            });
+        } else {
+            req.continue();
+        }
+    }).as('mcpToolCall');
+}
+
+describe("devportal-005-02 : DevPortal MCP Playground — connect and invoke a tool", () => {
+    const { publisher, developer, password } = Utils.getUserInfo();
+    const appName = Utils.generateName();
+    const appDescription = 'Test app for MCP Playground';
+    let mcpId;
+    let sourceApiId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("MCP Playground connects and invokes a tool after subscribing", () => {
+        Utils.createMockToolMcpServer().then(({ mcpId: createdId, sourceApiId: createdSrcId }) => {
+            mcpId = createdId;
+            sourceApiId = createdSrcId;
+
+            mockToolCallSuccess();
+
+            // Switch to the DevPortal as the developer user.
+            cy.logoutFromPublisher();
+            cy.loginToDevportal(developer, password);
+
+            // Create an application and subscribe to the MCP server.
+            cy.createApp(appName, appDescription);
+            cy.visit(`/devportal/mcp-servers/${mcpId}/overview?tenant=carbon.super`, largeTimeout);
+            cy.get('#left-menu-credentials', largeTimeout).click();
+            cy.get('#application-subscribe', largeTimeout).click();
+            cy.get('.MuiAutocomplete-popper li', largeTimeout).contains(appName).click();
+            cy.get('#subscribe-to-api-btn').click();
+            cy.get('#subscription-table td', largeTimeout).contains(appName).should('exist');
+
+            // Generate production OAuth keys for the application so that
+            // "GET TEST KEY" in the playground Configuration drawer can issue a token.
+            cy.get(`#${appName}-PK`).click();
+            cy.get('#generate-keys').click();
+            cy.get('[data-testid="create-secret-button"]', largeTimeout).should('be.visible').and('not.be.disabled').click();
+            // The generated secret is only shown once, in this dialog — capture it now,
+            // since "GET TEST KEY" below re-prompts for the consumer secret (multiple secrets mode).
+            cy.get('[data-testid="secret-dialog-close"]', { timeout: 30000 }).should('be.visible');
+            cy.get('#bootstrap-input').invoke('val').then((generatedSecret) => {
+                Cypress.env('consumerSecret', generatedSecret);
+            });
+            cy.get('[data-testid="secret-dialog-close"]').click();
+            cy.get('#consumer-key', largeTimeout).should('exist');
+
+            // Navigate to the MCP Playground.
+            cy.visit(`/devportal/mcp-servers/${mcpId}/overview?tenant=carbon.super`, largeTimeout);
+            cy.contains('button', /try out/i, largeTimeout).click();
+            cy.url({ timeout: 15000 }).should('match', /mcp-playground/);
+
+            // The Connect button is disabled until an access token is configured.
+            // Open the Configuration drawer and generate a test token.
+            cy.get('[data-testid="configuration-button"]', largeTimeout).should('be.visible').click();
+            cy.get('#api-chat-configure-key-drawer', largeTimeout).should('be.visible');
+
+            // Wait for TryOutController to load subscriptions and key state, then generate a token.
+            cy.get('#gen-test-key', { timeout: 30000 }).should('not.be.disabled').click();
+            // Multiple-secrets mode re-prompts for the consumer secret before issuing the token.
+            cy.get('#consumerSecretInput', { timeout: 30000 }).should('be.visible').clear().then(($input) => {
+                const secretToType = Cypress.env('consumerSecret');
+                expect(secretToType, 'consumerSecret should be set before generating the test key').to.exist;
+                cy.wrap($input).type(secretToType);
+            });
+            cy.get('[role="dialog"]').contains('button', 'Generate').should('not.be.disabled').click();
+            cy.get('#accessTokenInput', { timeout: 30000 }).invoke('val').should('not.be.empty');
+
+            // Close the drawer — the token is now wired to the playground.
+            cy.get('[data-testid="key-details-save"]').click();
+
+            // Connect to the MCP server.
+            cy.contains('button', 'Connect', largeTimeout).should('not.be.disabled').click();
+            cy.contains('button', 'Disconnect', { timeout: 30000 }).should('be.visible');
+
+            // Tools are not fetched automatically — click "List Tools" to retrieve them.
+            cy.contains('button', 'List Tools', { timeout: 15000 }).click();
+
+            cy.contains(Utils.getMockToolName(), { timeout: 15000 }).click();
+            cy.contains('button', 'Run Tool', { timeout: 15000 }).should('not.be.disabled').click();
+
+            // The mocked tools/call response should render as a successful result.
+            cy.wait('@mcpToolCall');
+            cy.contains('Tool Result', { timeout: 30000 }).should('be.visible');
+            cy.contains('success-verified', { timeout: 15000 }).should('be.visible');
+        });
+    });
+
+    afterEach(() => {
+        const baseUrl = Cypress.config().baseUrl;
+        const { carbonUsername, carbonPassword } = Utils.getUserInfo();
+
+        // Deletes the MCP server and source API via admin Basic Auth. logoutFromPublisher()
+        // only ends the publisher app's own session, not the underlying SSO session, so
+        // re-visiting /publisher auto-authenticates as whoever is still logged in
+        // (developer) instead of showing a fresh login form - cy.loginToPublisher would
+        // silently fail here. Basic Auth sidesteps the cookie/session dance entirely.
+        //
+        // Deleting the application doesn't synchronously clear its subscription record -
+        // an active subscription blocks MCP server deletion with a 409 for a short window
+        // after the app delete - so retry a few times with a short wait to absorb that
+        // propagation delay before giving up.
+        const deleteMcpServerWithRetry = (idToDelete, retriesLeft) => {
+            if (retriesLeft === undefined) retriesLeft = 5;
+            cy.request({
+                method: 'DELETE',
+                url: `${baseUrl}/api/am/publisher/v4/mcp-servers/${idToDelete}`,
+                auth: { username: carbonUsername, password: carbonPassword },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                if (resp.status === 409 && retriesLeft > 0) {
+                    cy.wait(2000);
+                    deleteMcpServerWithRetry(idToDelete, retriesLeft - 1);
+                }
+            });
+        };
+
+        const deleteApiResources = () => {
+            if (mcpId) {
+                deleteMcpServerWithRetry(mcpId);
+                mcpId = null;
+            }
+            if (sourceApiId) {
+                cy.request({
+                    method: 'DELETE',
+                    url: `${baseUrl}/api/am/publisher/v4/apis/${sourceApiId}`,
+                    auth: { username: carbonUsername, password: carbonPassword },
+                    failOnStatusCode: false,
+                });
+                sourceApiId = null;
+            }
+        };
+
+        // cy.request() only carries the browser's cookies, not the SPA's own bearer-token
+        // auth, so it can't authenticate against the devportal API as the developer.
+        // Obtain a real developer OAuth token via DCR + password grant instead.
+        cy.request({
+            method: 'POST',
+            url: `${baseUrl}/client-registration/v0.17/register`,
+            auth: { username: 'developer', password: 'test123' },
+            body: {
+                clientName: 'cleanup-tmp', owner: 'developer', grantType: 'password client_credentials', saasApp: true,
+            },
+            failOnStatusCode: false,
+        }).then((dcrResp) => {
+            const { clientId, clientSecret } = dcrResp.body || {};
+            if (!clientId) {
+                deleteApiResources();
+                return;
+            }
+            cy.request({
+                method: 'POST',
+                url: `${baseUrl}/oauth2/token`,
+                auth: { username: clientId, password: clientSecret },
+                form: true,
+                body: {
+                    grant_type: 'password', username: 'developer', password: 'test123', scope: 'apim:subscribe',
+                },
+                failOnStatusCode: false,
+            }).then((tokenResp) => {
+                const devToken = tokenResp.body && tokenResp.body.access_token;
+                if (!devToken) {
+                    deleteApiResources();
+                    return;
+                }
+                cy.request({
+                    method: 'GET',
+                    url: `${baseUrl}/api/am/devportal/v3/applications?limit=100`,
+                    auth: { bearer: devToken },
+                    failOnStatusCode: false,
+                }).then((appsResp) => {
+                    const app = (appsResp.body.list || []).find((a) => a.name === appName);
+                    if (!app) {
+                        deleteApiResources();
+                        return;
+                    }
+                    cy.request({
+                        method: 'DELETE',
+                        url: `${baseUrl}/api/am/devportal/v3/applications/${app.applicationId}`,
+                        auth: { bearer: devToken },
+                        failOnStatusCode: false,
+                    }).then(() => deleteApiResources());
+                });
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/publisher/004-endpoints/11-advanced-endpoint-duration-default-empty.cy.js
+++ b/tests/cypress/e2e/publisher/004-endpoints/11-advanced-endpoint-duration-default-empty.cy.js
@@ -28,8 +28,6 @@ describe("publisher-004-11 : Advanced endpoint config Duration field is empty by
     const endpoint = 'https://petstore.swagger.io/v2/store/inventory';
     let testApiId;
 
-    Cypress.on('uncaught:exception', () => false);
-
     beforeEach(() => {
         cy.loginToPublisher(publisher, password);
     });
@@ -108,7 +106,11 @@ describe("publisher-004-11 : Advanced endpoint config Duration field is empty by
             // Advanced Config's own "Save" button only stages the value in local component
             // state - persist it for real via the endpoint page's Save button, then reload
             // the page to force a fresh fetch from the backend before re-checking the value.
+            // handleSave() doesn't await updateAPI(), so wait for the PUT to actually
+            // complete before reloading - otherwise the reload can race the persist.
+            cy.intercept('PUT', `**/apis/${apiId}`).as('saveEndpointConfig');
             cy.get('#endpoint-save-btn').click();
+            cy.wait('@saveEndpointConfig');
 
             cy.visit(`/publisher/apis/${apiId}/overview`);
             cy.get('#itest-api-details-api-config-acc').click();

--- a/tests/cypress/e2e/publisher/004-endpoints/11-advanced-endpoint-duration-default-empty.cy.js
+++ b/tests/cypress/e2e/publisher/004-endpoints/11-advanced-endpoint-duration-default-empty.cy.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+// Test for: "Fix misleading hardcoded 30000 in Advanced Endpoint Configuration Duration field"
+// Before the fix, the Duration (ms) field was pre-populated with '30000' as a real value,
+// misleading users into thinking 30000ms was their saved timeout. After the fix, the field
+// is empty by default and 30000 is shown only as placeholder hint text.
+
+describe("publisher-004-11 : Advanced endpoint config Duration field is empty by default with placeholder 30000", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    const endpoint = 'https://petstore.swagger.io/v2/store/inventory';
+    let testApiId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    afterEach(() => {
+        if (testApiId) {
+            Utils.deleteAPI(testApiId);
+            testApiId = null;
+        }
+    });
+
+    it.only("Duration (ms) field is empty (not 30000) when first opening Advanced Config for production endpoint", () => {
+        Utils.addAPI({}).then((apiId) => {
+            testApiId = apiId;
+            cy.visit(`/publisher/apis/${apiId}/overview`);
+            cy.get('#itest-api-details-api-config-acc').click();
+            cy.get('#left-menu-itemendpoints').click();
+            cy.get('[data-testid="http/restendpoint-add-btn"]').click();
+
+            cy.get('#production-endpoint-checkbox').click();
+            cy.get('#production_endpoints').focus().type(endpoint);
+
+            // Open Advanced Endpoint Configuration for the production endpoint
+            cy.get('#production_endpoints-endpoint-configuration-icon-btn').click();
+
+            // Duration field must be empty — not '30000'
+            cy.get('#duration-input').should('have.value', '');
+
+            // The placeholder should be '30000' to hint at the default
+            cy.get('#duration-input').should('have.attr', 'placeholder', '30000');
+
+            cy.get('#endpoint-configuration-submit-btn').click();
+        });
+    });
+
+    it.only("Duration (ms) field is empty (not 30000) when first opening Advanced Config for sandbox endpoint", () => {
+        Utils.addAPI({}).then((apiId) => {
+            testApiId = apiId;
+            cy.visit(`/publisher/apis/${apiId}/overview`);
+            cy.get('#itest-api-details-api-config-acc').click();
+            cy.get('#left-menu-itemendpoints').click();
+            cy.get('[data-testid="http/restendpoint-add-btn"]').click();
+
+            cy.get('#sandbox-endpoint-checkbox').click();
+            cy.get('#sandbox_endpoints').focus().type(endpoint);
+
+            // Open Advanced Endpoint Configuration for the sandbox endpoint
+            cy.get('#sandbox_endpoints-endpoint-configuration-icon-btn').click();
+
+            // Duration field must be empty — not '30000'
+            cy.get('#duration-input').should('have.value', '');
+
+            // The placeholder should be '30000' to hint at the default
+            cy.get('#duration-input').should('have.attr', 'placeholder', '30000');
+
+            cy.get('#endpoint-configuration-submit-btn').click();
+        });
+    });
+
+    it.only("A saved Duration value is preserved on re-open (not reset to 30000 or blank)", () => {
+        Utils.addAPI({}).then((apiId) => {
+            testApiId = apiId;
+            cy.visit(`/publisher/apis/${apiId}/overview`);
+            cy.get('#itest-api-details-api-config-acc').click();
+            cy.get('#left-menu-itemendpoints').click();
+            cy.get('[data-testid="http/restendpoint-add-btn"]').click();
+
+            cy.get('#production-endpoint-checkbox').click();
+            cy.get('#production_endpoints').focus().type(endpoint);
+
+            // Open Advanced Config, set a custom duration, and stage it
+            cy.get('#production_endpoints-endpoint-configuration-icon-btn').click();
+            cy.get('#duration-input').clear().type('5000');
+            cy.get('#endpoint-configuration-submit-btn').click();
+
+            // Advanced Config's own "Save" button only stages the value in local component
+            // state - persist it for real via the endpoint page's Save button, then reload
+            // the page to force a fresh fetch from the backend before re-checking the value.
+            cy.get('#endpoint-save-btn').click();
+
+            cy.visit(`/publisher/apis/${apiId}/overview`);
+            cy.get('#itest-api-details-api-config-acc').click();
+            cy.get('#left-menu-itemendpoints').click();
+
+            // Re-open and verify the saved value survived the reload
+            cy.get('#production_endpoints-endpoint-configuration-icon-btn').click();
+            cy.get('#duration-input').should('have.value', '5000');
+            cy.get('#endpoint-configuration-submit-btn').click();
+        });
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/02-create-mcp-server-from-openapi-url.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/02-create-mcp-server-from-openapi-url.cy.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("publisher-023-00 : Create MCP Server from OpenAPI URL", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    const mcpName = Utils.generateName();
+    const mcpContext = `/${mcpName.toLowerCase().replace(/-/g, '')}`;
+    const mcpVersion = '1.0.0';
+    const openApiUrl = 'https://petstore3.swagger.io/api/v3/openapi.json';
+    const endpoint = 'https://petstore3.swagger.io/api/v3';
+    let createdMcpId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Creates MCP Server from OpenAPI URL via the creation wizard", () => {
+        // Navigate directly to the OpenAPI import wizard (bypasses the landing page card click)
+        cy.visit('/publisher/mcp-servers/create/import-api-definition', { timeout: 30000 });
+
+        // Step 1: Provide OpenAPI URL
+        // Validation fires on blur (onBlur event), not on keystroke.
+        // Find the actual <input> inside the TextField wrapper and type + blur it directly.
+        cy.get('[data-testid="swagger-url-endpoint"]', { timeout: 30000 }).should('be.visible');
+        cy.get('[data-testid="swagger-url-endpoint"] input').clear().type(openApiUrl).blur();
+
+        // Wait for the URL validation indicator (CheckIcon) to appear — confirms validation succeeded
+        cy.get('#url-validated', { timeout: 30000 });
+
+        // Next button becomes enabled after successful validation (allow up to 30s for React update)
+        cy.get('#open-api-create-next-btn', { timeout: 30000 })
+            .should('not.have.class', 'Mui-disabled')
+            .click();
+
+        // Step 2: Tool selection — select all available operations, then proceed
+        // useToolSelection starts with selectedOperations=[], so Next button is disabled until
+        // operations are moved to the selected (right) list.
+        cy.get('input[aria-label="all items selected"]', { timeout: 30000 })
+            .first()
+            .should('not.be.disabled')
+            .click({ force: true });
+        cy.get('button[aria-label="move selected right"]', { timeout: 10000 })
+            .should('not.be.disabled')
+            .click();
+        cy.get('#open-api-create-next-btn', { timeout: 15000 })
+            .should('not.have.class', 'Mui-disabled')
+            .click();
+
+        // Step 3: Fill MCP Server details
+        // Note: when isMCPServer=true, DefaultAPIForm renders the context field with id='context'
+        // (no InputProps.id override), so the inner input's id is 'context', not 'itest-id-apicontext-input'.
+        cy.get('#itest-id-apiname-input', { timeout: 15000 }).clear().type(mcpName);
+        cy.get('#context').clear().type(mcpContext);
+        cy.get('#itest-id-apiversion-input').clear().type(mcpVersion);
+        cy.get('#itest-id-apiendpoint-input').clear().type(endpoint).blur();
+
+        cy.intercept('POST', '**/mcp-servers/generate-from-openapi*').as('createMcp');
+        cy.get('#open-api-create-btn').should('not.have.class', 'Mui-disabled').click();
+        cy.wait('@createMcp', { timeout: 30000 });
+
+        // Should redirect to overview page
+        cy.url({ timeout: 15000 }).should('match', /\/publisher\/mcp-servers\/[^/]+\/overview/);
+        cy.get('#itest-api-name-version', { timeout: 15000 }).should('contain', mcpName);
+
+        // Capture the MCP server ID for cleanup
+        cy.url().then((url) => {
+            const match = url.match(/mcp-servers\/([^/]+)\/overview/);
+            if (match) {
+                createdMcpId = match[1];
+            }
+        });
+    });
+
+    afterEach(() => {
+        if (createdMcpId) {
+            Utils.deleteMCPServer(createdMcpId);
+            createdMcpId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/03-create-mcp-server-from-existing-api.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/03-create-mcp-server-from-existing-api.cy.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("publisher-023-01 : Create MCP Server from an existing API", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    const mcpName = Utils.generateName();
+    const mcpContext = `/${mcpName.toLowerCase().replace(/-/g, '')}`;
+    const mcpVersion = '1.0.0';
+    const sourceApiName = Utils.generateName();
+    let sourceApiId;
+    let createdMcpId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Creates MCP Server by selecting an existing API and its operations", () => {
+        const apiPayload = JSON.stringify({
+            name: sourceApiName,
+            version: '1.0.0',
+            context: `/${sourceApiName.toLowerCase().replace(/[^a-z0-9]/g, '')}`,
+            policies: ['Unlimited'],
+            endpointConfig: {
+                endpoint_type: 'http',
+                sandbox_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                production_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+            },
+            operations: [
+                { target: '/pet', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+                { target: '/pet', verb: 'POST', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+                { target: '/pet/findByStatus', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+            ],
+        });
+
+        Utils.addAPI({ payload: apiPayload }).then((apiId) => {
+                sourceApiId = apiId;
+                expect(sourceApiId, 'Source API created').to.be.a('string');
+
+                // Navigate directly to the existing API wizard with the source API pre-selected.
+                // The wizard reads ?apiId from the URL and auto-fetches the API's operations,
+                // so we skip the fragile autocomplete search-and-click interaction.
+                cy.visit(`/publisher/mcp-servers/create/mcp-from-existing-api?apiId=${sourceApiId}`, { timeout: 30000 });
+
+                // Wait for operations to load into the left transfer list.
+                // ExistingAPIToolSelection fetches operations asynchronously via API.get() —
+                // wait for at least one listitem before interacting with the checkbox.
+                cy.get('[role="listitem"]', { timeout: 30000 }).should('have.length.greaterThan', 0);
+
+                // Select all available operations and move them to the right list
+                cy.get('input[aria-label="all items selected"]').first().click();
+                cy.get('button[aria-label="move selected right"]', { timeout: 10000 })
+                    .should('not.be.disabled')
+                    .click();
+
+                // Next button becomes enabled when operations are selected
+                cy.get('#open-api-create-next-btn', { timeout: 15000 })
+                    .should('not.have.class', 'Mui-disabled')
+                    .click();
+
+                // Step 2: Fill MCP Server details.
+                // mcpServerInputs starts with empty name/context/version in this wizard,
+                // so we must type all fields AND blur the last one to complete form validation.
+                // Note: when isMCPServer=true, context field uses id='context' (no InputProps.id).
+                cy.get('#itest-id-apiname-input', { timeout: 15000 }).clear().type(mcpName);
+                cy.get('#context').clear().type(mcpContext);
+                cy.get('#itest-id-apiversion-input').clear().type(mcpVersion).blur();
+
+                cy.intercept('POST', '**/mcp-servers/generate-from-api').as('createMcp');
+                cy.get('#open-api-create-next-btn').should('not.have.class', 'Mui-disabled').click();
+                cy.wait('@createMcp', { timeout: 30000 });
+
+                // Should redirect to overview page
+                cy.url({ timeout: 15000 }).should('match', /\/publisher\/mcp-servers\/[^/]+\/overview/);
+                cy.get('#itest-api-name-version', { timeout: 15000 }).should('contain', mcpName);
+
+                cy.url().then((url) => {
+                    const match = url.match(/mcp-servers\/([^/]+)\/overview/);
+                    if (match) {
+                        createdMcpId = match[1];
+                    }
+                });
+            });
+    });
+
+    afterEach(() => {
+        if (createdMcpId) {
+            Utils.deleteMCPServer(createdMcpId);
+            createdMcpId = null;
+        }
+        if (sourceApiId) {
+            Utils.deleteAPI(sourceApiId);
+            sourceApiId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/04-mcp-server-tools-management.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/04-mcp-server-tools-management.cy.js
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+describe("publisher-023-03 : MCP Server tools management (edit and add tools)", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    let mcpId;
+    let sourceApiId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    function setupMcpWithTools(suffix) {
+        const srcName = `TestSrc${suffix}`;
+        const srcContext = `/testsrc${suffix}`;
+        const mcpName = `TestMcp${suffix}`;
+        const mcpContext = `/testmcp${suffix}`;
+
+        const srcPayload = JSON.stringify({
+            name: srcName,
+            version: '1.0.0',
+            context: srcContext,
+            policies: ['Unlimited'],
+            endpointConfig: {
+                endpoint_type: 'http',
+                sandbox_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                production_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+            },
+            operations: [
+                { target: '/pet', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+                { target: '/pet', verb: 'POST', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+            ],
+        });
+
+        return Utils.addAPI({ payload: srcPayload }).then((createdSrcId) => {
+            expect(createdSrcId, 'Source API created').to.be.a('string');
+
+            const mcpPayload = JSON.stringify({
+                name: mcpName,
+                version: '1.0.0',
+                context: mcpContext,
+                policies: ['Unlimited'],
+                endpointConfig: {
+                    endpoint_type: 'http',
+                    sandbox_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                    production_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                },
+                transport: ['http', 'https'],
+                visibility: 'PUBLIC',
+                operations: [
+                    {
+                        feature: 'TOOL',
+                        apiOperationMapping: {
+                            apiId: createdSrcId,
+                            apiName: srcName,
+                            apiVersion: '1.0.0',
+                            apiContext: srcContext,
+                            backendOperation: { target: '/pet', verb: 'GET' },
+                        },
+                    },
+                    {
+                        feature: 'TOOL',
+                        apiOperationMapping: {
+                            apiId: createdSrcId,
+                            apiName: srcName,
+                            apiVersion: '1.0.0',
+                            apiContext: srcContext,
+                            backendOperation: { target: '/pet', verb: 'POST' },
+                        },
+                    },
+                ],
+            });
+
+            return Utils.addMCPServerFromEndpointConfig({ payload: mcpPayload }).then((createdMcpId) => {
+                expect(createdMcpId, 'MCP created').to.be.a('string');
+                return cy.wrap({ sourceApiId: createdSrcId, mcpId: createdMcpId });
+            });
+        });
+    }
+
+    it.only("Can expand a tool accordion and edit its name and description, then save", () => {
+        const suffix = Utils.getRandomString(5);
+        const updatedToolName = `renamedtool_${suffix}`;
+        const updatedDescription = `Updated description ${suffix}`;
+
+        setupMcpWithTools(suffix).then(({ sourceApiId: srcId, mcpId: id }) => {
+            sourceApiId = srcId;
+            mcpId = id;
+
+            // In combined runs the publisher session can become invalid during the curl
+            // setup phase (SSO token expiry / redirect state), causing a 401 on the
+            // subsequent cy.visit. Explicitly log out and back in to get a fresh session
+            // before navigating to the MCP overview.
+            cy.logoutFromPublisher();
+            cy.loginToPublisher(publisher, password);
+            cy.visit(`/publisher/mcp-servers/${mcpId}/overview`, { timeout: 30000 });
+
+            // The left-menu item has visibility:hidden during the sidebar animation —
+            // use { force: true } so the click fires even while the animation is in progress.
+            cy.get('#left-menu-tools', { timeout: 30000 }).click({ force: true });
+
+            // Wait for the Save button which confirms the tools page has loaded
+            cy.get('#resources-save-operations', { timeout: 15000 }).should('exist');
+
+            // Wait for at least one tool accordion to appear
+            cy.get('.MuiAccordionSummary-root', { timeout: 30000 }).should('have.length.greaterThan', 0);
+
+            // The sidebar navigation also uses MUI Accordion components, so plain
+            // .MuiAccordionSummary-root would match sidebar items first. Scope to the
+            // ToolDetails custom class which is applied only to tool accordions.
+            cy.get('.ToolDetails-accordionContainer', { timeout: 30000 }).should('have.length.greaterThan', 0);
+
+            // Expand the first tool accordion using native DOM click. Cypress's synthetic
+            // click({ force: true }) does not reliably trigger MUI's controlled Accordion
+            // onChange callback; calling .click() directly on the raw DOM element does.
+            cy.get('.ToolDetails-accordionContainer').first()
+                .find('.MuiAccordionSummary-root').then(($el) => $el[0].click());
+
+            // Wait for the tool accordion to gain Mui-expanded class.
+            cy.get('.ToolDetails-accordionContainer').first()
+                .should('have.class', 'Mui-expanded', { timeout: 10000 });
+
+            // Interact with the expanded accordion's Name and Description fields.
+            cy.get('.ToolDetails-accordionContainer').first()
+                .find('.MuiAccordionDetails-root').within(() => {
+                    cy.get('input').first()
+                        .clear({ force: true })
+                        .type(updatedToolName, { force: true });
+
+                    cy.get('textarea').first()
+                        .clear({ force: true })
+                        .type(updatedDescription, { force: true });
+                });
+
+            cy.intercept('PUT', `**/mcp-servers/${mcpId}`).as('saveMcp');
+            cy.get('#resources-save-operations').click();
+            cy.wait('@saveMcp', { timeout: 30000 }).its('response.statusCode').should('eq', 200);
+        });
+    });
+
+    it.only("Tools page shows all tools for an MCP server created from an existing API", () => {
+        const suffix = Utils.getRandomString(5);
+
+        setupMcpWithTools(suffix).then(({ sourceApiId: srcId, mcpId: id }) => {
+            sourceApiId = srcId;
+            mcpId = id;
+
+            // In combined runs the publisher session can become invalid during the curl
+            // setup phase (SSO token expiry / redirect state), causing a 401 on the
+            // subsequent cy.visit. Explicitly log out and back in to get a fresh session
+            // before navigating to the MCP overview.
+            cy.logoutFromPublisher();
+            cy.loginToPublisher(publisher, password);
+            cy.visit(`/publisher/mcp-servers/${mcpId}/overview`, { timeout: 30000 });
+            cy.get('#left-menu-tools', { timeout: 30000 }).click({ force: true });
+
+            cy.get('#resources-save-operations', { timeout: 15000 }).should('exist');
+
+            // Both operations should appear as tool accordions.
+            // Scope to .ToolDetails-accordionContainer to avoid matching sidebar accordions.
+            cy.get('.ToolDetails-accordionContainer', { timeout: 30000 }).should('have.length', 2);
+        });
+    });
+
+    it.only("Can add a new tool from an unused underlying API operation via AddTool", () => {
+        // Use an underlying API with 3 operations but only map 2 as MCP tools, leaving
+        // GET /pet/findByStatus available in the AddTool operation selector.
+        const suffix = Utils.getRandomString(5);
+        const srcName = `TestSrc${suffix}`;
+        const srcContext = `/testsrc${suffix}`;
+        const mcpName = `TestMcp${suffix}`;
+        const mcpContext = `/testmcp${suffix}`;
+
+        const srcPayload = JSON.stringify({
+            name: srcName,
+            version: '1.0.0',
+            context: srcContext,
+            policies: ['Unlimited'],
+            endpointConfig: {
+                endpoint_type: 'http',
+                sandbox_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                production_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+            },
+            operations: [
+                { target: '/pet', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+                { target: '/pet', verb: 'POST', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+                { target: '/pet/findByStatus', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited' },
+            ],
+        });
+
+        Utils.addAPI({ payload: srcPayload }).then((createdSrcId) => {
+            expect(createdSrcId, 'Source API created').to.be.a('string');
+            sourceApiId = createdSrcId;
+
+            const mcpPayload = JSON.stringify({
+                name: mcpName,
+                version: '1.0.0',
+                context: mcpContext,
+                policies: ['Unlimited'],
+                endpointConfig: {
+                    endpoint_type: 'http',
+                    sandbox_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                    production_endpoints: { url: 'https://petstore3.swagger.io/api/v3' },
+                },
+                transport: ['http', 'https'],
+                visibility: 'PUBLIC',
+                // Only 2 of the 3 underlying operations are mapped — the 3rd is left for AddTool.
+                operations: [
+                    {
+                        feature: 'TOOL',
+                        apiOperationMapping: {
+                            apiId: createdSrcId,
+                            apiName: srcName,
+                            apiVersion: '1.0.0',
+                            apiContext: srcContext,
+                            backendOperation: { target: '/pet', verb: 'GET' },
+                        },
+                    },
+                    {
+                        feature: 'TOOL',
+                        apiOperationMapping: {
+                            apiId: createdSrcId,
+                            apiName: srcName,
+                            apiVersion: '1.0.0',
+                            apiContext: srcContext,
+                            backendOperation: { target: '/pet', verb: 'POST' },
+                        },
+                    },
+                ],
+            });
+
+            Utils.addMCPServerFromEndpointConfig({ payload: mcpPayload }).then((createdMcpId) => {
+                expect(createdMcpId, 'MCP created').to.be.a('string');
+                mcpId = createdMcpId;
+
+                cy.logoutFromPublisher();
+                cy.loginToPublisher(publisher, password);
+                cy.visit(`/publisher/mcp-servers/${mcpId}/overview`, { timeout: 30000 });
+                cy.get('#left-menu-tools', { timeout: 30000 }).click({ force: true });
+                cy.get('#resources-save-operations', { timeout: 15000 }).should('exist');
+
+                // Confirm 2 tools are currently shown.
+                cy.get('.ToolDetails-accordionContainer', { timeout: 30000 }).should('have.length', 2);
+
+                // Select GET /pet/findByStatus from the AddTool operation autocomplete.
+                // The OperationSelector renders with id="operation-autocomplete"; getOptionLabel
+                // formats options as "VERB target", so we type the distinctive path segment.
+                cy.get('#operation-autocomplete', { timeout: 15000 }).click().type('findByStatus');
+                cy.get('.MuiAutocomplete-popper li', { timeout: 10000 })
+                    .contains('/pet/findByStatus')
+                    .click();
+
+                // Auto-fill populates the name field; fill in a description and add the tool.
+                cy.get('#tool-description').clear().type('Find pets by their status');
+                cy.get('#add-tool-button').click();
+
+                // The tool accordion list should grow to 3.
+                cy.get('.ToolDetails-accordionContainer', { timeout: 15000 }).should('have.length', 3);
+
+                // Save and confirm the PUT request succeeds.
+                cy.intercept('PUT', `**/mcp-servers/${mcpId}`).as('saveMcp');
+                cy.get('#resources-save-operations').click();
+                cy.wait('@saveMcp', { timeout: 30000 }).its('response.statusCode').should('eq', 200);
+            });
+        });
+    });
+
+    afterEach(() => {
+        if (mcpId) {
+            Utils.deleteMCPServer(mcpId);
+            mcpId = null;
+        }
+        if (sourceApiId) {
+            Utils.deleteAPI(sourceApiId);
+            sourceApiId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/04-mcp-server-tools-management.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/04-mcp-server-tools-management.cy.js
@@ -153,7 +153,16 @@ describe("publisher-023-03 : MCP Server tools management (edit and add tools)", 
 
             cy.intercept('PUT', `**/mcp-servers/${mcpId}`).as('saveMcp');
             cy.get('#resources-save-operations').click();
-            cy.wait('@saveMcp', { timeout: 30000 }).its('response.statusCode').should('eq', 200);
+            cy.wait('@saveMcp', { timeout: 30000 }).then((interception) => {
+                expect(interception.response.statusCode).to.equal(200);
+                // The Name/Description fields edited above bind to a tool's target/description
+                // (see ToolDetailsSection.jsx) - confirm the saved payload actually carries the
+                // edited values, not just that the save call succeeded.
+                const savedTool = interception.request.body.operations
+                    .find((op) => op.target === updatedToolName);
+                expect(savedTool, 'renamed tool present in saved payload').to.exist;
+                expect(savedTool.description).to.equal(updatedDescription);
+            });
         });
     });
 
@@ -276,10 +285,17 @@ describe("publisher-023-03 : MCP Server tools management (edit and add tools)", 
                 // The tool accordion list should grow to 3.
                 cy.get('.ToolDetails-accordionContainer', { timeout: 15000 }).should('have.length', 3);
 
-                // Save and confirm the PUT request succeeds.
+                // Save and confirm the newly added tool's mapping is actually in the payload,
+                // not just that the save call succeeded.
                 cy.intercept('PUT', `**/mcp-servers/${mcpId}`).as('saveMcp');
                 cy.get('#resources-save-operations').click();
-                cy.wait('@saveMcp', { timeout: 30000 }).its('response.statusCode').should('eq', 200);
+                cy.wait('@saveMcp', { timeout: 30000 }).then((interception) => {
+                    expect(interception.response.statusCode).to.equal(200);
+                    const addedTool = interception.request.body.operations.find(
+                        (op) => op.apiOperationMapping?.backendOperation?.target === '/pet/findByStatus',
+                    );
+                    expect(addedTool, '/pet/findByStatus tool present in saved payload').to.exist;
+                });
             });
         });
     });

--- a/tests/cypress/e2e/publisher/024-mcp-server/05-deployment-status-mcp-server.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/05-deployment-status-mcp-server.cy.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env("largeTimeout") || 30000 };
+
+// Deploy a revision on the deployments page and verify the "Successfully Deployed"
+// chip appears in the Gateways table (Deployment Status column).
+// The chip is rendered by envDeploymentStatusComponent() in Environments.jsx
+// when settings.isGatewayNotificationEnabled is true (confirmed in local env).
+function verifyDeploymentStatusChip(visitPath) {
+    cy.visit(visitPath, largeTimeout);
+    cy.get('#add-description-btn', largeTimeout).scrollIntoView().click({ force: true });
+    cy.get('#add-description', largeTimeout).click({ force: true });
+    cy.get('#add-description').type('test');
+    cy.get('#deploy-btn').should('not.have.class', 'Mui-disabled').click();
+
+    // The Gateways table chip rendered by envDeploymentStatusComponent()
+    // shows "Successfully Deployed" once the gateway picks up the revision.
+    cy.contains('.MuiChip-label', 'Successfully Deployed', largeTimeout).should('be.visible');
+}
+
+describe("publisher-023-04 : Deployment status chip in Gateways table for MCP Server", () => {
+    const { publisher, password } = Utils.getUserInfo();
+
+    Cypress.on("uncaught:exception", () => false);
+
+    beforeEach(function () {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Shows Successfully Deployed chip in Gateways table after deploying an MCP Server revision", () => {
+        Utils.addMCPServerFromEndpointConfig({}).then((mcpId) => {
+            expect(mcpId, 'MCP server created').to.be.a('string');
+            verifyDeploymentStatusChip(`/publisher/mcp-servers/${mcpId}/deployments`);
+            Utils.deleteMCPServer(mcpId);
+        });
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/06-mcp-server-lifecycle.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/06-mcp-server-lifecycle.cy.js
@@ -37,8 +37,6 @@ describe("publisher-023-05 : MCP Server lifecycle transitions", () => {
     const { publisher, password } = Utils.getUserInfo();
     let testMcpId;
 
-    Cypress.on('uncaught:exception', () => false);
-
     beforeEach(() => {
         cy.loginToPublisher(publisher, password);
     });

--- a/tests/cypress/e2e/publisher/024-mcp-server/06-mcp-server-lifecycle.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/06-mcp-server-lifecycle.cy.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env('largeTimeout') || 30000 };
+
+/**
+ * Creates an MCP server, creates a revision, deploys it, then returns the mcpId.
+ * Deployment is a prerequisite for the Publish button to become active.
+ */
+function createDeployedMcpServer() {
+    return Utils.addMCPServerFromEndpointConfig({}).then((mcpId) => {
+        expect(mcpId, 'MCP server created').to.be.a('string');
+        return Utils.addMCPRevision(mcpId).then((revisionId) => {
+            return Utils.deployMCPRevision(mcpId, revisionId).then(() => mcpId);
+        });
+    });
+}
+
+describe("publisher-023-05 : MCP Server lifecycle transitions", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    let testMcpId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("Can publish a deployed MCP Server and see state change to Published", {
+        retries: {
+            runMode: 3,
+            openMode: 0,
+        },
+    }, () => {
+        createDeployedMcpServer().then((id) => {
+            testMcpId = id;
+            cy.visit(`/publisher/mcp-servers/${testMcpId}/lifecycle`, largeTimeout);
+
+            cy.get('[data-testid="Publish-btn"]', largeTimeout)
+                .should('not.have.class', 'Mui-disabled')
+                .click();
+
+            cy.get('button[data-testid="Demote to Created-btn"]', largeTimeout).should('be.visible');
+        });
+    });
+
+    it.only("Can publish then deprecate an MCP Server via the lifecycle UI", {
+        retries: {
+            runMode: 3,
+            openMode: 0,
+        },
+    }, () => {
+        createDeployedMcpServer().then((id) => {
+            testMcpId = id;
+            cy.visit(`/publisher/mcp-servers/${testMcpId}/lifecycle`, largeTimeout);
+
+            // First publish via the UI
+            cy.get('[data-testid="Publish-btn"]', largeTimeout)
+                .should('not.have.class', 'Mui-disabled')
+                .click();
+
+            // Confirm we are in Published state
+            cy.get('button[data-testid="Demote to Created-btn"]', largeTimeout).should('be.visible');
+
+            // Now deprecate — requires confirmation dialog
+            cy.get('[data-testid="Deprecate-btn"]', largeTimeout)
+                .should('not.have.class', 'Mui-disabled')
+                .click();
+            cy.get('#itest-id-conf', largeTimeout).contains('DEPRECATE').click();
+
+            // After deprecating, Retire button confirms Deprecated state
+            cy.get('button[data-testid="Retire-btn"]', largeTimeout).should('be.visible');
+        });
+    });
+
+    afterEach(() => {
+        if (testMcpId) {
+            Utils.deleteMCPServer(testMcpId);
+            testMcpId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/07-mcp-server-publisher-playground.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/07-mcp-server-publisher-playground.cy.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+/**
+ * Mocks the actual tool invocation (tools/call) with a canned success result, leaving
+ * initialize/notifications/tools-list to pass through untouched - the gateway answers
+ * those directly from the MCP server's own stored metadata, never touching the backend.
+ * tools/call is the only step that would otherwise reach the (placeholder, unreachable)
+ * backend URL, so intercepting just that call here means no real backend is ever needed.
+ */
+function mockToolCallSuccess() {
+    cy.intercept('POST', '**/mcp', (req) => {
+        if (req.body && req.body.method === 'tools/call') {
+            req.reply({
+                statusCode: 200,
+                body: {
+                    jsonrpc: '2.0',
+                    id: req.body.id,
+                    result: {
+                        content: [{ type: 'text', text: JSON.stringify({ mockToolResult: 'success-verified' }) }],
+                        isError: false,
+                    },
+                },
+            });
+        } else {
+            req.continue();
+        }
+    }).as('mcpToolCall');
+}
+
+describe("publisher-023-06 : MCP Server Publisher Playground", () => {
+    const { publisher, password } = Utils.getUserInfo();
+    let mcpId;
+    let sourceApiId;
+
+    Cypress.on('uncaught:exception', () => false);
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    it.only("MCP Playground connects to an MCP server and invokes a tool", () => {
+        Utils.createMockToolMcpServer().then(({ mcpId: createdId, sourceApiId: createdSrcId }) => {
+            mcpId = createdId;
+            sourceApiId = createdSrcId;
+
+            mockToolCallSuccess();
+
+            // Navigate to the publisher MCP playground.
+            cy.visit(`/publisher/mcp-servers/${mcpId}/mcp-playground`, { timeout: 30000 });
+
+            // Wait until the Connect button is enabled. The playground auto-generates an
+            // internal key on load; the button stays active once the key is ready.
+            cy.contains('button', 'Connect', { timeout: 30000 }).should('not.be.disabled');
+
+            // The MCPPlayground component (G8) propagates the token from the parent
+            // TryOutConsole into its own internal state via a useEffect. The button
+            // becomes enabled once TryOutConsole's apiKey is set, but G8's internal
+            // token state lags one render behind (the useEffect fires after the paint).
+            // If Connect is clicked in that window, the connect closure runs with
+            // token=undefined — no Internal-Key header is sent and the gateway returns
+            // 401, silently failing. 1 second is not enough when preceding specs have
+            // loaded the browser (heavier JS context slows React scheduling), so we
+            // wait 3 seconds to ensure the second render has settled before clicking.
+            cy.wait(3000);
+
+            // Click Connect and wait for the MCP session to be established.
+            cy.contains('button', 'Connect').should('not.be.disabled').click();
+
+            // "Disconnect" appearing confirms the connection is live.
+            cy.contains('button', 'Disconnect', { timeout: 60000 }).should('be.visible');
+
+            // Tools are not fetched automatically — click "List Tools" to retrieve them.
+            cy.contains('button', 'List Tools', { timeout: 15000 }).click();
+
+            cy.contains(Utils.getMockToolName(), { timeout: 15000 }).click();
+
+            // The Run Tool button is enabled for the selected tool.
+            cy.contains('button', 'Run Tool', { timeout: 15000 }).should('not.be.disabled').click();
+
+            // The mocked tools/call response should render as a successful result.
+            cy.wait('@mcpToolCall');
+            cy.contains('Tool Result', { timeout: 30000 }).should('be.visible');
+            cy.contains('success-verified', { timeout: 15000 }).should('be.visible');
+        });
+    });
+
+    afterEach(() => {
+        if (mcpId) {
+            Utils.deleteMCPServer(mcpId);
+            mcpId = null;
+        }
+        if (sourceApiId) {
+            Utils.deleteAPI(sourceApiId);
+            sourceApiId = null;
+        }
+    });
+});

--- a/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
@@ -218,7 +218,7 @@ function configureEndpointAuth(mcpServerId, authType) {
 // (subtypeConfiguration.subtype === 'SERVER_PROXY'). This spec covers that whole
 // feature end to end, grouped into focused sub-tests instead of one spec file per
 // scenario.
-describe("publisher-023-07 : MCP endpoint backend definition Re-sync (third-party / SERVER_PROXY servers)", () => {
+describe("publisher-023-07 : MCP endpoint backend definition Re-sync (third-party / SERVER_PROXY servers)", { testIsolation: false }, () => {
     Cypress.on('uncaught:exception', (err, runnable) => {
         return false;
     });
@@ -226,19 +226,18 @@ describe("publisher-023-07 : MCP endpoint backend definition Re-sync (third-part
     const { publisher, password } = Utils.getUserInfo();
     let mcpId;
 
-    // A single MCP server is shared across every test in this file rather than created
-    // per test: every scenario below mocks the server's subtype, backends list, and
-    // resync responses, so the real server's own content is never read or asserted on -
-    // it only needs to exist so the SPA routes resolve. Recreating it per test bought no
-    // extra isolation, just ~14x the create/delete round trips (each delete also carries
-    // a hardcoded 5s wait in Utils.deleteMCPServer).
+    // A single login and a single MCP server are shared across every test in this file
+    // rather than repeated per test: every scenario below mocks the server's subtype,
+    // backends list, and resync responses, so the real server's own content is never
+    // read or asserted on - it only needs to exist so the SPA routes resolve. Recreating
+    // it per test bought no extra isolation, just ~14x the create/delete round trips (each
+    // delete also carries a hardcoded 5s wait in Utils.deleteMCPServer). testIsolation is
+    // disabled above so the cookies this login sets aren't cleared between tests - a
+    // per-test beforeEach login would otherwise time out on test 1 (the before() login is
+    // still live then) and skip the rest of the file when that hook throws.
     before(() => {
         cy.loginToPublisher(publisher, password);
         Utils.addMCPServerFromEndpointConfig({}).then((id) => { mcpId = id; });
-    });
-
-    beforeEach(() => {
-        cy.loginToPublisher(publisher, password);
     });
 
     after(() => {

--- a/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
@@ -59,7 +59,7 @@ function mockServerSubtype(mcpServerId, subtype, alias = 'getMCPServer') {
  * @param {string} mcpServerId
  * @param {string} [alias]
  */
-function mockBackendsList(mcpServerId, alias = 'getBackends') {
+function mockBackendsList(mcpServerId, alias = 'getBackends', endpointSecurity) {
     cy.intercept(
         { method: 'GET', pathname: `/api/am/publisher/v4/mcp-servers/${mcpServerId}/backends` },
         (req) => {
@@ -72,6 +72,7 @@ function mockBackendsList(mcpServerId, alias = 'getBackends') {
                             endpoint_type: 'http',
                             production_endpoints: { url: 'https://localhost:3100' },
                             sandbox_endpoints: { url: 'https://localhost:3100' },
+                            ...(endpointSecurity ? { endpoint_security: endpointSecurity } : {}),
                         }),
                         definition: '{"tools":[]}',
                     },
@@ -132,9 +133,9 @@ function openDefinitionDrawer() {
 }
 
 /** Mocks a SERVER_PROXY server + its backends list, visits the endpoints page and opens the drawer. */
-function openProxyServerDefinitionDrawer(mcpServerId) {
+function openProxyServerDefinitionDrawer(mcpServerId, endpointSecurity) {
     mockServerSubtype(mcpServerId, 'SERVER_PROXY');
-    mockBackendsList(mcpServerId);
+    mockBackendsList(mcpServerId, 'getBackends', endpointSecurity);
     visitEndpointsPage(mcpServerId);
     openDefinitionDrawer();
 }
@@ -196,9 +197,16 @@ function configureEndpointAuth(mcpServerId, authType) {
             },
         },
     ).as('getSingleBackend');
-    cy.intercept('PUT', `**/mcp-servers/${mcpServerId}/backends/**`, {
-        statusCode: 200,
-        body: {},
+    // Capture what was actually submitted so the caller can (a) reflect it in a later
+    // mockBackendsList() mock and (b) assert the auth it configured was really saved,
+    // instead of just that the PUT returned 200.
+    let savedEndpointSecurity;
+    cy.intercept('PUT', `**/mcp-servers/${mcpServerId}/backends/**`, (req) => {
+        const sentConfig = typeof req.body.endpointConfig === 'string'
+            ? JSON.parse(req.body.endpointConfig)
+            : req.body.endpointConfig;
+        savedEndpointSecurity = sentConfig?.endpoint_security;
+        req.reply({ statusCode: 200, body: {} });
     }).as('saveEndpointSecurity');
 
     cy.visit(`/publisher/mcp-servers/${mcpServerId}/endpoints/${FAKE_BACKEND_ID}/PRODUCTION`, largeTimeout);
@@ -210,7 +218,10 @@ function configureEndpointAuth(mcpServerId, authType) {
     cy.get('#endpoint-security-submit-btn').click();
 
     cy.get('#endpoint-save-btn').click();
-    cy.wait('@saveEndpointSecurity');
+    return cy.wait('@saveEndpointSecurity').then(() => {
+        expect(savedEndpointSecurity, 'endpoint_security saved by the PUT').to.exist;
+        return savedEndpointSecurity;
+    });
 }
 
 // Endpoint backend definition Re-sync is only exposed for third-party MCP servers,
@@ -412,18 +423,19 @@ describe("publisher-023-07 : MCP endpoint backend definition Re-sync (third-part
 
     AUTH_MATRIX.forEach(({ authType, label }) => {
         it.only(`still delegates credentials to the backend store (no inline securityInfo) with ${label}`, () => {
-            configureEndpointAuth(mcpId, authType);
-            openProxyServerDefinitionDrawer(mcpId);
+            configureEndpointAuth(mcpId, authType).then((savedEndpointSecurity) => {
+                openProxyServerDefinitionDrawer(mcpId, savedEndpointSecurity);
 
-            mockResyncSuccess('validateMCP');
-            cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
-            cy.wait('@validateMCP').then((interception) => {
-                expect(interception.request.body).to.have.property('mcpServerId', mcpId);
-                expect(interception.request.body).to.have.property('endpointType', 'PRODUCTION');
-                expect(interception.request.body).not.to.have.property('securityInfo');
+                mockResyncSuccess('validateMCP');
+                cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+                cy.wait('@validateMCP').then((interception) => {
+                    expect(interception.request.body).to.have.property('mcpServerId', mcpId);
+                    expect(interception.request.body).to.have.property('endpointType', 'PRODUCTION');
+                    expect(interception.request.body).not.to.have.property('securityInfo');
+                });
+
+                cy.contains('Definition fetched from backend', largeTimeout).should('be.visible');
             });
-
-            cy.contains('Definition fetched from backend', largeTimeout).should('be.visible');
         });
     });
 });

--- a/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
+++ b/tests/cypress/e2e/publisher/024-mcp-server/08-mcp-server-endpoint-resync.cy.js
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Utils from "@support/utils";
+
+const largeTimeout = { timeout: Cypress.env("largeTimeout") || 30000 };
+
+// Fake backend used by every intercept below - the real MCP server created via
+// Utils.addMCPServerFromEndpointConfig() has no real backend of this shape, but the endpoints page
+// never talks to the real backend list once mockBackendsList() is registered.
+const FAKE_BACKEND_ID = 'test-backend-id-01';
+
+// Minimal valid MCP tools definition returned by a successful re-sync.
+const MOCK_DEFINITION = JSON.stringify({
+    tools: [
+        {
+            name: 'mock-tool',
+            description: 'A mock MCP tool for testing',
+            inputSchema: { type: 'object', properties: {} },
+        },
+    ],
+});
+
+/**
+ * Intercepts GET /mcp-servers/{id} and overrides subtypeConfiguration.subtype in the
+ * response body. Register this BEFORE visiting the page.
+ * @param {string} mcpServerId
+ * @param {'SERVER_PROXY'|'DIRECT_BACKEND'|'EXISTING_API'} subtype
+ * @param {string} [alias]
+ */
+function mockServerSubtype(mcpServerId, subtype, alias = 'getMCPServer') {
+    cy.intercept('GET', `**/mcp-servers/${mcpServerId}`, (req) => {
+        req.continue((res) => {
+            if (res.body && typeof res.body === 'object') {
+                res.body.subtypeConfiguration = { subtype, configuration: null };
+            }
+        });
+    }).as(alias);
+}
+
+/**
+ * Intercepts GET /mcp-servers/{id}/backends and returns a single fake backend entry.
+ * Register this BEFORE visiting the endpoints page so that the page renders endpoint cards.
+ * @param {string} mcpServerId
+ * @param {string} [alias]
+ */
+function mockBackendsList(mcpServerId, alias = 'getBackends') {
+    cy.intercept(
+        { method: 'GET', pathname: `/api/am/publisher/v4/mcp-servers/${mcpServerId}/backends` },
+        (req) => {
+            req.continue((res) => {
+                res.body = [
+                    {
+                        id: FAKE_BACKEND_ID,
+                        name: 'Default Backend',
+                        endpointConfig: JSON.stringify({
+                            endpoint_type: 'http',
+                            production_endpoints: { url: 'https://localhost:3100' },
+                            sandbox_endpoints: { url: 'https://localhost:3100' },
+                        }),
+                        definition: '{"tools":[]}',
+                    },
+                ];
+            });
+        },
+    ).as(alias);
+}
+
+/** Stubs POST mcp-servers/validate-mcp-server with a 200 + content. */
+function mockResyncSuccess(alias = 'validateMCP') {
+    cy.intercept('POST', '**/mcp-servers/validate-mcp-server', {
+        statusCode: 200,
+        body: { content: MOCK_DEFINITION },
+    }).as(alias);
+}
+
+/** Stubs POST mcp-servers/validate-mcp-server with an error status. */
+function mockResyncError(statusCode = 500, alias = 'validateMCPError') {
+    cy.intercept('POST', '**/mcp-servers/validate-mcp-server', {
+        statusCode,
+        body: { message: 'Internal server error' },
+    }).as(alias);
+}
+
+/** Stubs POST mcp-servers/validate-mcp-server with 200 but null content. */
+function mockResyncEmptyContent(alias = 'validateMCPEmpty') {
+    cy.intercept('POST', '**/mcp-servers/validate-mcp-server', {
+        statusCode: 200,
+        body: { content: null },
+    }).as(alias);
+}
+
+/** Stubs POST mcp-servers/validate-mcp-server with a configurable delay. */
+function mockResyncWithDelay(delayMs = 2000, alias = 'validateMCPSlow') {
+    cy.intercept('POST', '**/mcp-servers/validate-mcp-server', (req) => {
+        req.reply({
+            statusCode: 200,
+            body: { content: MOCK_DEFINITION },
+            delay: delayMs,
+        });
+    }).as(alias);
+}
+
+/**
+ * Visits the MCP server Endpoints page and waits for the loader to clear.
+ * @param {string} mcpServerId
+ */
+function visitEndpointsPage(mcpServerId) {
+    cy.visit(`/publisher/mcp-servers/${mcpServerId}/endpoints`, largeTimeout);
+    cy.get('#apim-loader > span', largeTimeout).should('not.exist');
+}
+
+/** Opens the backend-definition drawer for the first endpoint card. */
+function openDefinitionDrawer() {
+    cy.get('[data-testid="endpoint-definition-view-btn"]', largeTimeout).first().click();
+    cy.get('[role="presentation"]', largeTimeout).should('be.visible');
+}
+
+/** Mocks a SERVER_PROXY server + its backends list, visits the endpoints page and opens the drawer. */
+function openProxyServerDefinitionDrawer(mcpServerId) {
+    mockServerSubtype(mcpServerId, 'SERVER_PROXY');
+    mockBackendsList(mcpServerId);
+    visitEndpointsPage(mcpServerId);
+    openDefinitionDrawer();
+}
+
+/**
+ * Fills in the endpoint security dialog for a given auth type. Assumes the security
+ * dialog is already open (endpoint-security-icon-btn clicked).
+ * @param {'APIKEY_HEADER'|'OAUTH'} authType
+ */
+function fillAuthFields(authType) {
+    switch (authType) {
+        case 'APIKEY_HEADER':
+            cy.get('#auth-type-select').parent().click();
+            cy.get('#auth-type-apikey').click();
+            cy.get('#auth-apiKeyIdentifierType').parent().click();
+            cy.contains('[role="option"]', 'Header').click();
+            cy.get('#auth-apiKeyIdentifier').clear().type('X-API-Key');
+            cy.get('#auth-apiKeyValue').clear().type('my-secret-api-key');
+            break;
+        case 'OAUTH':
+            cy.get('#auth-type-select').parent().click();
+            cy.get('#auth-type-OAUTH').click();
+            // The token URL / client credentials fields only render once a grant type
+            // that needs them (Client Credentials) is selected.
+            cy.get('#grant-type-select').parent().click();
+            cy.contains('[role="option"]', 'Client Credentials').click();
+            cy.get('#auth-tokenUrl').clear().type('https://oauth.example.com/token');
+            cy.get('#auth-clientId').clear().type('my-client-id');
+            cy.get('#auth-clientSecret').clear().type('my-client-secret');
+            break;
+        default:
+            throw new Error(`Unknown authType: ${authType}`);
+    }
+}
+
+/**
+ * Navigates to the endpoint edit page and configures the given authentication method
+ * on the endpoint's security settings, then saves. The single-backend GET and the
+ * backend PUT are both intercepted, so this works against FAKE_BACKEND_ID without
+ * requiring a real backend to exist.
+ * @param {string} mcpServerId
+ * @param {'APIKEY_HEADER'|'OAUTH'} authType
+ */
+function configureEndpointAuth(mcpServerId, authType) {
+    cy.intercept(
+        { method: 'GET', pathname: `/api/am/publisher/v4/mcp-servers/${mcpServerId}/backends/${FAKE_BACKEND_ID}` },
+        {
+            statusCode: 200,
+            body: {
+                id: FAKE_BACKEND_ID,
+                name: 'Default Backend',
+                endpointConfig: JSON.stringify({
+                    endpoint_type: 'http',
+                    production_endpoints: { url: 'https://localhost:3100' },
+                    sandbox_endpoints: { url: 'https://localhost:3100' },
+                    endpoint_security: {},
+                }),
+                definition: '{"tools":[]}',
+            },
+        },
+    ).as('getSingleBackend');
+    cy.intercept('PUT', `**/mcp-servers/${mcpServerId}/backends/**`, {
+        statusCode: 200,
+        body: {},
+    }).as('saveEndpointSecurity');
+
+    cy.visit(`/publisher/mcp-servers/${mcpServerId}/endpoints/${FAKE_BACKEND_ID}/PRODUCTION`, largeTimeout);
+    cy.get('#apim-loader > span', largeTimeout).should('not.exist');
+    cy.wait('@getSingleBackend');
+
+    cy.get('#endpoint-security-icon-btn', { timeout: 15000 }).click();
+    fillAuthFields(authType);
+    cy.get('#endpoint-security-submit-btn').click();
+
+    cy.get('#endpoint-save-btn').click();
+    cy.wait('@saveEndpointSecurity');
+}
+
+// Endpoint backend definition Re-sync is only exposed for third-party MCP servers,
+// i.e. servers created by proxying an existing external MCP endpoint
+// (subtypeConfiguration.subtype === 'SERVER_PROXY'). This spec covers that whole
+// feature end to end, grouped into focused sub-tests instead of one spec file per
+// scenario.
+describe("publisher-023-07 : MCP endpoint backend definition Re-sync (third-party / SERVER_PROXY servers)", () => {
+    Cypress.on('uncaught:exception', (err, runnable) => {
+        return false;
+    });
+
+    const { publisher, password } = Utils.getUserInfo();
+    let mcpId;
+
+    // A single MCP server is shared across every test in this file rather than created
+    // per test: every scenario below mocks the server's subtype, backends list, and
+    // resync responses, so the real server's own content is never read or asserted on -
+    // it only needs to exist so the SPA routes resolve. Recreating it per test bought no
+    // extra isolation, just ~14x the create/delete round trips (each delete also carries
+    // a hardcoded 5s wait in Utils.deleteMCPServer).
+    before(() => {
+        cy.loginToPublisher(publisher, password);
+        Utils.addMCPServerFromEndpointConfig({}).then((id) => { mcpId = id; });
+    });
+
+    beforeEach(() => {
+        cy.loginToPublisher(publisher, password);
+    });
+
+    after(() => {
+        if (mcpId) {
+            Utils.deleteMCPServer(mcpId);
+        }
+    });
+
+    it.only("shows Re-sync only for a third-party (SERVER_PROXY) server, never for DIRECT_BACKEND or EXISTING_API", () => {
+        mockServerSubtype(mcpId, 'SERVER_PROXY', 'getServerProxy');
+        mockBackendsList(mcpId);
+        visitEndpointsPage(mcpId);
+        cy.wait('@getServerProxy');
+        openDefinitionDrawer();
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').should('exist').and('be.visible');
+
+        ['DIRECT_BACKEND', 'EXISTING_API'].forEach((subtype) => {
+            mockServerSubtype(mcpId, subtype, 'getServerOther');
+            mockBackendsList(mcpId);
+            visitEndpointsPage(mcpId);
+            cy.wait('@getServerOther');
+            openDefinitionDrawer();
+            cy.get('[data-testid="endpoint-definition-resync-btn"]').should('not.exist');
+        });
+    });
+
+    it.only("disables Re-sync while viewing a revision, keeps it enabled for the live endpoint", () => {
+        cy.intercept('GET', `**/mcp-servers/${mcpId}`, (req) => {
+            req.continue((res) => {
+                if (res.body && typeof res.body === 'object') {
+                    res.body.subtypeConfiguration = { subtype: 'SERVER_PROXY', configuration: null };
+                    res.body.isRevision = true;
+                }
+            });
+        }).as('getServerRevision');
+        mockBackendsList(mcpId);
+        visitEndpointsPage(mcpId);
+        cy.wait('@getServerRevision');
+        openDefinitionDrawer();
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').should('be.disabled');
+
+        mockServerSubtype(mcpId, 'SERVER_PROXY', 'getServerLive');
+        mockBackendsList(mcpId);
+        visitEndpointsPage(mcpId);
+        cy.wait('@getServerLive');
+        openDefinitionDrawer();
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').should('not.be.disabled');
+    });
+
+    it.only("delegates credential resolution to the backend and populates the editor with the fetched definition", () => {
+        openProxyServerDefinitionDrawer(mcpId);
+        mockResyncSuccess('validateMCP');
+
+        // Nothing synced yet - Update stays disabled until a re-sync succeeds.
+        cy.get('[data-testid="endpoint-definition-update-btn"]').should('be.disabled');
+
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+
+        // handleResync() always sends mcpServerId + endpointType and never inline
+        // securityInfo - the backend resolves stored credentials on its own.
+        cy.wait('@validateMCP').then((interception) => {
+            expect(interception.request.body).to.have.property('mcpServerId', mcpId);
+            expect(interception.request.body).to.have.property('endpointType', 'PRODUCTION');
+            expect(interception.request.body).not.to.have.property('securityInfo');
+        });
+
+        cy.contains('Definition fetched from backend', largeTimeout).should('be.visible');
+        cy.get('[role="presentation"] .view-lines', largeTimeout).should('contain.text', 'mock-tool');
+        cy.get('[data-testid="endpoint-definition-update-btn"]', largeTimeout).should('not.be.disabled');
+    });
+
+    it.only("disables the Re-sync button while the request is in-flight and re-enables it once it settles", () => {
+        openProxyServerDefinitionDrawer(mcpId);
+
+        mockResyncWithDelay(3000, 'validateMCPSlow');
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').should('be.disabled');
+
+        cy.wait('@validateMCPSlow', { timeout: 10000 });
+        cy.get('[data-testid="endpoint-definition-resync-btn"]', largeTimeout).should('not.be.disabled');
+    });
+
+    [
+        { label: 'a 500 Internal Server Error', setup: () => mockResyncError(500, 'validateMCPErr') },
+        { label: 'a 401 Unauthorized', setup: () => mockResyncError(401, 'validateMCPErr') },
+        { label: '200 with null content', setup: () => mockResyncEmptyContent('validateMCPErr') },
+    ].forEach(({ label, setup }) => {
+        it.only(`shows an error alert and keeps Update disabled when the backend returns ${label}`, () => {
+            openProxyServerDefinitionDrawer(mcpId);
+
+            setup();
+            cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+            cy.wait('@validateMCPErr');
+
+            cy.contains('Could not re-sync backend definition.', largeTimeout).should('be.visible');
+            cy.get('[data-testid="endpoint-definition-update-btn"]').should('be.disabled');
+            cy.get('[data-testid="endpoint-definition-resync-btn"]', largeTimeout).should('not.be.disabled');
+        });
+    });
+
+    it.only("reviews the fetched definition, persists it via Update, and reflects it after the endpoints refetch", () => {
+        // Tracks whether Update has persisted the resynced definition yet, so the
+        // mocked GET backends response reflects it on the following re-fetch.
+        let backendUpdated = false;
+
+        mockServerSubtype(mcpId, 'SERVER_PROXY');
+        cy.intercept(
+            { method: 'GET', pathname: `/api/am/publisher/v4/mcp-servers/${mcpId}/backends` },
+            (req) => {
+                req.continue((res) => {
+                    res.body = [{
+                        id: FAKE_BACKEND_ID,
+                        name: 'Default Backend',
+                        endpointConfig: JSON.stringify({
+                            endpoint_type: 'http',
+                            production_endpoints: { url: 'https://localhost:3100' },
+                            sandbox_endpoints: { url: 'https://localhost:3100' },
+                        }),
+                        definition: backendUpdated ? MOCK_DEFINITION : '{"tools":[]}',
+                    }];
+                });
+            },
+        ).as('getBackends');
+        mockResyncSuccess('validateMCP');
+        cy.intercept('PUT', `**/mcp-servers/${mcpId}/backends/**`, (req) => {
+            backendUpdated = true;
+            req.reply({ statusCode: 200, body: {} });
+        }).as('putBackend');
+
+        visitEndpointsPage(mcpId);
+        cy.wait('@getBackends');
+        openDefinitionDrawer();
+
+        // Step 1: starting state - nothing synced yet.
+        cy.get('[data-testid="endpoint-definition-update-btn"]').should('be.disabled');
+        cy.get('[role="presentation"] .view-lines', largeTimeout).should('not.contain.text', 'mock-tool');
+
+        // Step 2: Re-sync fetches the fresh definition from the backend.
+        cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+        cy.wait('@validateMCP');
+        cy.contains('Definition fetched from backend', largeTimeout).should('be.visible');
+        cy.get('[role="presentation"] .view-lines', largeTimeout).should('contain.text', 'mock-tool');
+
+        // Step 3: Update persists the reviewed definition to the backend.
+        cy.get('[data-testid="endpoint-definition-update-btn"]').should('not.be.disabled').click();
+        cy.wait('@putBackend').then((interception) => {
+            expect(interception.response.statusCode).to.equal(200);
+            const sentDefinition = JSON.parse(interception.request.body.definition);
+            expect(sentDefinition).to.deep.equal(JSON.parse(MOCK_DEFINITION));
+        });
+        cy.contains('Backend API definition updated successfully', largeTimeout).should('be.visible');
+
+        // Step 4: onDefinitionUpdate() triggers a fresh fetch of the endpoints list.
+        cy.wait('@getBackends');
+
+        // Step 5: reopening the drawer shows the persisted definition straight away -
+        // proving the update round-tripped correctly, with no further Re-sync needed.
+        openDefinitionDrawer();
+        cy.get('[role="presentation"] .view-lines', largeTimeout).should('contain.text', 'mock-tool');
+    });
+
+    // handleResync() never inspects the endpoint's configured auth type - it always
+    // delegates credential resolution to the backend by ID. These sub-tests configure
+    // API Key (Header) and OAuth 2.0 (Client Credentials) - the two auth methods third-party
+    // MCP servers actually use in practice - through the endpoint security UI and confirm
+    // that Re-sync's request body stays identical (mcpServerId + endpointType, no inline
+    // securityInfo) regardless of what security is set on the endpoint.
+    const AUTH_MATRIX = [
+        { authType: 'APIKEY_HEADER', label: 'API Key (Header) auth' },
+        { authType: 'OAUTH', label: 'OAuth 2.0 (Client Credentials) auth' },
+    ];
+
+    AUTH_MATRIX.forEach(({ authType, label }) => {
+        it.only(`still delegates credentials to the backend store (no inline securityInfo) with ${label}`, () => {
+            configureEndpointAuth(mcpId, authType);
+            openProxyServerDefinitionDrawer(mcpId);
+
+            mockResyncSuccess('validateMCP');
+            cy.get('[data-testid="endpoint-definition-resync-btn"]').click();
+            cy.wait('@validateMCP').then((interception) => {
+                expect(interception.request.body).to.have.property('mcpServerId', mcpId);
+                expect(interception.request.body).to.have.property('endpointType', 'PRODUCTION');
+                expect(interception.request.body).not.to.have.property('securityInfo');
+            });
+
+            cy.contains('Definition fetched from backend', largeTimeout).should('be.visible');
+        });
+    });
+});

--- a/tests/cypress/support/utils.js
+++ b/tests/cypress/support/utils.js
@@ -388,7 +388,17 @@ export default class Utils {
                         -d '{"description":""}' \
                         -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpId}/revisions"`;
                         cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
-                            const revision = JSON.parse(result.stdout);
+                            let revision;
+                            try {
+                                revision = JSON.parse(result.stdout);
+                            } catch (e) {
+                                reject(`addMCPRevision: non-JSON response. body=${result.stdout}`);
+                                return;
+                            }
+                            if (!revision || typeof revision.id !== 'string') {
+                                reject(`addMCPRevision: server returned no id. body=${result.stdout}`);
+                                return;
+                            }
                             resolve(revision.id);
                         });
                     });

--- a/tests/cypress/support/utils.js
+++ b/tests/cypress/support/utils.js
@@ -332,14 +332,224 @@ export default class Utils {
             }
         });
     }
-    static deleteMCPServer(mcpServerId) {
-        if (!mcpServerId) return;
-        Cypress.on('uncaught:exception', () => false);
-        return Utils.getApiToken().then((token) => {
-            const curl = `curl -k -X DELETE \
-                        -H "Authorization: Bearer ${token}" \
-                        "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpServerId}"`;
-            return cy.exec(curl, { failOnNonZeroExit: false });
+
+    static addMCPServerFromEndpointConfig(data) {
+        let { name, version, context, endpoint, payload } = data;
+        name = name || `TestMCP${Utils.getRandomString(4)}`;
+        context = context || `/${name.toLowerCase()}`;
+        version = version || '1.0.0';
+        endpoint = endpoint || 'https://localhost:9443';
+        const newPayload = payload || JSON.stringify({
+            name,
+            version,
+            context,
+            endpointConfig: {
+                endpoint_type: 'http',
+                sandbox_endpoints: { url: endpoint },
+                production_endpoints: { url: endpoint },
+            },
+            transport: ['http', 'https'],
+            visibility: 'PUBLIC',
+            policies: ['Unlimited'],
+        });
+        return new Cypress.Promise((resolve, reject) => {
+            Utils.getApiToken()
+                .then((token) => {
+                    const curl = `curl -k -s -X POST \
+                    -H "Content-Type: application/json" \
+                    -d '${newPayload}' \
+                    -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/generate-from-api"`;
+                    cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
+                        let mcp;
+                        try {
+                            const cleaned = result.stdout.replace(/[\x01-\x1F]/g, ' ');
+                            mcp = JSON.parse(cleaned);
+                        } catch (e) {
+                            reject(`Error while parsing MCP server creation response: ${result.stdout}`);
+                            return;
+                        }
+                        if (!mcp || typeof mcp.id !== 'string') {
+                            reject(`Error while creating MCP server: ${JSON.stringify(mcp)}`);
+                            return;
+                        }
+                        resolve(mcp.id);
+                    });
+                });
+        });
+    }
+
+    static addMCPRevision(mcpId) {
+        return new Cypress.Promise((resolve, reject) => {
+            try {
+                Utils.getApiToken()
+                    .then((token) => {
+                        const curl = `curl -k -s -X POST \
+                        -H "Content-Type: application/json" \
+                        -d '{"description":""}' \
+                        -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpId}/revisions"`;
+                        cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
+                            const revision = JSON.parse(result.stdout);
+                            resolve(revision.id);
+                        });
+                    });
+            } catch (e) {
+                reject('Error while creating MCP revision');
+            }
+        });
+    }
+
+    static deployMCPRevision(mcpId, revisionId) {
+        const payload = `[{"name":"Default","vhost":"${new URL(Cypress.config().baseUrl).hostname}","displayOnDevportal":true}]`;
+        return new Cypress.Promise((resolve, reject) => {
+            try {
+                Utils.getApiToken()
+                    .then((token) => {
+                        const curl = `curl -k -s -X POST \
+                        -H "Content-Type: application/json" \
+                        -d '${payload}' \
+                        -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpId}/deploy-revision?revisionId=${revisionId}"`;
+                        cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
+                            resolve(result.stdout);
+                        });
+                    });
+            } catch (e) {
+                reject('Error while deploying MCP revision');
+            }
+        });
+    }
+
+    static publishMCPServer(mcpId) {
+        return new Cypress.Promise((resolve, reject) => {
+            try {
+                Utils.getApiToken()
+                    .then((token) => {
+                        const curl = `curl -k -s -X POST \
+                        -H "Content-Type: application/json" \
+                        -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/change-lifecycle?action=Publish&mcpServerId=${mcpId}"`;
+                        cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
+                            resolve(result.stdout);
+                        });
+                    });
+            } catch (e) {
+                reject('Error while publishing MCP server');
+            }
+        });
+    }
+
+    /**
+     * The tool name APIM auto-derives for the mocked `GET /status` operation with no
+     * operationId, used by Utils.createMockToolMcpServer().
+     */
+    static getMockToolName() {
+        return 'get_status';
+    }
+
+    /**
+     * Creates, deploys, and publishes a uniquely-named MCP server exposing a single tool
+     * (GET /status, no parameters, no auth) mapped from a small source API. The endpoint
+     * URL is a placeholder that is never actually contacted - see the note below.
+     *
+     * Playground-invocation tests using this helper MUST intercept the tool invocation
+     * (cy.intercept('POST', '**\/mcp', ...) filtering on `body.method === 'tools/call'`)
+     * and reply with a canned result, rather than letting it hit a real backend. This is
+     * safe to do because `initialize`, `notifications/initialized`, and `tools/list` are
+     * all answered directly by the gateway from the MCP server's own stored metadata -
+     * only `tools/call` ever attempts to reach the configured endpoint, and since that
+     * call originates from the browser, intercepting it there means the placeholder URL
+     * is never actually dialed. This avoids any dependency on a real backend (bundled
+     * sample or external) purely for exercising the Playground's connect/list/run UI flow.
+     *
+     * Every test run gets its own uniquely-named resources via the same generate-from-api
+     * + apiOperationMapping flow used elsewhere in this suite (see setupMcpWithTools in
+     * 03-mcp-server-tools-management.spec.js), so there's no name collision with a
+     * previous run's leftover server.
+     * @returns {Cypress.Chainable<{mcpId: string, sourceApiId: string}>}
+     */
+    static createMockToolMcpServer() {
+        const suffix = Utils.getRandomString(5);
+        const srcName = `TestPlaygroundSrc${suffix}`;
+        const srcContext = `/testplaygroundsrc${suffix}`;
+        const mcpName = `TestPlaygroundMCP${suffix}`;
+        const mcpContext = `/testplaygroundmcp${suffix}`;
+        const baseUrl = Cypress.config().baseUrl;
+        // Never actually contacted - tools/call is always intercepted by the caller before
+        // this URL would be dialed. Points at the running pack itself purely so the value
+        // is a well-formed, resolvable-looking URL.
+        const endpointConfig = {
+            endpoint_type: 'http',
+            sandbox_endpoints: { url: `${baseUrl}/placeholder-unused-endpoint` },
+            production_endpoints: { url: `${baseUrl}/placeholder-unused-endpoint` },
+        };
+
+        const srcPayload = JSON.stringify({
+            name: srcName,
+            version: '1.0.0',
+            context: srcContext,
+            policies: ['Unlimited'],
+            endpointConfig,
+            operations: [
+                {
+                    target: '/status', verb: 'GET', authType: 'Application & Application User', throttlingPolicy: 'Unlimited',
+                },
+            ],
+        });
+
+        return Utils.addAPI({ payload: srcPayload }).then((sourceApiId) => {
+            expect(sourceApiId, 'Source API created').to.be.a('string');
+
+            const mcpPayload = JSON.stringify({
+                name: mcpName,
+                version: '1.0.0',
+                context: mcpContext,
+                transport: ['http', 'https'],
+                visibility: 'PUBLIC',
+                policies: ['Unlimited'],
+                endpointConfig,
+                operations: [
+                    {
+                        feature: 'TOOL',
+                        apiOperationMapping: {
+                            apiId: sourceApiId,
+                            apiName: srcName,
+                            apiVersion: '1.0.0',
+                            apiContext: srcContext,
+                            backendOperation: { target: '/status', verb: 'GET' },
+                        },
+                    },
+                ],
+            });
+
+            return Utils.addMCPServerFromEndpointConfig({ payload: mcpPayload }).then((mcpId) => {
+                expect(mcpId, 'MCP server created').to.be.a('string');
+                return Utils.addMCPRevision(mcpId).then((revisionId) => {
+                    return Utils.deployMCPRevision(mcpId, revisionId).then(() => {
+                        return Utils.publishMCPServer(mcpId).then(() => ({ mcpId, sourceApiId }));
+                    });
+                });
+            });
+        });
+    }
+
+    static deleteMCPServer(mcpId) {
+        if (!mcpId) return;
+        Cypress.on('uncaught:exception', (err, runnable) => {
+            return false;
+        });
+        return new Cypress.Promise((resolve, reject) => {
+            try {
+                Utils.getApiToken()
+                    .then((token) => {
+                        const curl = `curl -k -s -X DELETE \
+                        -H "Content-Type: application/json" \
+                        -H "Authorization: Bearer ${token}" "${Cypress.config().baseUrl}/api/am/publisher/v4/mcp-servers/${mcpId}"`;
+                        cy.exec(curl, { failOnNonZeroExit: false }).then((result) => {
+                            resolve(result.stdout);
+                        });
+                        cy.wait(5000);
+                    });
+            } catch (e) {
+                reject('Error while deleting MCP server');
+            }
         });
     }
 


### PR DESCRIPTION
This pull request adds several new Cypress end-to-end tests to improve coverage of MCP server workflows in the DevPortal and Publisher, as well as a regression test for the default value behavior of the Advanced Endpoint Configuration Duration field. The new tests ensure that published MCP servers are visible and navigable in the DevPortal, that users can subscribe to MCP servers, that the MCP Playground functions correctly with tool invocation, and that the endpoint duration field behaves as expected for both new and existing APIs.

**DevPortal MCP Server workflow tests:**

* Added a test to verify that a published MCP server appears in the DevPortal listing and can be navigated to its overview page. (`00-browse-mcp-servers-in-devportal.cy.js`)
* Added a test to verify that a developer can subscribe to a published MCP server using a new application, and that the subscription appears in the subscriptions table. (`01-subscribe-to-mcp-server.cy.js`)
* Added a comprehensive test for the MCP Playground, including mocking tool invocation, generating OAuth keys, connecting to the MCP server, listing tools, running a tool, and verifying the mocked result. The test includes robust cleanup logic to remove test artifacts. (`02-devportal-mcp-playground.cy.js`)

**Publisher Advanced Endpoint Configuration regression test:**

* Added tests to ensure that the Duration (ms) field in Advanced Endpoint Configuration is empty by default (with a placeholder of 30000), and that any saved value is preserved on re-opening the configuration. (`11-advanced-endpoint-duration-default-empty.cy.js`)