### PR TITLE
[deprecated] Show the provider organization for cross organization subscriptions

### DIFF
--- a/portals/devportal/src/main/webapp/site/public/locales/en.json
+++ b/portals/devportal/src/main/webapp/site/public/locales/en.json
@@ -577,6 +577,7 @@
   "Applications.Details.Subscriptions.api.webhooks": "Webhooks",
   "Applications.Details.Subscriptions.api.webhooks.delivery.time.unavailable": "Delivery data unavailable",
   "Applications.Details.Subscriptions.api.webhooks.subscriptions.unavailable": "No Webhook subscriptions available at this time.",
+  "Applications.Details.Subscriptions.apiProviderTenantDomain": "Provider Organization",
   "Applications.Details.Subscriptions.apis.add.subscription.button": "Subscribe",
   "Applications.Details.Subscriptions.business.plan": "Business Plan",
   "Applications.Details.Subscriptions.business.plan.updated": "Business Plan updated successfully!",

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionSection.jsx
@@ -44,6 +44,7 @@ const classes = {
     titleWrapper: `${PREFIX}-titleWrapper`,
     genericMessageWrapper: `${PREFIX}-genericMessageWrapper`,
     subsTable: `${PREFIX}-subsTable`,
+    subsTableCrossTenant: `${PREFIX}-subsTableCrossTenant`,
     sectionContainer: `${PREFIX}-sectionContainer`,
     pagination: `${PREFIX}-pagination`,
 };
@@ -154,6 +155,25 @@ const Root = styled('div')((
         width: '100%',
     },
 
+    // DEPRECATED cross tenant subscription visibility only. With the optional "Provider Organization" column the
+    // table has six columns instead of five, so redistribute the widths by percentage and clear the pixel minWidths
+    // set above, keeping the fixed layout scaled to the card instead of overflowing it. Applied alongside subsTable
+    // and, being declared later at equal specificity, it wins.
+    [`& .${classes.subsTableCrossTenant}`]: {
+        '& th:nth-of-type(1)': { width: '22%', minWidth: 0 }, // Entity Name
+        '& th:nth-of-type(2)': { width: '14%', minWidth: 0 }, // Provider Organization
+        '& th:nth-of-type(3)': { width: '15%', minWidth: 0 }, // Lifecycle State
+        '& th:nth-of-type(4)': { width: '16%', minWidth: 0 }, // Business Plan
+        '& th:nth-of-type(5)': { width: '18%', minWidth: 0 }, // Subscription Status
+        '& th:nth-of-type(6)': { width: '15%', minWidth: 0 }, // Action
+        '& td:nth-of-type(1)': { width: '22%', minWidth: 0 },
+        '& td:nth-of-type(2)': { width: '14%', minWidth: 0 },
+        '& td:nth-of-type(3)': { width: '15%', minWidth: 0 },
+        '& td:nth-of-type(4)': { width: '16%', minWidth: 0 },
+        '& td:nth-of-type(5)': { width: '18%', minWidth: 0 },
+        '& td:nth-of-type(6)': { width: '15%', minWidth: 0 },
+    },
+
     [`& .${classes.pagination}`]: {
         display: 'flex',
         justifyContent: 'flex-end',
@@ -179,6 +199,7 @@ const SubscriptionSection = ({
     subscriptions,
     subscriptionsNotFound,
     pseudoSubscriptions,
+    showProviderTenant,
     onAddClick,
     handleSubscriptionDelete,
     handleSubscriptionUpdate,
@@ -243,12 +264,25 @@ const SubscriptionSection = ({
                                         <ResourceNotFound />
                                     ) : (
                                         <>
-                                            <Table className={classes.subsTable}>
+                                            <Table
+                                                className={showProviderTenant
+                                                    ? `${classes.subsTable} ${classes.subsTableCrossTenant}`
+                                                    : classes.subsTable}
+                                            >
                                                 <TableHead>
                                                     <TableRow>
                                                         <TableCell className={classes.firstCell}>
                                                             {entityNameColumn}
                                                         </TableCell>
+                                                        {showProviderTenant && (
+                                                            <TableCell>
+                                                                <FormattedMessage
+                                                                    id={'Applications.Details.Subscriptions'
+                                                                        + '.apiProviderTenantDomain'}
+                                                                    defaultMessage='Provider Organization'
+                                                                />
+                                                            </TableCell>
+                                                        )}
                                                         <TableCell>
                                                             <FormattedMessage
                                                                 id='Applications.Details.Subscriptions.subscription.state'
@@ -282,6 +316,7 @@ const SubscriptionSection = ({
                                                                 <SubscriptionTableData
                                                                     key={subscription.subscriptionId}
                                                                     subscription={subscription}
+                                                                    showProviderTenant={showProviderTenant}
                                                                     handleSubscriptionDelete={handleSubscriptionDelete}
                                                                     handleSubscriptionUpdate={handleSubscriptionUpdate}
                                                                     getAPIById={getAPIById}
@@ -318,6 +353,7 @@ SubscriptionSection.propTypes = {
     subscriptions: PropTypes.arrayOf(PropTypes.shape({})),
     subscriptionsNotFound: PropTypes.bool,
     pseudoSubscriptions: PropTypes.bool,
+    showProviderTenant: PropTypes.bool,
     onAddClick: PropTypes.func.isRequired,
     handleSubscriptionDelete: PropTypes.func.isRequired,
     handleSubscriptionUpdate: PropTypes.func.isRequired,
@@ -337,6 +373,7 @@ SubscriptionSection.defaultProps = {
     subscriptions: [],
     subscriptionsNotFound: false,
     pseudoSubscriptions: false,
+    showProviderTenant: false,
 };
 
 export default SubscriptionSection;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -101,6 +101,13 @@ class SubscriptionTableData extends React.Component {
         const { subscription } = this.props;
         this.mounted = true;
         this.checkIfWebhookAPI();
+        // A subscription to an API owned by another organization (deprecated cross tenant visibility) cannot be
+        // resolved in the current organization, so the backend returns no apiId for it. Skip the per API lookup:
+        // getAPIById(undefined) would leave the path parameter unsubstituted, producing '/apis/{apiId}' which fails
+        // URI normalization, and the API is not retrievable here in any case.
+        if (!subscription.apiId) {
+            return;
+        }
         this.populateAPIData(subscription.apiId);
         this.checkIfDynamicUsagePolicy(subscription.throttlingPolicy);
     }
@@ -254,8 +261,10 @@ class SubscriptionTableData extends React.Component {
     */
     render() {
         const {
+            showProviderTenant,
             subscription: {
                 apiInfo, status, throttlingPolicy, subscriptionId, apiId, requestedThrottlingPolicy,
+                apiProviderTenantDomain,
             },
         } = this.props;
         const {
@@ -315,6 +324,7 @@ class SubscriptionTableData extends React.Component {
                             </>
                         )}
                     </TableCell>
+                    {showProviderTenant && <TableCell>{apiProviderTenantDomain}</TableCell>}
                     <TableCell>{apiInfo.lifeCycleStatus}</TableCell>
                     {throttlingPolicy.includes(CONSTANTS.DEFAULT_SUBSCRIPTIONLESS_PLAN) ? (
                         <TableCell>
@@ -586,11 +596,16 @@ SubscriptionTableData.propTypes = {
         applicationId: PropTypes.string.isRequired,
         status: PropTypes.string.isRequired,
         requestedThrottlingPolicy: PropTypes.string.isRequired,
+        apiProviderTenantDomain: PropTypes.string,
     }).isRequired,
+    showProviderTenant: PropTypes.bool,
     handleSubscriptionDelete: PropTypes.func.isRequired,
     handleSubscriptionUpdate: PropTypes.func.isRequired,
     getAPIById: PropTypes.func.isRequired,
     getMCPServerById: PropTypes.func.isRequired,
     getSubscriptionPolicyByName: PropTypes.func.isRequired,
+};
+SubscriptionTableData.defaultProps = {
+    showProviderTenant: false,
 };
 export default SubscriptionTableData;

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -235,7 +235,13 @@ class SubscriptionTableData extends React.Component {
      * Check if the API is a webhook API
      */
     checkIfWebhookAPI() {
-        this.setState({ isWebhookAPI: this.props.subscription.apiInfo.type === CONSTANTS.API_TYPES.WEBSUB });
+        const { subscription } = this.props;
+        // Webhook details are fetched by API id. A subscription to an API owned by another organization carries no
+        // apiId, so treat it as a non webhook subscription rather than offering a link that cannot resolve.
+        this.setState({
+            isWebhookAPI: Boolean(subscription.apiId)
+                && subscription.apiInfo.type === CONSTANTS.API_TYPES.WEBSUB,
+        });
     }
 
     /**

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/SubscriptionTableData.jsx
@@ -100,14 +100,14 @@ class SubscriptionTableData extends React.Component {
     componentDidMount() {
         const { subscription } = this.props;
         this.mounted = true;
-        this.checkIfWebhookAPI();
         // A subscription to an API owned by another organization (deprecated cross tenant visibility) cannot be
-        // resolved in the current organization, so the backend returns no apiId for it. Skip the per API lookup:
-        // getAPIById(undefined) would leave the path parameter unsubstituted, producing '/apis/{apiId}' which fails
-        // URI normalization, and the API is not retrievable here in any case.
+        // resolved in the current organization, so the backend returns no apiId for it. Nothing below can run
+        // without one: getAPIById(undefined) would leave the path parameter unsubstituted, producing
+        // '/apis/{apiId}' which fails URI normalization, and the webhook callback URLs are looked up by API id too.
         if (!subscription.apiId) {
             return;
         }
+        this.checkIfWebhookAPI();
         this.populateAPIData(subscription.apiId);
         this.checkIfDynamicUsagePolicy(subscription.throttlingPolicy);
     }
@@ -235,13 +235,7 @@ class SubscriptionTableData extends React.Component {
      * Check if the API is a webhook API
      */
     checkIfWebhookAPI() {
-        const { subscription } = this.props;
-        // Webhook details are fetched by API id. A subscription to an API owned by another organization carries no
-        // apiId, so treat it as a non webhook subscription rather than offering a link that cannot resolve.
-        this.setState({
-            isWebhookAPI: Boolean(subscription.apiId)
-                && subscription.apiInfo.type === CONSTANTS.API_TYPES.WEBSUB,
-        });
+        this.setState({ isWebhookAPI: this.props.subscription.apiInfo.type === CONSTANTS.API_TYPES.WEBSUB });
     }
 
     /**

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -270,7 +270,6 @@ class SubscriptionsBase extends React.Component {
             searchText: '',
             pseudoSubscriptions: false,
             pseudoMcpSubscriptions: false,
-            showProviderTenant: false,
             dialogSubscriptions: null,
             dialogMcpSubscriptions: null,
             dialogRefreshKey: 0,
@@ -317,14 +316,6 @@ class SubscriptionsBase extends React.Component {
      */
     componentDidMount() {
         this.mounted = true;
-        // DEPRECATED cross tenant subscription visibility. The settings flag is present only when the server has
-        // opted in, in which case the backend also returns the application's subscriptions to other tenants' APIs
-        // and the owning organization is shown alongside each row.
-        const settingsContext = this.context;
-        this.setState({
-            showProviderTenant: Boolean(settingsContext && settingsContext.settings
-                && settingsContext.settings.crossTenantSubscriptionEnabled),
-        });
         const { apisAccessible, mcpServersAccessible } = this.props;
         this.ensureLoaded(
             apisAccessible ? SUBSCRIPTIONS_PER_PAGE : 0,
@@ -845,12 +836,18 @@ class SubscriptionsBase extends React.Component {
             subscriptionsNotFound,
             pseudoSubscriptions,
             pseudoMcpSubscriptions,
-            showProviderTenant,
             dialogSubscriptions,
             dialogMcpSubscriptions,
             dialogRefreshKey,
             dialogMcpRefreshKey,
         } = this.state;
+
+        // DEPRECATED cross tenant subscription visibility. Read from the live context rather than caching at mount:
+        // the settings are replaced asynchronously once the user is authenticated, so a value captured in
+        // componentDidMount can be stale.
+        const settingsContext = this.context;
+        const showProviderTenant = Boolean(settingsContext && settingsContext.settings
+            && settingsContext.settings.crossTenantSubscriptionEnabled);
 
         if (!isAuthorize) {
             window.location = app.context + '/services/configs';

--- a/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
+++ b/portals/devportal/src/main/webapp/source/src/app/components/Applications/Details/Subscriptions.jsx
@@ -35,6 +35,7 @@ import Alert from 'AppComponents/Shared/Alert';
 import APIList from 'AppComponents/Apis/Listing/APICardView';
 import CONSTANTS from 'AppData/Constants';
 import Subscription from 'AppData/Subscription';
+import SettingsContext from 'AppComponents/Shared/SettingsContext';
 import Api from 'AppData/api';
 import MCPServer from 'AppData/MCPServer';
 import { app } from 'Settings';
@@ -269,6 +270,7 @@ class SubscriptionsBase extends React.Component {
             searchText: '',
             pseudoSubscriptions: false,
             pseudoMcpSubscriptions: false,
+            showProviderTenant: false,
             dialogSubscriptions: null,
             dialogMcpSubscriptions: null,
             dialogRefreshKey: 0,
@@ -315,6 +317,14 @@ class SubscriptionsBase extends React.Component {
      */
     componentDidMount() {
         this.mounted = true;
+        // DEPRECATED cross tenant subscription visibility. The settings flag is present only when the server has
+        // opted in, in which case the backend also returns the application's subscriptions to other tenants' APIs
+        // and the owning organization is shown alongside each row.
+        const settingsContext = this.context;
+        this.setState({
+            showProviderTenant: Boolean(settingsContext && settingsContext.settings
+                && settingsContext.settings.crossTenantSubscriptionEnabled),
+        });
         const { apisAccessible, mcpServersAccessible } = this.props;
         this.ensureLoaded(
             apisAccessible ? SUBSCRIPTIONS_PER_PAGE : 0,
@@ -835,6 +845,7 @@ class SubscriptionsBase extends React.Component {
             subscriptionsNotFound,
             pseudoSubscriptions,
             pseudoMcpSubscriptions,
+            showProviderTenant,
             dialogSubscriptions,
             dialogMcpSubscriptions,
             dialogRefreshKey,
@@ -884,6 +895,7 @@ class SubscriptionsBase extends React.Component {
                                 subscriptions={apiSubscriptions}
                                 subscriptionsNotFound={subscriptionsNotFound}
                                 pseudoSubscriptions={pseudoSubscriptions}
+                                showProviderTenant={showProviderTenant}
                                 onAddClick={this.handleOpenDialog}
                                 handleSubscriptionDelete={this.handleSubscriptionDelete}
                                 handleSubscriptionUpdate={this.handleSubscriptionUpdate}
@@ -933,6 +945,7 @@ class SubscriptionsBase extends React.Component {
                                 subscriptions={mcpSubscriptions}
                                 subscriptionsNotFound={subscriptionsNotFound}
                                 pseudoSubscriptions={pseudoMcpSubscriptions}
+                                showProviderTenant={showProviderTenant}
                                 onAddClick={this.handleOpenMcpDialog}
                                 handleSubscriptionDelete={this.handleSubscriptionDelete}
                                 handleSubscriptionUpdate={this.handleSubscriptionUpdate}
@@ -1172,6 +1185,8 @@ class SubscriptionsBase extends React.Component {
         }
     }
 }
+
+SubscriptionsBase.contextType = SettingsContext;
 
 SubscriptionsBase.propTypes = {
     application: PropTypes.shape({


### PR DESCRIPTION
> **Not intended for merge as-is.** Opened on the public repository so that automated review runs
> over the change. The shipping fix is on the 4.6.0 support line
> (wso2-support/apim-apps#797); this is the same change ported onto `main`.

### Purpose

Renders an optional "Provider Organization" column in the application subscriptions view when the
server reports `crossTenantSubscriptionEnabled`, which is only the case when the deprecated cross
organization subscription visibility configuration is enabled on the backend. The column is absent
otherwise, so the view is unchanged for every deployment that does not opt in.

Also skips the per API lookup for a subscription whose API cannot be resolved in the current
organization. The backend returns no `apiId` for those rows, and `getAPIById(undefined)` leaves the
path parameter unsubstituted, producing `/apis/{apiId}` which fails URI normalization.

### Depends on

https://github.com/wso2/carbon-apimgt/pull/13985 — without it the settings flag is never returned,
so the column stays hidden.

### Notes for review

- `main` has diverged from the 4.6.0 support line here (table pagination, the fragment wrapper, and
  `populateAPIData` in place of the separate lookups), so this was re-applied by hand rather than
  cherry-picked. The resulting diff is the same shape as the support-line change: 4 files, +69/-1.
- `SubscriptionTableData.propTypes` marks `apiId` and `apiInfo.lifeCycleStatus` as required, but a
  cross organization row carries both as `null` by design, which produces dev-mode PropType
  warnings. That is pre-existing and was left identical to the support-line change; happy to relax
  those two in this branch if preferred.

### Verification

`npm run build:prod` succeeds on this branch. Behaviour was verified on the 4.6.0 line: rows for
APIs owned by another organization show the owning organization with an empty lifecycle state and
Edit and Delete disabled, matching the 4.0.0 behaviour, and with the configuration off the table
renders its original five columns. Not run against a `main` build.

Related: https://github.com/wso2-enterprise/wso2-apim-internal/issues/18922
