### PR TITLE
Fix intermittent UI test failure

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -694,7 +694,8 @@ Cypress.Commands.add('createAPIWithoutEndpoint', (name = null, version = null, t
 Cypress.Commands.add('createApp', (appName, appDescription) => {
     cy.visit(`/devportal/applications/create?tenant=carbon.super`);
     cy.intercept('**/application-attributes').as('attrGet');
-    cy.wait('@attrGet', { timeout: 300000 }).then(() => {
+    cy.intercept('**/throttling-policies/**').as('tiersGet');
+    cy.wait(['@attrGet', '@tiersGet'], { timeout: 300000 }).then(() => {
         // Filling the form
         cy.get('#application-name').click();
         cy.get('#application-name').type(appName);

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -692,9 +692,9 @@ Cypress.Commands.add('createAPIWithoutEndpoint', (name = null, version = null, t
 })
 
 Cypress.Commands.add('createApp', (appName, appDescription) => {
-    cy.visit(`/devportal/applications/create?tenant=carbon.super`);
     cy.intercept('**/application-attributes').as('attrGet');
     cy.intercept('**/throttling-policies/**').as('tiersGet');
+    cy.visit(`/devportal/applications/create?tenant=carbon.super`);
     cy.wait(['@attrGet', '@tiersGet'], { timeout: 300000 }).then(() => {
         // Filling the form
         cy.get('#application-name').click();


### PR DESCRIPTION
This PR fixes intermittent dev portal integration test failure for `devportal/005-mcp-servers/02-devportal-mcp-playground.cy.js`

  1. Wait on both @attrGet and @tiersGet before touching the form, so allAppAttributes is guaranteed non-null when Save validates it.
  2. Register both intercepts before cy.visit() (not after), since an intercept registered after visit() can race the app's own componentDidMount fetches and simply miss them.